### PR TITLE
Introduce a build-tool-neutral crap4java core

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 `crap4java` is a shared CRAP metric toolkit for Java projects.
 
 It combines method cyclomatic complexity with JaCoCo method coverage and reports CRAP scores.
-The current implementation still behaves like the original Maven-oriented CLI while the native Gradle and Maven plugin integrations are being built in dedicated modules.
+The current CLI now resolves Maven and Gradle modules natively, including standard multi-module layouts, while the dedicated build tool plugins are being added in separate modules.
 
 ## Modules
 
-- `core`: analysis engine, CLI orchestration, and current Maven-oriented coverage runner
+- `core`: analysis engine, build-tool-neutral CLI orchestration, and Maven/Gradle coverage runner
 - `cli`: executable entrypoint that packages the core as a runnable jar
 - `gradle-plugin`: placeholder module for the upcoming Gradle integration
 - `maven-plugin`: placeholder module for the upcoming Maven integration
@@ -21,14 +21,17 @@ The current implementation still behaves like the original Maven-oriented CLI wh
 
 ## Coverage Pipeline
 
-For each invocation today:
+For each resolved module today:
 
-1. Delete stale coverage artifacts:
-   - `target/site/jacoco/`
-   - `target/jacoco.exec`
-2. Run `mvn -q org.jacoco:jacoco-maven-plugin:0.8.12:prepare-agent test org.jacoco:jacoco-maven-plugin:0.8.12:report`
-3. Read `target/site/jacoco/jacoco.xml`
-4. Analyze selected Java files
+1. Detect Maven or Gradle automatically, unless `--build-tool` is supplied.
+2. Delete stale JaCoCo artifacts for the detected build tool.
+3. Run the module-scoped coverage command:
+   - Maven: `mvn` or `mvnw`, using JaCoCo `0.8.13`
+   - Gradle: `gradle` or `gradlew`, running `test` and `jacocoTestReport`
+4. Read the module report:
+   - Maven: `target/site/jacoco/jacoco.xml`
+   - Gradle: `build/reports/jacoco/test/jacocoTestReport.xml`
+5. Analyze the selected Java files for that module
 
 ## Build and Test
 
@@ -56,8 +59,9 @@ java -jar cli/target/crap4java-cli-0.1.0-SNAPSHOT.jar
 --help                Print usage to stdout
 (no args)             Analyze all Java files under src/
 --changed             Analyze changed Java files under src/
+--build-tool <tool>   Force `auto`, `maven`, or `gradle`
 <file ...>            Analyze only these files
-<directory ...>       Analyze all Java files under each directory's src/ subtree
+<directory ...>       Analyze all Java files under each directory's nested src/ subtrees
 ```
 
 Examples:
@@ -66,6 +70,8 @@ Examples:
 java -jar cli/target/crap4java-cli-0.1.0-SNAPSHOT.jar --help
 java -jar cli/target/crap4java-cli-0.1.0-SNAPSHOT.jar
 java -jar cli/target/crap4java-cli-0.1.0-SNAPSHOT.jar --changed
+java -jar cli/target/crap4java-cli-0.1.0-SNAPSHOT.jar --build-tool gradle
+java -jar cli/target/crap4java-cli-0.1.0-SNAPSHOT.jar --build-tool maven module-a/src/main/java/demo/Sample.java
 java -jar cli/target/crap4java-cli-0.1.0-SNAPSHOT.jar src/main/java/demo/Sample.java
 java -jar cli/target/crap4java-cli-0.1.0-SNAPSHOT.jar module-a module-b
 ```

--- a/core/src/main/java/media/barney/crap4java/core/BuildTool.java
+++ b/core/src/main/java/media/barney/crap4java/core/BuildTool.java
@@ -1,0 +1,21 @@
+package media.barney.crap4java.core;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+
+enum BuildTool {
+    MAVEN,
+    GRADLE;
+
+    static EnumSet<BuildTool> detect(Path directory) {
+        EnumSet<BuildTool> detected = EnumSet.noneOf(BuildTool.class);
+        if (Files.exists(directory.resolve("pom.xml"))) {
+            detected.add(MAVEN);
+        }
+        if (Files.exists(directory.resolve("build.gradle")) || Files.exists(directory.resolve("build.gradle.kts"))) {
+            detected.add(GRADLE);
+        }
+        return detected;
+    }
+}

--- a/core/src/main/java/media/barney/crap4java/core/BuildToolSelection.java
+++ b/core/src/main/java/media/barney/crap4java/core/BuildToolSelection.java
@@ -1,0 +1,29 @@
+package media.barney.crap4java.core;
+
+import java.util.Locale;
+
+enum BuildToolSelection {
+    AUTO,
+    MAVEN,
+    GRADLE;
+
+    static BuildToolSelection parse(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("--build-tool requires one of: auto, maven, gradle");
+        }
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "auto" -> AUTO;
+            case "maven" -> MAVEN;
+            case "gradle" -> GRADLE;
+            default -> throw new IllegalArgumentException("--build-tool requires one of: auto, maven, gradle");
+        };
+    }
+
+    BuildTool toBuildTool() {
+        return switch (this) {
+            case MAVEN -> BuildTool.MAVEN;
+            case GRADLE -> BuildTool.GRADLE;
+            case AUTO -> throw new IllegalStateException("AUTO does not map to a concrete build tool");
+        };
+    }
+}

--- a/core/src/main/java/media/barney/crap4java/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap4java/core/ChangedFileDetector.java
@@ -11,7 +11,7 @@ final class ChangedFileDetector {
     }
 
     static List<Path> changedJavaFiles(Path projectRoot) throws IOException, InterruptedException {
-        Process process = new ProcessBuilder("git", "-C", projectRoot.toString(), "status", "--porcelain")
+        Process process = new ProcessBuilder("git", "-C", projectRoot.toString(), "status", "--porcelain", "--untracked-files=all")
                 .redirectErrorStream(true)
                 .start();
 
@@ -33,9 +33,9 @@ final class ChangedFileDetector {
         return files;
     }
 
-    static List<Path> changedJavaFilesUnderSrc(Path projectRoot) throws IOException, InterruptedException {
+    static List<Path> changedJavaFilesUnderSourceRoots(Path projectRoot) throws IOException, InterruptedException {
         return changedJavaFiles(projectRoot).stream()
-                .filter(path -> path.normalize().startsWith(projectRoot.resolve("src").normalize()))
+                .filter(path -> isUnderSourceTree(projectRoot, path))
                 .toList();
     }
 
@@ -72,49 +72,14 @@ final class ChangedFileDetector {
     private static boolean isJavaPath(String path) {
         return path.endsWith(".java");
     }
-}
 
-/* mutate4java-manifest
-version=1
-moduleHash=d6a200db9e9478a6b5be1b8ae4ba417ef0bb3feb428bf334a5029462e76fce49
-scope.0.id=Y2xhc3M6Q2hhbmdlZEZpbGVEZXRlY3RvciNDaGFuZ2VkRmlsZURldGVjdG9yOjg
-scope.0.kind=class
-scope.0.startLine=8
-scope.0.endLine=75
-scope.0.semanticHash=314b1b7d383824f09865a4814f458ca28b3bff55ca405f8d6a14db73bce3d80e
-scope.1.id=bWV0aG9kOkNoYW5nZWRGaWxlRGV0ZWN0b3IjY2hhbmdlZEphdmFGaWxlcygxKToxMw
-scope.1.kind=method
-scope.1.startLine=13
-scope.1.endLine=34
-scope.1.semanticHash=8e8554ef51ed29e8fbc41e16c0b2279540d453c92ca270f25f1bf1ea7adf058b
-scope.2.id=bWV0aG9kOkNoYW5nZWRGaWxlRGV0ZWN0b3IjY2hhbmdlZEphdmFGaWxlc1VuZGVyU3JjKDEpOjM2
-scope.2.kind=method
-scope.2.startLine=36
-scope.2.endLine=40
-scope.2.semanticHash=964da5ec5598ea16203adfa61e65258cb353959cca24ffbf3e7016a015ef84c4
-scope.3.id=bWV0aG9kOkNoYW5nZWRGaWxlRGV0ZWN0b3IjY3RvcigwKToxMA
-scope.3.kind=method
-scope.3.startLine=10
-scope.3.endLine=11
-scope.3.semanticHash=8fe3abf26e99f2bd7186b30f9fe28659467f583d27b11adf97718417babfbefb
-scope.4.id=bWV0aG9kOkNoYW5nZWRGaWxlRGV0ZWN0b3IjaXNDYW5kaWRhdGVMaW5lKDEpOjU0
-scope.4.kind=method
-scope.4.startLine=54
-scope.4.endLine=62
-scope.4.semanticHash=b63e199ff7b921628fb65cc3b934e3938d92ce5d153227ef5e3e061968408b06
-scope.5.id=bWV0aG9kOkNoYW5nZWRGaWxlRGV0ZWN0b3IjaXNKYXZhUGF0aCgxKTo3Mg
-scope.5.kind=method
-scope.5.startLine=72
-scope.5.endLine=74
-scope.5.semanticHash=d6a306fcbb03b875c827caa8ff9b65330919721e0247ffc8f67de36907d6b621
-scope.6.id=bWV0aG9kOkNoYW5nZWRGaWxlRGV0ZWN0b3IjcGFyc2VTdGF0dXNMaW5lKDIpOjQy
-scope.6.kind=method
-scope.6.startLine=42
-scope.6.endLine=52
-scope.6.semanticHash=23c700724f3dd1a6161c3357c22492ad34072b011e35c655633737ff4af4434c
-scope.7.id=bWV0aG9kOkNoYW5nZWRGaWxlRGV0ZWN0b3IjcmVuYW1lVGFyZ2V0KDEpOjY0
-scope.7.kind=method
-scope.7.startLine=64
-scope.7.endLine=70
-scope.7.semanticHash=29da8c6dd6483a1004615c3364a5b239b115ea8298fe813a0bd5c64f88f8bd2b
-*/
+    private static boolean isUnderSourceTree(Path projectRoot, Path file) {
+        Path normalized = projectRoot.normalize().relativize(file.normalize());
+        for (Path segment : normalized) {
+            if ("src".equals(segment.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/media/barney/crap4java/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap4java/core/CliApplication.java
@@ -31,35 +31,41 @@ final class CliApplication {
             return parse.exitCode;
         }
         CliArguments parsed = parse.arguments;
-        List<Path> filesToAnalyze = filesForMode(parsed);
-        if (filesToAnalyze.isEmpty()) {
-            out.println("No Java files to analyze.");
+        try {
+            List<Path> filesToAnalyze = filesForMode(parsed);
+            if (filesToAnalyze.isEmpty()) {
+                out.println("No Java files to analyze.");
+                return 0;
+            }
+
+            List<MethodMetrics> metrics = analyzeByModule(filesToAnalyze, parsed.buildToolSelection());
+            metrics.sort(Comparator.comparing(MethodMetrics::crapScore,
+                    Comparator.nullsLast(Comparator.reverseOrder())));
+            out.print(ReportFormatter.format(metrics));
+
+            double max = Main.maxCrap(metrics);
+            if (thresholdExceeded(max)) {
+                err.printf("CRAP threshold exceeded: %.1f > 8.0%n", max);
+                return 2;
+            }
             return 0;
+        } catch (IllegalArgumentException ex) {
+            err.println(ex.getMessage());
+            return 1;
         }
-
-        List<MethodMetrics> metrics = analyzeByModule(filesToAnalyze);
-        metrics.sort(Comparator.comparing(MethodMetrics::crapScore,
-                Comparator.nullsLast(Comparator.reverseOrder())));
-        out.print(ReportFormatter.format(metrics));
-
-        double max = Main.maxCrap(metrics);
-        if (thresholdExceeded(max)) {
-            err.printf("CRAP threshold exceeded: %.1f > 8.0%n", max);
-            return 2;
-        }
-        return 0;
     }
 
-    private List<MethodMetrics> analyzeByModule(List<Path> filesToAnalyze) throws Exception {
+    private List<MethodMetrics> analyzeByModule(List<Path> filesToAnalyze,
+                                                BuildToolSelection buildToolSelection) throws Exception {
         List<MethodMetrics> metrics = new ArrayList<>();
-        for (Map.Entry<Path, List<Path>> entry : groupByModuleRoot(filesToAnalyze).entrySet()) {
-            Path moduleRoot = entry.getKey();
-            Path jacocoXml = moduleRoot.resolve("target/site/jacoco/jacoco.xml");
-            coverageRunner.generateCoverage(moduleRoot);
+        for (Map.Entry<ProjectModule, List<Path>> entry : groupByModule(filesToAnalyze, buildToolSelection).entrySet()) {
+            ProjectModule module = entry.getKey();
+            Path jacocoXml = module.jacocoXmlPath();
+            coverageRunner.generateCoverage(module);
             if (!Files.exists(jacocoXml)) {
                 err.println("Warning: JaCoCo XML not found at " + jacocoXml + ". Coverage will be N/A.");
             }
-            metrics.addAll(CrapAnalyzer.analyze(moduleRoot, entry.getValue(), jacocoXml));
+            metrics.addAll(CrapAnalyzer.analyze(module.moduleRoot(), entry.getValue(), jacocoXml));
         }
         return metrics;
     }
@@ -85,8 +91,8 @@ final class CliApplication {
 
     private List<Path> filesForMode(CliArguments parsed) throws Exception {
         return switch (parsed.mode()) {
-            case ALL_SRC -> SourceFileFinder.findAllJavaFilesUnderSrc(projectRoot);
-            case CHANGED_SRC -> ChangedFileDetector.changedJavaFilesUnderSrc(projectRoot);
+            case ALL_SRC -> SourceFileFinder.findAllJavaFilesUnderSourceRoots(projectRoot);
+            case CHANGED_SRC -> ChangedFileDetector.changedJavaFilesUnderSourceRoots(projectRoot);
             case EXPLICIT_FILES -> explicitFiles(parsed.fileArgs());
             case HELP -> List.of();
         };
@@ -97,7 +103,7 @@ final class CliApplication {
         for (String arg : args) {
             Path path = projectRoot.resolve(arg).normalize();
             if (Files.isDirectory(path)) {
-                files.addAll(SourceFileFinder.findAllJavaFilesUnderSrc(path));
+                files.addAll(SourceFileFinder.findAllJavaFilesUnderSourceRoots(path));
             } else {
                 files.add(path);
             }
@@ -107,23 +113,15 @@ final class CliApplication {
         return sorted;
     }
 
-    static Path moduleRootFor(Path workspaceRoot, Path file) {
-        Path normalizedWorkspaceRoot = workspaceRoot.normalize();
-        Path current = Files.isDirectory(file) ? file.normalize() : file.normalize().getParent();
-        while (current != null && current.startsWith(normalizedWorkspaceRoot)) {
-            if (Files.exists(current.resolve("pom.xml"))) {
-                return current;
-            }
-            current = current.getParent();
-        }
-        return normalizedWorkspaceRoot;
+    static ProjectModule moduleFor(Path workspaceRoot, Path file, BuildToolSelection buildToolSelection) {
+        return ProjectModuleResolver.resolve(workspaceRoot, file, buildToolSelection);
     }
 
-    private Map<Path, List<Path>> groupByModuleRoot(List<Path> filesToAnalyze) {
-        Map<Path, List<Path>> grouped = new LinkedHashMap<>();
+    private Map<ProjectModule, List<Path>> groupByModule(List<Path> filesToAnalyze, BuildToolSelection buildToolSelection) {
+        Map<ProjectModule, List<Path>> grouped = new LinkedHashMap<>();
         for (Path file : filesToAnalyze) {
-            Path moduleRoot = moduleRootFor(projectRoot, file);
-            grouped.computeIfAbsent(moduleRoot, ignored -> new ArrayList<>()).add(file);
+            ProjectModule module = moduleFor(projectRoot, file, buildToolSelection);
+            grouped.computeIfAbsent(module, ignored -> new ArrayList<>()).add(file);
         }
         return grouped;
     }
@@ -146,108 +144,3 @@ final class CliApplication {
         }
     }
 }
-
-/* mutate4java-manifest
-version=1
-moduleHash=5e28beaff6bbfa47827aba63f26186be35ab0a7211b3d96c9cffa37b93f2f64f
-scope.0.id=Y2xhc3M6Q2xpQXBwbGljYXRpb24jQ2xpQXBwbGljYXRpb246MTQ
-scope.0.kind=class
-scope.0.startLine=14
-scope.0.endLine=148
-scope.0.semanticHash=72e3edb9c173f66282605ffd23efb26af90afc903be0c61f28b0d1bed8fdde20
-scope.1.id=Y2xhc3M6Q2xpQXBwbGljYXRpb24uUGFyc2VPdXRjb21lI1BhcnNlT3V0Y29tZToxMzE
-scope.1.kind=class
-scope.1.startLine=131
-scope.1.endLine=147
-scope.1.semanticHash=45ed2bfb66d7822af10a2384e04bae542509fb8fb1a46052b2bf49795e404530
-scope.2.id=ZmllbGQ6Q2xpQXBwbGljYXRpb24jY292ZXJhZ2VSdW5uZXI6MTk
-scope.2.kind=field
-scope.2.startLine=19
-scope.2.endLine=19
-scope.2.semanticHash=d92a1ba1476f655cf1babf2fbbc9b36f71fd57e400859cf09e46a1253a04c184
-scope.3.id=ZmllbGQ6Q2xpQXBwbGljYXRpb24jZXJyOjE4
-scope.3.kind=field
-scope.3.startLine=18
-scope.3.endLine=18
-scope.3.semanticHash=0f12a462a677e93faaa05787bc46db2cace278490b3a801f721c167aedea712a
-scope.4.id=ZmllbGQ6Q2xpQXBwbGljYXRpb24jb3V0OjE3
-scope.4.kind=field
-scope.4.startLine=17
-scope.4.endLine=17
-scope.4.semanticHash=b98df4fbf291f7cd01ba32f6b30c169fc64c08011a73e48a271561a4fcdd0a52
-scope.5.id=ZmllbGQ6Q2xpQXBwbGljYXRpb24jcHJvamVjdFJvb3Q6MTY
-scope.5.kind=field
-scope.5.startLine=16
-scope.5.endLine=16
-scope.5.semanticHash=967df8631e20dcf5fe7b1534d2b220568e0e1c2f48d3990f2701b87b204eaad0
-scope.6.id=ZmllbGQ6Q2xpQXBwbGljYXRpb24uUGFyc2VPdXRjb21lI2FyZ3VtZW50czoxMzI
-scope.6.kind=field
-scope.6.startLine=132
-scope.6.endLine=132
-scope.6.semanticHash=661f16ad226990eadabf31eb84854855268c8a11339b14e3255dd5bba3147187
-scope.7.id=ZmllbGQ6Q2xpQXBwbGljYXRpb24uUGFyc2VPdXRjb21lI2V4aXRDb2RlOjEzMw
-scope.7.kind=field
-scope.7.startLine=133
-scope.7.endLine=133
-scope.7.semanticHash=9b365df939989346da53099623aa9608e776c5c7fa71f7e9a96132e7df1bbedf
-scope.8.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uI2FuYWx5emVCeU1vZHVsZSgxKTo1Mw
-scope.8.kind=method
-scope.8.startLine=53
-scope.8.endLine=65
-scope.8.semanticHash=9e87960a5cb9616913a7fbe79fbb8ae27e79b3ca100d365c1fba9c9e51d549bc
-scope.9.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uI2N0b3IoNCk6MjE
-scope.9.kind=method
-scope.9.startLine=21
-scope.9.endLine=26
-scope.9.semanticHash=f0fc877ed56783fd79a8d2c8590b731e35c0b16a80be0be16d30494d186d0b05
-scope.10.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uI2V4ZWN1dGUoMSk6Mjg
-scope.10.kind=method
-scope.10.startLine=28
-scope.10.endLine=51
-scope.10.semanticHash=e834a9410d6c93bdcfb4ccd07064562674c2afb34c8fb73d853070615253cd50
-scope.11.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uI2V4cGxpY2l0RmlsZXMoMSk6OTU
-scope.11.kind=method
-scope.11.startLine=95
-scope.11.endLine=108
-scope.11.semanticHash=e371db323f2ca72e6f886e53697121802f1d5f29e878d1fcec396241d98c0cd9
-scope.12.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uI2ZpbGVzRm9yTW9kZSgxKTo4Ng
-scope.12.kind=method
-scope.12.startLine=86
-scope.12.endLine=93
-scope.12.semanticHash=dcf1caca27fab7b7478c3f57fd0a2ab6036931b44af0a8b39691615b3f76d831
-scope.13.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uI2dyb3VwQnlNb2R1bGVSb290KDEpOjEyMg
-scope.13.kind=method
-scope.13.startLine=122
-scope.13.endLine=129
-scope.13.semanticHash=b162fe08460eea66f1c87678860bc8be1e90d225b5ae07016a4f0aa3103b5b20
-scope.14.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uI21vZHVsZVJvb3RGb3IoMik6MTEw
-scope.14.kind=method
-scope.14.startLine=110
-scope.14.endLine=120
-scope.14.semanticHash=a180b2afd49b317ec0ef05c2dbfaf083e513097e268f36ca534a50a27a886e8c
-scope.15.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uI3BhcnNlQXJndW1lbnRzKDEpOjcx
-scope.15.kind=method
-scope.15.startLine=71
-scope.15.endLine=84
-scope.15.semanticHash=899bc3c351cfb3d2ad575d8fe4ba812948e282104bb60fb1412ba2c3861305f2
-scope.16.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uI3RocmVzaG9sZEV4Y2VlZGVkKDEpOjY3
-scope.16.kind=method
-scope.16.startLine=67
-scope.16.endLine=69
-scope.16.semanticHash=00b761a57b4a4a66733929fb784fbe41d9760841f7ed75fb61ce54edf4f20ed7
-scope.17.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uLlBhcnNlT3V0Y29tZSNjdG9yKDIpOjEzNQ
-scope.17.kind=method
-scope.17.startLine=135
-scope.17.endLine=138
-scope.17.semanticHash=bac767bb702fe8b4a04ddc028c794d85ecb0968a4357fe90c0c152d76966a315
-scope.18.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uLlBhcnNlT3V0Y29tZSNleGl0KDEpOjE0NA
-scope.18.kind=method
-scope.18.startLine=144
-scope.18.endLine=146
-scope.18.semanticHash=10b36de9f002c3f16736f379c7754defec224dccb1cb16006d03a5e72aadcfab
-scope.19.id=bWV0aG9kOkNsaUFwcGxpY2F0aW9uLlBhcnNlT3V0Y29tZSNvaygxKToxNDA
-scope.19.kind=method
-scope.19.startLine=140
-scope.19.endLine=142
-scope.19.semanticHash=a557a67f31a114feacb3bd934fb922508d7e77088f8afc84a424948584fa0c4f
-*/

--- a/core/src/main/java/media/barney/crap4java/core/CliArguments.java
+++ b/core/src/main/java/media/barney/crap4java/core/CliArguments.java
@@ -2,30 +2,5 @@ package media.barney.crap4java.core;
 
 import java.util.List;
 
-record CliArguments(CliMode mode, List<String> fileArgs) {
+record CliArguments(CliMode mode, BuildToolSelection buildToolSelection, List<String> fileArgs) {
 }
-
-/* mutate4java-manifest
-version=1
-moduleHash=d1a406bd369d2573ff065574f27152f4a361ea4dc00c227f3bb7abfd75d2eaa9
-scope.0.id=Y2xhc3M6Q2xpQXJndW1lbnRzI0NsaUFyZ3VtZW50czo1
-scope.0.kind=class
-scope.0.startLine=5
-scope.0.endLine=6
-scope.0.semanticHash=46a0476b8b3c65283f40ecaa583840e5677af56f04391655096ae2994a20dae9
-scope.1.id=ZmllbGQ6Q2xpQXJndW1lbnRzI2ZpbGVBcmdzOjU
-scope.1.kind=field
-scope.1.startLine=5
-scope.1.endLine=5
-scope.1.semanticHash=f80baf7e7953a4656e562aaf16e4f07371e3273850635d8563b47631b1dad17c
-scope.2.id=ZmllbGQ6Q2xpQXJndW1lbnRzI21vZGU6NQ
-scope.2.kind=field
-scope.2.startLine=5
-scope.2.endLine=5
-scope.2.semanticHash=b09c0d200fb0d0f48cf18d6f308f4a995a0bdc16401be97c6b5ac3be74abcc23
-scope.3.id=bWV0aG9kOkNsaUFyZ3VtZW50cyNjdG9yKDIpOjU
-scope.3.kind=method
-scope.3.startLine=1
-scope.3.endLine=6
-scope.3.semanticHash=3c385dea36d6d24964b2feb1340e96cbf5c204aa5618b4b6aad43b65176dcab2
-*/

--- a/core/src/main/java/media/barney/crap4java/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap4java/core/CliArgumentsParser.java
@@ -10,40 +10,54 @@ final class CliArgumentsParser {
 
     static CliArguments parse(String[] args) {
         if (args.length == 0) {
-            return new CliArguments(CliMode.ALL_SRC, List.of());
+            return new CliArguments(CliMode.ALL_SRC, BuildToolSelection.AUTO, List.of());
         }
 
-        if (containsFlag(args, "--help")) {
-            return new CliArguments(CliMode.HELP, List.of());
+        ParseState state = parseState(args);
+        if (state.help) {
+            return new CliArguments(CliMode.HELP, state.buildToolSelection, List.of());
         }
-
-        boolean changed = containsFlag(args, "--changed");
-        List<String> values = nonFlagArgs(args);
+        boolean changed = state.changed;
+        List<String> values = state.fileArgs;
         ensureChangedIsNotCombined(changed, values);
         if (changed) {
-            return new CliArguments(CliMode.CHANGED_SRC, List.of());
+            return new CliArguments(CliMode.CHANGED_SRC, state.buildToolSelection, List.of());
         }
-        return new CliArguments(CliMode.EXPLICIT_FILES, List.copyOf(values));
+        if (values.isEmpty()) {
+            return new CliArguments(CliMode.ALL_SRC, state.buildToolSelection, List.of());
+        }
+        return new CliArguments(CliMode.EXPLICIT_FILES, state.buildToolSelection, List.copyOf(values));
     }
 
-    private static boolean containsFlag(String[] args, String flag) {
-        for (String arg : args) {
-            if (flag.equals(arg)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static List<String> nonFlagArgs(String[] args) {
+    private static ParseState parseState(String[] args) {
+        boolean help = false;
+        boolean changed = false;
+        BuildToolSelection buildToolSelection = BuildToolSelection.AUTO;
+        boolean buildToolSeen = false;
         List<String> values = new ArrayList<>();
-        for (String arg : args) {
-            if (arg.startsWith("--")) {
-                continue;
+        for (int index = 0; index < args.length; index++) {
+            String arg = args[index];
+            switch (arg) {
+                case "--help" -> help = true;
+                case "--changed" -> changed = true;
+                case "--build-tool" -> {
+                    if (buildToolSeen) {
+                        throw new IllegalArgumentException("--build-tool can only be provided once");
+                    }
+                    if (index + 1 >= args.length) {
+                        throw new IllegalArgumentException("--build-tool requires one of: auto, maven, gradle");
+                    }
+                    buildToolSelection = BuildToolSelection.parse(args[++index]);
+                    buildToolSeen = true;
+                }
+                default -> {
+                    if (!arg.startsWith("--")) {
+                        values.add(arg);
+                    }
+                }
             }
-            values.add(arg);
         }
-        return values;
+        return new ParseState(help, changed, buildToolSelection, values);
     }
 
     private static void ensureChangedIsNotCombined(boolean changed, List<String> values) {
@@ -51,39 +65,10 @@ final class CliArgumentsParser {
             throw new IllegalArgumentException("--changed cannot be combined with file arguments");
         }
     }
-}
 
-/* mutate4java-manifest
-version=1
-moduleHash=c601a3269ac203989827cc53ee454fc10939fa53e57696dd51933588e9ffdd3c
-scope.0.id=Y2xhc3M6Q2xpQXJndW1lbnRzUGFyc2VyI0NsaUFyZ3VtZW50c1BhcnNlcjo2
-scope.0.kind=class
-scope.0.startLine=6
-scope.0.endLine=54
-scope.0.semanticHash=e1a985a18c271d3f33ed005b3954e9933a6b6a51a06728ba9f8015b2ed148726
-scope.1.id=bWV0aG9kOkNsaUFyZ3VtZW50c1BhcnNlciNjb250YWluc0ZsYWcoMik6Mjk
-scope.1.kind=method
-scope.1.startLine=29
-scope.1.endLine=36
-scope.1.semanticHash=e222c83f83779c94d458d47525f0e6d676f4c6be6b74c198d8b91c8bf3b95544
-scope.2.id=bWV0aG9kOkNsaUFyZ3VtZW50c1BhcnNlciNjdG9yKDApOjg
-scope.2.kind=method
-scope.2.startLine=8
-scope.2.endLine=9
-scope.2.semanticHash=c9502e5b2d38c24ae05d67ebe8ddde01d9ecd2bf449a91ac80aa7ba16421ee7d
-scope.3.id=bWV0aG9kOkNsaUFyZ3VtZW50c1BhcnNlciNlbnN1cmVDaGFuZ2VkSXNOb3RDb21iaW5lZCgyKTo0OQ
-scope.3.kind=method
-scope.3.startLine=49
-scope.3.endLine=53
-scope.3.semanticHash=5cb2beb93b0a2fcc0eea65e584c43ac03abac646a4a1eb153dd697193f33f5c4
-scope.4.id=bWV0aG9kOkNsaUFyZ3VtZW50c1BhcnNlciNub25GbGFnQXJncygxKTozOA
-scope.4.kind=method
-scope.4.startLine=38
-scope.4.endLine=47
-scope.4.semanticHash=c552c2037213247b8fc707727d39c9091f857462f0e836d19bd293eca2ce05da
-scope.5.id=bWV0aG9kOkNsaUFyZ3VtZW50c1BhcnNlciNwYXJzZSgxKToxMQ
-scope.5.kind=method
-scope.5.startLine=11
-scope.5.endLine=27
-scope.5.semanticHash=77f58a4ff446f7980fab2ce25b35a52a9dc246e814ae59e19e19a883f3d79d50
-*/
+    private record ParseState(boolean help,
+                              boolean changed,
+                              BuildToolSelection buildToolSelection,
+                              List<String> fileArgs) {
+    }
+}

--- a/core/src/main/java/media/barney/crap4java/core/CoverageRunner.java
+++ b/core/src/main/java/media/barney/crap4java/core/CoverageRunner.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
-import java.util.List;
 
 final class CoverageRunner {
 
@@ -14,16 +13,12 @@ final class CoverageRunner {
         this.executor = executor;
     }
 
-    void generateCoverage(Path projectRoot) throws Exception {
-        deleteIfExists(projectRoot.resolve("target/site/jacoco"));
-        deleteIfExists(projectRoot.resolve("target/jacoco.exec"));
+    void generateCoverage(ProjectModule module) throws Exception {
+        for (Path staleCoveragePath : module.staleCoveragePaths()) {
+            deleteIfExists(staleCoveragePath);
+        }
 
-        int exit = executor.run(List.of(
-                "mvn", "-q",
-                "org.jacoco:jacoco-maven-plugin:0.8.12:prepare-agent",
-                "test",
-                "org.jacoco:jacoco-maven-plugin:0.8.12:report"
-        ), projectRoot);
+        int exit = executor.run(module.coverageCommand(), module.executionRoot());
         if (exit != 0) {
             throw new IllegalStateException("Coverage command failed with exit " + exit);
         }
@@ -49,33 +44,3 @@ final class CoverageRunner {
         Files.deleteIfExists(path);
     }
 }
-
-/* mutate4java-manifest
-version=1
-moduleHash=080f89894e26acfa200b3c2dca10a0349ee9996687565dbfc43572b1d90a8eb1
-scope.0.id=Y2xhc3M6Q292ZXJhZ2VSdW5uZXIjQ292ZXJhZ2VSdW5uZXI6OQ
-scope.0.kind=class
-scope.0.startLine=9
-scope.0.endLine=51
-scope.0.semanticHash=222115fc5fd871d8ad974cf4c94cd0e52e88ee06fe1e89a8e2c6416610e667ec
-scope.1.id=ZmllbGQ6Q292ZXJhZ2VSdW5uZXIjZXhlY3V0b3I6MTE
-scope.1.kind=field
-scope.1.startLine=11
-scope.1.endLine=11
-scope.1.semanticHash=c4eedf9e7c0e6dffb225b9db0a0ca739c26698121741ae20349559e2bc48602a
-scope.2.id=bWV0aG9kOkNvdmVyYWdlUnVubmVyI2N0b3IoMSk6MTM
-scope.2.kind=method
-scope.2.startLine=13
-scope.2.endLine=15
-scope.2.semanticHash=24bd1d89a71e4c966e1f894918fbada2a751dbd894339d3832764a5b9ddf2608
-scope.3.id=bWV0aG9kOkNvdmVyYWdlUnVubmVyI2RlbGV0ZUlmRXhpc3RzKDEpOjMy
-scope.3.kind=method
-scope.3.startLine=32
-scope.3.endLine=50
-scope.3.semanticHash=3e9c1df528853970581858951a8747028bd49974850a38b37d4b10b3527140c5
-scope.4.id=bWV0aG9kOkNvdmVyYWdlUnVubmVyI2dlbmVyYXRlQ292ZXJhZ2UoMSk6MTc
-scope.4.kind=method
-scope.4.startLine=17
-scope.4.endLine=30
-scope.4.semanticHash=2370d9f69b2da165bd3ec40585384649f6d75eb3193c5a09baff7d25762fa826
-*/

--- a/core/src/main/java/media/barney/crap4java/core/Main.java
+++ b/core/src/main/java/media/barney/crap4java/core/Main.java
@@ -28,10 +28,12 @@ public final class Main {
     static String usage() {
         return """
                 Usage:
-                  crap4java            Analyze all Java files under src/
-                  crap4java --changed  Analyze changed Java files under src/
-                  crap4java <path...>  Analyze files, or for directory args analyze <dir>/src/**/*.java
-                  crap4java --help     Print this help message
+                  crap4java                                Analyze all Java files under src/
+                  crap4java --changed                      Analyze changed Java files under src/
+                  crap4java --build-tool gradle           Force Gradle for all resolved modules
+                  crap4java --build-tool maven --changed  Force Maven for changed files
+                  crap4java <path...>                     Analyze files, or for directory args analyze <dir>/**/src/**/*.java
+                  crap4java --help                        Print this help message
                 """;
     }
 
@@ -45,43 +47,3 @@ public final class Main {
         return max;
     }
 }
-
-/* mutate4java-manifest
-version=1
-moduleHash=e33f577606041952eb9ddde846aa921b7b03fa24e487e2a834540f64b992914c
-scope.0.id=Y2xhc3M6TWFpbiNNYWluOjc
-scope.0.kind=class
-scope.0.startLine=7
-scope.0.endLine=47
-scope.0.semanticHash=4958ec2d89a67c8cf8abbdba7cf1f27c2ed0a96f892b959933533c0dae70c14c
-scope.1.id=bWV0aG9kOk1haW4jY3RvcigwKTo5
-scope.1.kind=method
-scope.1.startLine=9
-scope.1.endLine=10
-scope.1.semanticHash=2a7894b82bf05c8917e82420e502ab2cc96fef2366eeef066911514202ec3bd1
-scope.2.id=bWV0aG9kOk1haW4jbWFpbigxKToxMg
-scope.2.kind=method
-scope.2.startLine=12
-scope.2.endLine=14
-scope.2.semanticHash=ad0b8e92af29f222e8dd39931244c11c92fec3df537a67a48b20b5f66ff38418
-scope.3.id=bWV0aG9kOk1haW4jbWF4Q3JhcCgxKTozOA
-scope.3.kind=method
-scope.3.startLine=38
-scope.3.endLine=46
-scope.3.semanticHash=9dc86a46e1bbd3c811f8c5fac1df658311b061ea8bb0d5d0eb6988e64d2b48a1
-scope.4.id=bWV0aG9kOk1haW4jcnVuKDQpOjE2
-scope.4.kind=method
-scope.4.startLine=16
-scope.4.endLine=18
-scope.4.semanticHash=cc7423c4434171101ff7f748e37f11409b415f102f126ddf5a1f9df77c2b278f
-scope.5.id=bWV0aG9kOk1haW4jcnVuKDUpOjIw
-scope.5.kind=method
-scope.5.startLine=20
-scope.5.endLine=26
-scope.5.semanticHash=026c69ed083265062059d1580ebc97d39024947bd7dc82141053916115a169ef
-scope.6.id=bWV0aG9kOk1haW4jdXNhZ2UoMCk6Mjg
-scope.6.kind=method
-scope.6.startLine=28
-scope.6.endLine=36
-scope.6.semanticHash=e96b9f53b2599d50ee02f75be6e027bc903b4bd00a18a0ee334a1f9a36b56e0f
-*/

--- a/core/src/main/java/media/barney/crap4java/core/ProcessCommandExecutor.java
+++ b/core/src/main/java/media/barney/crap4java/core/ProcessCommandExecutor.java
@@ -1,9 +1,21 @@
 package media.barney.crap4java.core;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 final class ProcessCommandExecutor implements CommandExecutor {
+
+    private final Duration timeout;
+
+    ProcessCommandExecutor() {
+        this(Duration.ofMinutes(10));
+    }
+
+    ProcessCommandExecutor(Duration timeout) {
+        this.timeout = timeout;
+    }
 
     @Override
     public int run(List<String> command, Path directory) throws Exception {
@@ -11,26 +23,10 @@ final class ProcessCommandExecutor implements CommandExecutor {
                 .directory(directory.toFile())
                 .inheritIO()
                 .start();
-        return process.waitFor();
+        if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            process.destroyForcibly();
+            throw new IllegalStateException("Command timed out after " + timeout.toSeconds() + " seconds: " + command.get(0));
+        }
+        return process.exitValue();
     }
 }
-
-/* mutate4java-manifest
-version=1
-moduleHash=6ea27d2229d3c3ec428dc6c5fff6f319242e088f19dd9369a4f1992ce2a80266
-scope.0.id=Y2xhc3M6UHJvY2Vzc0NvbW1hbmRFeGVjdXRvciNQcm9jZXNzQ29tbWFuZEV4ZWN1dG9yOjY
-scope.0.kind=class
-scope.0.startLine=6
-scope.0.endLine=16
-scope.0.semanticHash=d49ac5bf424aba3412a65e6fa49929921a017705f4c243d18d5828d46ca74e6e
-scope.1.id=bWV0aG9kOlByb2Nlc3NDb21tYW5kRXhlY3V0b3IjY3RvcigwKTo2
-scope.1.kind=method
-scope.1.startLine=1
-scope.1.endLine=16
-scope.1.semanticHash=d1a3877e6063504f6423a8dc876b39079a1832a2c7bc3f3145646bd3e99dd29c
-scope.2.id=bWV0aG9kOlByb2Nlc3NDb21tYW5kRXhlY3V0b3IjcnVuKDIpOjg
-scope.2.kind=method
-scope.2.startLine=8
-scope.2.endLine=15
-scope.2.semanticHash=7be95a2db36c31ff28eb73e5aad6fcc4dbdd9b03cc3ece380c4a6aa13599060c
-*/

--- a/core/src/main/java/media/barney/crap4java/core/ProjectModule.java
+++ b/core/src/main/java/media/barney/crap4java/core/ProjectModule.java
@@ -1,0 +1,112 @@
+package media.barney.crap4java.core;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+record ProjectModule(Path moduleRoot, Path executionRoot, BuildTool buildTool) {
+
+    private static final String JACOCO_MAVEN_PLUGIN_VERSION = "0.8.13";
+
+    ProjectModule {
+        moduleRoot = moduleRoot.normalize();
+        executionRoot = executionRoot.normalize();
+    }
+
+    Path jacocoXmlPath() {
+        return switch (buildTool) {
+            case MAVEN -> moduleRoot.resolve("target/site/jacoco/jacoco.xml");
+            case GRADLE -> moduleRoot.resolve("build/reports/jacoco/test/jacocoTestReport.xml");
+        };
+    }
+
+    List<Path> staleCoveragePaths() {
+        return switch (buildTool) {
+            case MAVEN -> List.of(
+                    moduleRoot.resolve("target/site/jacoco"),
+                    moduleRoot.resolve("target/jacoco.exec")
+            );
+            case GRADLE -> List.of(
+                    moduleRoot.resolve("build/reports/jacoco/test"),
+                    moduleRoot.resolve("build/jacoco")
+            );
+        };
+    }
+
+    List<String> coverageCommand() {
+        return switch (buildTool) {
+            case MAVEN -> mavenCoverageCommand();
+            case GRADLE -> gradleCoverageCommand();
+        };
+    }
+
+    private List<String> mavenCoverageCommand() {
+        List<String> command = new ArrayList<>();
+        command.add(mavenLauncher());
+        command.add("-q");
+        if (!executionRoot.equals(moduleRoot)) {
+            command.add("-pl");
+            command.add(moduleSelector());
+            command.add("-am");
+        }
+        command.add("org.jacoco:jacoco-maven-plugin:" + JACOCO_MAVEN_PLUGIN_VERSION + ":prepare-agent");
+        command.add("test");
+        command.add("org.jacoco:jacoco-maven-plugin:" + JACOCO_MAVEN_PLUGIN_VERSION + ":report");
+        return List.copyOf(command);
+    }
+
+    private List<String> gradleCoverageCommand() {
+        List<String> command = new ArrayList<>();
+        command.add(gradleLauncher());
+        command.add("--no-daemon");
+        command.add("-q");
+        command.add(taskName("test"));
+        command.add(taskName("jacocoTestReport"));
+        return List.copyOf(command);
+    }
+
+    private String taskName(String baseTask) {
+        if (executionRoot.equals(moduleRoot)) {
+            return baseTask;
+        }
+        return gradleProjectPath() + ":" + baseTask;
+    }
+
+    private String gradleProjectPath() {
+        Path relative = executionRoot.relativize(moduleRoot);
+        StringBuilder builder = new StringBuilder();
+        for (Path segment : relative) {
+            builder.append(':').append(segment.toString().replace('\\', '/'));
+        }
+        return builder.isEmpty() ? ":" : builder.toString();
+    }
+
+    private String moduleSelector() {
+        return executionRoot.relativize(moduleRoot).toString().replace('\\', '/');
+    }
+
+    private String mavenLauncher() {
+        if (isWindows() && Files.exists(executionRoot.resolve("mvnw.cmd"))) {
+            return "mvnw.cmd";
+        }
+        if (!isWindows() && Files.exists(executionRoot.resolve("mvnw"))) {
+            return "./mvnw";
+        }
+        return "mvn";
+    }
+
+    private String gradleLauncher() {
+        if (isWindows() && Files.exists(executionRoot.resolve("gradlew.bat"))) {
+            return "gradlew.bat";
+        }
+        if (!isWindows() && Files.exists(executionRoot.resolve("gradlew"))) {
+            return "./gradlew";
+        }
+        return "gradle";
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().startsWith("windows");
+    }
+}

--- a/core/src/main/java/media/barney/crap4java/core/ProjectModuleResolver.java
+++ b/core/src/main/java/media/barney/crap4java/core/ProjectModuleResolver.java
@@ -1,0 +1,93 @@
+package media.barney.crap4java.core;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+
+final class ProjectModuleResolver {
+
+    private ProjectModuleResolver() {
+    }
+
+    static ProjectModule resolve(Path workspaceRoot, Path file, BuildToolSelection selection) {
+        Path normalizedWorkspaceRoot = workspaceRoot.normalize();
+        Path candidate = Files.isDirectory(file) ? file.normalize() : file.normalize().getParent();
+        while (candidate != null && candidate.startsWith(normalizedWorkspaceRoot)) {
+            EnumSet<BuildTool> detected = BuildTool.detect(candidate);
+            if (!detected.isEmpty()) {
+                BuildTool buildTool = selectBuildTool(candidate, detected, selection);
+                return new ProjectModule(candidate, executionRoot(normalizedWorkspaceRoot, candidate, buildTool), buildTool);
+            }
+            candidate = candidate.getParent();
+        }
+        throw new IllegalArgumentException("No Maven or Gradle module found for " + file.normalize());
+    }
+
+    private static BuildTool selectBuildTool(Path moduleRoot,
+                                             EnumSet<BuildTool> detected,
+                                             BuildToolSelection selection) {
+        if (selection == BuildToolSelection.AUTO) {
+            if (detected.size() == 1) {
+                return detected.iterator().next();
+            }
+            throw new IllegalArgumentException(
+                    "Ambiguous build tool for module " + moduleRoot
+                            + ". Found both Maven and Gradle markers. Use --build-tool maven or --build-tool gradle."
+            );
+        }
+
+        BuildTool requested = selection.toBuildTool();
+        if (detected.contains(requested)) {
+            return requested;
+        }
+        throw new IllegalArgumentException(
+                "Requested build tool " + selection.name().toLowerCase()
+                        + " does not match the detected module at " + moduleRoot + "."
+        );
+    }
+
+    private static Path executionRoot(Path workspaceRoot, Path moduleRoot, BuildTool buildTool) {
+        return switch (buildTool) {
+            case MAVEN -> topmostAncestor(workspaceRoot, moduleRoot,
+                    directory -> Files.exists(directory.resolve("mvnw"))
+                            || Files.exists(directory.resolve("mvnw.cmd"))
+                            || Files.exists(directory.resolve("pom.xml")));
+            case GRADLE -> {
+                Path settingsOrWrapper = topmostAncestorOrNull(workspaceRoot, moduleRoot,
+                        directory -> Files.exists(directory.resolve("settings.gradle"))
+                                || Files.exists(directory.resolve("settings.gradle.kts"))
+                                || Files.exists(directory.resolve("gradlew"))
+                                || Files.exists(directory.resolve("gradlew.bat")));
+                if (settingsOrWrapper != null) {
+                    yield settingsOrWrapper;
+                }
+                yield topmostAncestor(workspaceRoot, moduleRoot,
+                        directory -> Files.exists(directory.resolve("build.gradle"))
+                                || Files.exists(directory.resolve("build.gradle.kts")));
+            }
+        };
+    }
+
+    private static Path topmostAncestor(Path workspaceRoot, Path start, DirectoryPredicate predicate) {
+        Path match = topmostAncestorOrNull(workspaceRoot, start, predicate);
+        return match != null ? match : start.normalize();
+    }
+
+    private static Path topmostAncestorOrNull(Path workspaceRoot, Path start, DirectoryPredicate predicate) {
+        Path normalizedWorkspaceRoot = workspaceRoot.normalize();
+        Path current = start.normalize();
+        Path match = null;
+        while (current != null && current.startsWith(normalizedWorkspaceRoot)) {
+            if (predicate.test(current)) {
+                match = current;
+            }
+            current = current.getParent();
+        }
+        return match;
+    }
+
+    @FunctionalInterface
+    private interface DirectoryPredicate {
+        boolean test(Path directory);
+    }
+}

--- a/core/src/main/java/media/barney/crap4java/core/SourceFileFinder.java
+++ b/core/src/main/java/media/barney/crap4java/core/SourceFileFinder.java
@@ -11,37 +11,27 @@ final class SourceFileFinder {
     private SourceFileFinder() {
     }
 
-    static List<Path> findAllJavaFilesUnderSrc(Path projectRoot) throws IOException {
-        Path src = projectRoot.resolve("src");
-        if (!Files.exists(src)) {
+    static List<Path> findAllJavaFilesUnderSourceRoots(Path projectRoot) throws IOException {
+        if (!Files.exists(projectRoot)) {
             return List.of();
         }
 
-        try (var stream = Files.walk(src)) {
+        try (var stream = Files.walk(projectRoot)) {
             return stream
                     .filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> isUnderSourceTree(projectRoot, path))
                     .sorted(Comparator.naturalOrder())
                     .toList();
         }
     }
-}
 
-/* mutate4java-manifest
-version=1
-moduleHash=21199b1e7988ac2b433d1228947d962a5a2af272adf722ee5f55cd2eeb385784
-scope.0.id=Y2xhc3M6U291cmNlRmlsZUZpbmRlciNTb3VyY2VGaWxlRmluZGVyOjk
-scope.0.kind=class
-scope.0.startLine=9
-scope.0.endLine=27
-scope.0.semanticHash=e44d77790f24780d1574e94b00ec8055d64dda3940dee87617bd65fdc1033cbb
-scope.1.id=bWV0aG9kOlNvdXJjZUZpbGVGaW5kZXIjY3RvcigwKToxMQ
-scope.1.kind=method
-scope.1.startLine=11
-scope.1.endLine=12
-scope.1.semanticHash=952989561249035658f6719d569bc70bd2b9d10da263124c47f965e77064bb82
-scope.2.id=bWV0aG9kOlNvdXJjZUZpbGVGaW5kZXIjZmluZEFsbEphdmFGaWxlc1VuZGVyU3JjKDEpOjE0
-scope.2.kind=method
-scope.2.startLine=14
-scope.2.endLine=26
-scope.2.semanticHash=a11a3345bb541c4571b681b1447f0496b1f16c9b46d9f0449ca2162039b2e078
-*/
+    private static boolean isUnderSourceTree(Path projectRoot, Path file) {
+        Path normalized = projectRoot.normalize().relativize(file.normalize());
+        for (Path segment : normalized) {
+            if ("src".equals(segment.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/test/java/media/barney/crap4java/core/ChangedFileDetectorTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/ChangedFileDetectorTest.java
@@ -54,15 +54,17 @@ class ChangedFileDetectorTest {
     }
 
     @Test
-    void filtersChangedFilesToSrcTreeOnly() throws Exception {
+    void filtersChangedFilesToSourceTreesOnly() throws Exception {
         run(tempDir, "git", "init");
         run(tempDir, "git", "config", "user.email", "test@example.com");
         run(tempDir, "git", "config", "user.name", "test");
 
         Path mainSrc = tempDir.resolve("src/main/java/demo");
-        Path testSrc = tempDir.resolve("test/crap4java");
+        Path moduleTestSrc = tempDir.resolve("module-a/src/test/java/demo");
+        Path nonSourceTree = tempDir.resolve("test/crap4java");
         Files.createDirectories(mainSrc);
-        Files.createDirectories(testSrc);
+        Files.createDirectories(moduleTestSrc);
+        Files.createDirectories(nonSourceTree);
 
         Path tracked = mainSrc.resolve("Tracked.java");
         Files.writeString(tracked, "class Tracked {}\n");
@@ -70,11 +72,16 @@ class ChangedFileDetectorTest {
         run(tempDir, "git", "commit", "-m", "init");
 
         Files.writeString(tracked, "class Tracked { int x = 1; }\n");
-        Files.writeString(testSrc.resolve("ChangedFileDetectorTest.java"), "class ChangedFileDetectorTest {}\n");
+        Path nested = moduleTestSrc.resolve("NestedChanged.java");
+        Files.writeString(nested, "class NestedChanged {}\n");
+        Files.writeString(nonSourceTree.resolve("ChangedFileDetectorTest.java"), "class ChangedFileDetectorTest {}\n");
 
-        List<Path> changed = ChangedFileDetector.changedJavaFilesUnderSrc(tempDir);
+        List<Path> changed = ChangedFileDetector.changedJavaFilesUnderSourceRoots(tempDir);
 
-        assertEquals(List.of(tempDir.resolve("src/main/java/demo/Tracked.java")), changed);
+        assertEquals(List.of(
+                tempDir.resolve("module-a/src/test/java/demo/NestedChanged.java"),
+                tempDir.resolve("src/main/java/demo/Tracked.java")
+        ), changed);
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap4java/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/CliApplicationTest.java
@@ -50,6 +50,7 @@ class CliApplicationTest {
     void doesNotWarnWhenJacocoXmlExists() throws Exception {
         Path sourceRoot = tempDir.resolve("src/main/java/demo");
         Files.createDirectories(sourceRoot);
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
         Path source = sourceRoot.resolve("Sample.java");
         Files.writeString(source, """
                 package demo;
@@ -135,21 +136,91 @@ class CliApplicationTest {
     }
 
     @Test
+    void explicitFileUsesOwningGradleModuleAndExecutionRoot() throws Exception {
+        Files.writeString(tempDir.resolve("settings.gradle"), "rootProject.name = 'workspace'");
+        Path moduleRoot = tempDir.resolve("apps/demo");
+        Path sourceRoot = moduleRoot.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Files.writeString(moduleRoot.resolve("build.gradle"), "plugins { id 'java' }");
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int alpha() {
+                        return 1;
+                    }
+                }
+                """);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        List<List<String>> commands = new ArrayList<>();
+        List<Path> directories = new ArrayList<>();
+        Path jacocoXml = moduleRoot.resolve("build/reports/jacoco/test/jacocoTestReport.xml");
+        CoverageRunner coverageRunner = new CoverageRunner((command, directory) -> {
+            commands.add(command);
+            directories.add(directory);
+            Files.createDirectories(jacocoXml.getParent());
+            Files.writeString(jacocoXml, """
+                    <report name="demo">
+                      <package name="demo">
+                        <class name="demo/Sample" sourcefilename="Sample.java">
+                          <method name="alpha" desc="()I" line="4">
+                            <counter type="INSTRUCTION" missed="0" covered="1"/>
+                          </method>
+                        </class>
+                      </package>
+                    </report>
+                    """);
+            return 0;
+        });
+
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), coverageRunner)
+                .execute(new String[]{"apps/demo/src/main/java/demo/Sample.java"});
+
+        assertEquals(0, exit);
+        assertEquals(List.of(tempDir), directories);
+        assertEquals(List.of(List.of("gradle", "--no-daemon", "-q", ":apps:demo:test", ":apps:demo:jacocoTestReport")), commands);
+        assertTrue(out.toString().contains("demo.Sample"));
+        assertFalse(err.toString().contains("Warning: JaCoCo XML not found"));
+    }
+
+    @Test
     void thresholdExceededUsesStrictlyGreaterThanEight() {
         assertFalse(CliApplication.thresholdExceeded(8.0));
         assertTrue(CliApplication.thresholdExceeded(8.1));
     }
 
     @Test
-    void moduleRootForFindsNearestAncestorWithPom() throws Exception {
+    void moduleForFindsNearestAncestorWithPom() throws Exception {
         Path moduleRoot = tempDir.resolve("tools/mutate4java");
         Path source = moduleRoot.resolve("src/mutate4java/Sample.java");
         Files.createDirectories(source.getParent());
         Files.writeString(moduleRoot.resolve("pom.xml"), "<project/>");
         Files.writeString(source, "class Sample {}");
 
-        Path module = CliApplication.moduleRootFor(tempDir, source);
+        ProjectModule module = CliApplication.moduleFor(tempDir, source, BuildToolSelection.AUTO);
 
-        assertEquals(moduleRoot, module);
+        assertEquals(moduleRoot, module.moduleRoot());
+        assertEquals(BuildTool.MAVEN, module.buildTool());
+    }
+
+    @Test
+    void ambiguousBuildToolReturnsExitOneWithoutUsage() throws Exception {
+        Path moduleRoot = tempDir.resolve("demo");
+        Path sourceRoot = moduleRoot.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Files.writeString(moduleRoot.resolve("pom.xml"), "<project/>");
+        Files.writeString(moduleRoot.resolve("build.gradle"), "plugins { id 'java' }");
+        Files.writeString(sourceRoot.resolve("Sample.java"), "class Sample {}");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), NOOP_COVERAGE)
+                .execute(new String[]{"demo/src/main/java/demo/Sample.java"});
+
+        assertEquals(1, exit);
+        assertEquals("", out.toString());
+        assertTrue(err.toString().contains("Ambiguous build tool for module"));
     }
 }

--- a/core/src/test/java/media/barney/crap4java/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/CliArgumentsParserTest.java
@@ -13,18 +13,21 @@ class CliArgumentsParserTest {
     void noArgsMeansAllSrcFiles() {
         CliArguments args = CliArgumentsParser.parse(new String[]{});
         assertEquals(CliMode.ALL_SRC, args.mode());
+        assertEquals(BuildToolSelection.AUTO, args.buildToolSelection());
     }
 
     @Test
     void changedFlagMeansChangedSrcFiles() {
         CliArguments args = CliArgumentsParser.parse(new String[]{"--changed"});
         assertEquals(CliMode.CHANGED_SRC, args.mode());
+        assertEquals(BuildToolSelection.AUTO, args.buildToolSelection());
     }
 
     @Test
     void fileNamesMeanExplicitFiles() {
         CliArguments args = CliArgumentsParser.parse(new String[]{"src/main/java/demo/A.java", "src/main/java/demo/B.java"});
         assertEquals(CliMode.EXPLICIT_FILES, args.mode());
+        assertEquals(BuildToolSelection.AUTO, args.buildToolSelection());
         assertEquals(List.of("src/main/java/demo/A.java", "src/main/java/demo/B.java"), args.fileArgs());
     }
 
@@ -34,6 +37,32 @@ class CliArgumentsParserTest {
 
         assertEquals(CliMode.EXPLICIT_FILES, args.mode());
         assertEquals(List.of("src/main/java/demo/A.java", "src/main/java/demo/B.java"), args.fileArgs());
+    }
+
+    @Test
+    void buildToolFlagIsParsed() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{"--build-tool", "gradle", "--changed"});
+
+        assertEquals(CliMode.CHANGED_SRC, args.mode());
+        assertEquals(BuildToolSelection.GRADLE, args.buildToolSelection());
+    }
+
+    @Test
+    void buildToolRequiresKnownValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--build-tool", "ant"}));
+    }
+
+    @Test
+    void buildToolRequiresValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--build-tool"}));
+    }
+
+    @Test
+    void buildToolCanOnlyBeProvidedOnce() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--build-tool", "maven", "--build-tool", "gradle"}));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap4java/core/CoverageRunnerTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/CoverageRunnerTest.java
@@ -19,25 +19,28 @@ class CoverageRunnerTest {
 
     @Test
     void deletesStaleCoverageAndRunsMavenCoverageCommand() throws Exception {
-        Path jacocoDir = tempDir.resolve("target/site/jacoco");
+        Path moduleRoot = tempDir.resolve("module-a");
+        Files.createDirectories(moduleRoot);
+        Path jacocoDir = moduleRoot.resolve("target/site/jacoco");
         Files.createDirectories(jacocoDir);
         Files.writeString(jacocoDir.resolve("old.xml"), "stale");
-        Path exec = tempDir.resolve("target/jacoco.exec");
+        Path exec = moduleRoot.resolve("target/jacoco.exec");
         Files.createDirectories(exec.getParent());
         Files.writeString(exec, "stale");
 
         RecordingExecutor executor = new RecordingExecutor(0);
         CoverageRunner runner = new CoverageRunner(executor);
 
-        runner.generateCoverage(tempDir);
+        runner.generateCoverage(new ProjectModule(moduleRoot, tempDir, BuildTool.MAVEN));
 
         assertFalse(Files.exists(jacocoDir));
         assertFalse(Files.exists(exec));
         assertEquals(List.of(
                 "mvn", "-q",
-                "org.jacoco:jacoco-maven-plugin:0.8.12:prepare-agent",
+                "-pl", "module-a", "-am",
+                "org.jacoco:jacoco-maven-plugin:0.8.13:prepare-agent",
                 "test",
-                "org.jacoco:jacoco-maven-plugin:0.8.12:report"
+                "org.jacoco:jacoco-maven-plugin:0.8.13:report"
         ), executor.commands.get(0));
         assertEquals(tempDir, executor.directories.get(0));
     }
@@ -48,7 +51,7 @@ class CoverageRunnerTest {
         CoverageRunner runner = new CoverageRunner(executor);
 
         IllegalStateException ex = assertThrows(IllegalStateException.class,
-                () -> runner.generateCoverage(tempDir));
+                () -> runner.generateCoverage(new ProjectModule(tempDir, tempDir, BuildTool.GRADLE)));
 
         assertEquals("Coverage command failed with exit 2", ex.getMessage());
     }

--- a/core/src/test/java/media/barney/crap4java/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/MainTest.java
@@ -29,6 +29,7 @@ class MainTest {
 
         assertEquals(0, exit);
         assertTrue(out.toString().contains("Usage:"));
+        assertTrue(out.toString().contains("--build-tool"));
     }
 
     @Test
@@ -62,6 +63,7 @@ class MainTest {
     void explicitFileArgsAreAnalyzed() throws Exception {
         Path sourceRoot = tempDir.resolve("src/main/java/demo");
         Files.createDirectories(sourceRoot);
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
         Path source = sourceRoot.resolve("Sample.java");
         Files.writeString(source, """
                 package demo;
@@ -96,6 +98,7 @@ class MainTest {
         Path moduleRoot = tempDir.resolve("module-a");
         Path sourceRoot = moduleRoot.resolve("src/main/java/demo");
         Files.createDirectories(sourceRoot);
+        Files.writeString(moduleRoot.resolve("build.gradle"), "plugins { id 'java' }");
         Files.writeString(sourceRoot.resolve("Sample.java"), """
                 package demo;
                 class Sample {

--- a/core/src/test/java/media/barney/crap4java/core/ProcessCommandExecutorTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/ProcessCommandExecutorTest.java
@@ -4,10 +4,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Locale;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProcessCommandExecutorTest {
 
@@ -21,10 +24,27 @@ class ProcessCommandExecutorTest {
         assertEquals(7, exit);
     }
 
+    @Test
+    void timesOutLongRunningProcesses() {
+        ProcessCommandExecutor executor = new ProcessCommandExecutor(Duration.ofMillis(100));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> executor.run(sleepCommand(), tempDir));
+
+        assertTrue(error.getMessage().contains("Command timed out"));
+    }
+
     private static List<String> exitCommand(int exitCode) {
         if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
             return List.of("cmd", "/c", "exit " + exitCode);
         }
         return List.of("sh", "-c", "exit " + exitCode);
+    }
+
+    private static List<String> sleepCommand() {
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
+            return List.of("powershell", "-Command", "Start-Sleep -Seconds 5");
+        }
+        return List.of("sh", "-c", "sleep 5");
     }
 }

--- a/core/src/test/java/media/barney/crap4java/core/ProjectModuleResolverTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/ProjectModuleResolverTest.java
@@ -1,0 +1,109 @@
+package media.barney.crap4java.core;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProjectModuleResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void resolvesNearestMavenModuleForExplicitFile() throws Exception {
+        Path moduleRoot = tempDir.resolve("services/orders");
+        Path source = moduleRoot.resolve("src/main/java/demo/Sample.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(moduleRoot.resolve("pom.xml"), "<project/>");
+        Files.writeString(source, "class Sample {}");
+
+        ProjectModule module = ProjectModuleResolver.resolve(tempDir, source, BuildToolSelection.AUTO);
+
+        assertEquals(moduleRoot, module.moduleRoot());
+        assertEquals(moduleRoot, module.executionRoot());
+        assertEquals(BuildTool.MAVEN, module.buildTool());
+    }
+
+    @Test
+    void resolvesGradleSubmoduleThroughSettingsRoot() throws Exception {
+        Files.writeString(tempDir.resolve("settings.gradle"), "rootProject.name = 'demo'");
+        Files.writeString(tempDir.resolve("gradlew"), "#!/bin/sh");
+        Files.writeString(tempDir.resolve("gradlew.bat"), "@echo off");
+        Path moduleRoot = tempDir.resolve("apps/demo");
+        Path source = moduleRoot.resolve("src/main/java/demo/Sample.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(moduleRoot.resolve("build.gradle.kts"), "plugins { java }");
+        Files.writeString(source, "class Sample {}");
+
+        ProjectModule module = ProjectModuleResolver.resolve(tempDir, source, BuildToolSelection.AUTO);
+
+        assertEquals(moduleRoot, module.moduleRoot());
+        assertEquals(tempDir, module.executionRoot());
+        assertEquals(BuildTool.GRADLE, module.buildTool());
+        assertEquals(List.of(gradleWrapperCommand(), "--no-daemon", "-q", ":apps:demo:test", ":apps:demo:jacocoTestReport"),
+                module.coverageCommand());
+        assertEquals(moduleRoot.resolve("build/reports/jacoco/test/jacocoTestReport.xml"), module.jacocoXmlPath());
+    }
+
+    @Test
+    void ambiguousModuleRequiresExplicitBuildTool() throws Exception {
+        Path moduleRoot = tempDir.resolve("demo");
+        Path source = moduleRoot.resolve("src/main/java/demo/Sample.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(moduleRoot.resolve("pom.xml"), "<project/>");
+        Files.writeString(moduleRoot.resolve("build.gradle"), "plugins { id 'java' }");
+        Files.writeString(source, "class Sample {}");
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> ProjectModuleResolver.resolve(tempDir, source, BuildToolSelection.AUTO));
+
+        assertEquals(
+                "Ambiguous build tool for module " + moduleRoot
+                        + ". Found both Maven and Gradle markers. Use --build-tool maven or --build-tool gradle.",
+                error.getMessage()
+        );
+    }
+
+    @Test
+    void explicitBuildToolResolvesAmbiguousModule() throws Exception {
+        Path moduleRoot = tempDir.resolve("demo");
+        Path source = moduleRoot.resolve("src/main/java/demo/Sample.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(moduleRoot.resolve("pom.xml"), "<project/>");
+        Files.writeString(moduleRoot.resolve("build.gradle"), "plugins { id 'java' }");
+        Files.writeString(source, "class Sample {}");
+
+        ProjectModule module = ProjectModuleResolver.resolve(tempDir, source, BuildToolSelection.GRADLE);
+
+        assertEquals(BuildTool.GRADLE, module.buildTool());
+        assertEquals(moduleRoot, module.moduleRoot());
+    }
+
+    @Test
+    void mismatchedExplicitBuildToolFailsClearly() throws Exception {
+        Path moduleRoot = tempDir.resolve("demo");
+        Path source = moduleRoot.resolve("src/main/java/demo/Sample.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(moduleRoot.resolve("pom.xml"), "<project/>");
+        Files.writeString(source, "class Sample {}");
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> ProjectModuleResolver.resolve(tempDir, source, BuildToolSelection.GRADLE));
+
+        assertEquals("Requested build tool gradle does not match the detected module at " + moduleRoot + ".", error.getMessage());
+    }
+
+    private static String gradleWrapperCommand() {
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
+            return "gradlew.bat";
+        }
+        return "./gradlew";
+    }
+}

--- a/core/src/test/java/media/barney/crap4java/core/SourceFileFinderTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/SourceFileFinderTest.java
@@ -16,17 +16,22 @@ class SourceFileFinderTest {
 
     @Test
     void findsAllJavaFilesUnderSrcOnly() throws Exception {
-        Path src = tempDir.resolve("src/main/java/demo");
-        Files.createDirectories(src);
-        Path inSrc = src.resolve("Sample.java");
-        Files.writeString(inSrc, "class Sample {}\n");
+        Path rootSrc = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(rootSrc);
+        Path inRootSrc = rootSrc.resolve("Sample.java");
+        Files.writeString(inRootSrc, "class Sample {}\n");
+
+        Path nestedModuleSrc = tempDir.resolve("module-a/src/test/java/demo");
+        Files.createDirectories(nestedModuleSrc);
+        Path inNestedSrc = nestedModuleSrc.resolve("NestedSample.java");
+        Files.writeString(inNestedSrc, "class NestedSample {}\n");
 
         Path outOfSrc = tempDir.resolve("other/Elsewhere.java");
         Files.createDirectories(outOfSrc.getParent());
         Files.writeString(outOfSrc, "class Elsewhere {}\n");
 
-        List<Path> files = SourceFileFinder.findAllJavaFilesUnderSrc(tempDir);
+        List<Path> files = SourceFileFinder.findAllJavaFilesUnderSourceRoots(tempDir);
 
-        assertEquals(List.of(inSrc), files);
+        assertEquals(List.of(inNestedSrc, inRootSrc), files);
     }
 }


### PR DESCRIPTION
Closes #2

## Summary
- add a build-tool-aware module model for Maven and Gradle resolution, coverage commands, and JaCoCo report locations
- teach the CLI to support --build-tool <auto|maven|gradle> while keeping the existing no-arg, --changed, explicit file, and directory modes
- extend the core test suite for module resolution, source discovery, changed-file detection, and process timeout handling

## Validation
- mvn -B test
- mvn -pl cli -am -DskipTests package
- java -jar cli/target/crap4java-cli-0.1.0-SNAPSHOT.jar --help

## Residual Risk
- Gradle multi-module execution currently derives task paths from directory structure, which is correct for standard layouts but not for custom project-to-directory mappings.