### PR TITLE
Add the native Maven crap4java plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The current CLI now resolves Maven and Gradle modules natively, including standa
 - `core`: analysis engine, build-tool-neutral CLI orchestration, and Maven/Gradle coverage runner
 - `cli`: executable entrypoint that packages the core as a runnable jar
 - `gradle-plugin`: self-contained Gradle plugin build exposing `media.barney.crap4java`
-- `maven-plugin`: placeholder module for the upcoming Maven integration
+- `maven-plugin`: native Maven plugin exposing the `check` goal
 
 ## Formula
 
@@ -44,6 +44,12 @@ Build and test the Gradle plugin module after packaging the core jar:
 ```bash
 mvn -pl core -am package
 gradle-plugin/gradlew test
+```
+
+Build and test the Maven plugin module, including its invoker integration fixtures:
+
+```bash
+mvn -pl maven-plugin -am verify
 ```
 
 ## Run

--- a/core/src/main/java/media/barney/crap4java/core/Main.java
+++ b/core/src/main/java/media/barney/crap4java/core/Main.java
@@ -20,7 +20,7 @@ public final class Main {
         return run(args, projectRoot, out, err, new CoverageRunner((command, directory) -> 0));
     }
 
-    static int run(String[] args, Path projectRoot, PrintStream out, PrintStream err) throws Exception {
+    public static int run(String[] args, Path projectRoot, PrintStream out, PrintStream err) throws Exception {
         return run(args, projectRoot, out, err, new CoverageRunner(new ProcessCommandExecutor()));
     }
 

--- a/core/src/main/java/media/barney/crap4java/core/ProjectModule.java
+++ b/core/src/main/java/media/barney/crap4java/core/ProjectModule.java
@@ -93,7 +93,7 @@ record ProjectModule(Path moduleRoot, Path executionRoot, BuildTool buildTool) {
         if (!isWindows() && Files.exists(executionRoot.resolve("mvnw"))) {
             return "./mvnw";
         }
-        return "mvn";
+        return isWindows() ? "mvn.cmd" : "mvn";
     }
 
     private String gradleLauncher() {

--- a/core/src/test/java/media/barney/crap4java/core/CoverageRunnerTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/CoverageRunnerTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,7 +37,7 @@ class CoverageRunnerTest {
         assertFalse(Files.exists(jacocoDir));
         assertFalse(Files.exists(exec));
         assertEquals(List.of(
-                "mvn", "-q",
+                mavenCommand(), "-q",
                 "-pl", "module-a", "-am",
                 "org.jacoco:jacoco-maven-plugin:0.8.13:prepare-agent",
                 "test",
@@ -71,5 +72,12 @@ class CoverageRunnerTest {
             directories.add(directory);
             return exitCode;
         }
+    }
+
+    private static String mavenCommand() {
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
+            return "mvn.cmd";
+        }
+        return "mvn";
     }
 }

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -9,7 +9,91 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
+  <packaging>maven-plugin</packaging>
   <artifactId>crap4java-maven-plugin</artifactId>
   <name>crap4java Maven Plugin</name>
-  <description>Placeholder module for the native Maven integration.</description>
+  <description>Native Maven plugin exposing the crap4java check goal.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>media.barney</groupId>
+      <artifactId>crap4java-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>3.9.9</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.9.9</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.1</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.15.1</version>
+        <configuration>
+          <goalPrefix>crap4java</goalPrefix>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.9.1</version>
+        <configuration>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+          <projectsDirectory>src/it</projectsDirectory>
+          <pomIncludes>
+            <pomInclude>*/pom.xml</pomInclude>
+          </pomIncludes>
+          <filterProperties>
+            <project.version>${project.version}</project.version>
+          </filterProperties>
+          <streamLogs>true</streamLogs>
+          <goals>
+            <goal>verify</goal>
+          </goals>
+        </configuration>
+        <executions>
+          <execution>
+            <id>invoker-install</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>install</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>invoker-run</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/maven-plugin/src/it/multi-module/module-a/pom.xml
+++ b/maven-plugin/src/it/multi-module/module-a/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it.demo</groupId>
+    <artifactId>multi-module</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>module-a</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/maven-plugin/src/it/multi-module/module-a/src/main/java/demo/a/ModuleASample.java
+++ b/maven-plugin/src/it/multi-module/module-a/src/main/java/demo/a/ModuleASample.java
@@ -1,0 +1,7 @@
+package demo.a;
+
+public class ModuleASample {
+    public int alpha() {
+        return 1;
+    }
+}

--- a/maven-plugin/src/it/multi-module/module-a/src/test/java/demo/a/ModuleASampleTest.java
+++ b/maven-plugin/src/it/multi-module/module-a/src/test/java/demo/a/ModuleASampleTest.java
@@ -1,0 +1,13 @@
+package demo.a;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModuleASampleTest {
+
+    @Test
+    void alphaReturnsOne() {
+        assertEquals(1, new ModuleASample().alpha());
+    }
+}

--- a/maven-plugin/src/it/multi-module/module-b/pom.xml
+++ b/maven-plugin/src/it/multi-module/module-b/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it.demo</groupId>
+    <artifactId>multi-module</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>module-b</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/maven-plugin/src/it/multi-module/module-b/src/main/java/demo/b/ModuleBSample.java
+++ b/maven-plugin/src/it/multi-module/module-b/src/main/java/demo/b/ModuleBSample.java
@@ -1,0 +1,7 @@
+package demo.b;
+
+public class ModuleBSample {
+    public int beta() {
+        return 2;
+    }
+}

--- a/maven-plugin/src/it/multi-module/module-b/src/test/java/demo/b/ModuleBSampleTest.java
+++ b/maven-plugin/src/it/multi-module/module-b/src/test/java/demo/b/ModuleBSampleTest.java
@@ -1,0 +1,13 @@
+package demo.b;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModuleBSampleTest {
+
+    @Test
+    void betaReturnsTwo() {
+        assertEquals(2, new ModuleBSample().beta());
+    }
+}

--- a/maven-plugin/src/it/multi-module/pom.xml
+++ b/maven-plugin/src/it/multi-module/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>it.demo</groupId>
+  <artifactId>multi-module</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+  <modules>
+    <module>module-a</module>
+    <module>module-b</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>media.barney</groupId>
+        <artifactId>crap4java-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin/src/it/multi-module/verify.bsh
+++ b/maven-plugin/src/it/multi-module/verify.bsh
@@ -1,0 +1,9 @@
+import java.nio.file.Files;
+
+if (!Files.exists(basedir.toPath().resolve("module-a/target/site/jacoco/jacoco.xml"))) {
+    throw new RuntimeException("Missing JaCoCo XML report for module-a");
+}
+if (!Files.exists(basedir.toPath().resolve("module-b/target/site/jacoco/jacoco.xml"))) {
+    throw new RuntimeException("Missing JaCoCo XML report for module-b");
+}
+return true;

--- a/maven-plugin/src/it/single-module/pom.xml
+++ b/maven-plugin/src/it/single-module/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>it.demo</groupId>
+  <artifactId>single-module</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>media.barney</groupId>
+        <artifactId>crap4java-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin/src/it/single-module/src/main/java/demo/Sample.java
+++ b/maven-plugin/src/it/single-module/src/main/java/demo/Sample.java
@@ -1,0 +1,10 @@
+package demo;
+
+public class Sample {
+    public int alpha(boolean value) {
+        if (value) {
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/maven-plugin/src/it/single-module/src/test/java/demo/SampleTest.java
+++ b/maven-plugin/src/it/single-module/src/test/java/demo/SampleTest.java
@@ -1,0 +1,13 @@
+package demo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SampleTest {
+
+    @Test
+    void alphaReturnsOneForTrue() {
+        assertEquals(1, new Sample().alpha(true));
+    }
+}

--- a/maven-plugin/src/it/single-module/verify.bsh
+++ b/maven-plugin/src/it/single-module/verify.bsh
@@ -1,0 +1,6 @@
+import java.nio.file.Files;
+
+if (!Files.exists(basedir.toPath().resolve("target/site/jacoco/jacoco.xml"))) {
+    throw new RuntimeException("Missing JaCoCo XML report for single-module IT");
+}
+return true;

--- a/maven-plugin/src/main/java/media/barney/crap4java/maven/Crap4JavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap4java/maven/Crap4JavaCheckMojo.java
@@ -1,0 +1,72 @@
+package media.barney.crap4java.maven;
+
+import media.barney.crap4java.core.Main;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+@Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, aggregator = true, threadSafe = true)
+public class Crap4JavaCheckMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        Path executionRoot = executionRoot();
+        if (!project.getBasedir().toPath().normalize().equals(executionRoot)) {
+            getLog().debug("Skipping crap4java check for non-root project " + project.getArtifactId());
+            return;
+        }
+        try {
+            int exit = hasExistingCoverageReports()
+                    ? Main.runWithExistingCoverage(new String[0], executionRoot, System.out, System.err)
+                    : Main.run(new String[0], executionRoot, System.out, System.err);
+            if (exit == 2) {
+                throw new MojoFailureException("crap4java threshold exceeded");
+            }
+            if (exit != 0) {
+                throw new MojoExecutionException("crap4java check failed with exit " + exit);
+            }
+        } catch (MojoFailureException | MojoExecutionException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new MojoExecutionException("Failed to execute crap4java", ex);
+        }
+    }
+
+    private boolean hasExistingCoverageReports() {
+        for (MavenProject reactorProject : reactorProjects()) {
+            Path basedir = reactorProject.getBasedir().toPath();
+            if (Files.exists(basedir.resolve("src")) && !Files.exists(basedir.resolve("target/site/jacoco/jacoco.xml"))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private List<MavenProject> reactorProjects() {
+        List<MavenProject> projects = session.getProjects();
+        return projects == null || projects.isEmpty() ? List.of(project) : projects;
+    }
+
+    private Path executionRoot() {
+        java.io.File multiModuleRoot = session.getRequest().getMultiModuleProjectDirectory();
+        if (multiModuleRoot != null) {
+            return multiModuleRoot.toPath().normalize();
+        }
+        return project.getBasedir().toPath().normalize();
+    }
+}


### PR DESCRIPTION
Closes #4

## Summary
- add the media.barney:crap4java-maven-plugin module with a native check mojo
- reuse the shared core from the reactor root, falling back to nested coverage generation only when JaCoCo XML reports are not already present
- cover the plugin with Maven Invoker integration fixtures for single-module and multi-module builds

## Validation
- mvn -pl maven-plugin -am verify

## Residual Risk
- the mojo currently skips inherited child executions by checking the reactor root at runtime; issue #5 should lock that behavior into CI and release docs.