### PR TITLE
#11 Fix Gradle existing-coverage semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,40 +64,40 @@ mvn -B -pl cli -am -DskipTests package
 From the project root you want to analyze:
 
 ```bash
-java -jar cli/target/crap4java-cli-0.1.0.jar
+java -jar cli/target/crap4java-cli-0.1.1.jar
 ```
 
 ## CLI
 
 ```text
 --help                Print usage to stdout
-(no args)             Analyze all Java files under src/
---changed             Analyze changed Java files under src/
+(no args)             Analyze all Java files under src/main/java/
+--changed             Analyze changed Java files under src/main/java/
 --build-tool <tool>   Force `auto`, `maven`, or `gradle`
 <file ...>            Analyze only these files
-<directory ...>       Analyze all Java files under each directory's nested src/ subtrees
+<directory ...>       Analyze all Java files under each directory's nested src/main/java/ subtrees
 ```
 
 Examples:
 
 ```bash
-java -jar cli/target/crap4java-cli-0.1.0.jar --help
-java -jar cli/target/crap4java-cli-0.1.0.jar
-java -jar cli/target/crap4java-cli-0.1.0.jar --changed
-java -jar cli/target/crap4java-cli-0.1.0.jar --build-tool gradle
-java -jar cli/target/crap4java-cli-0.1.0.jar --build-tool maven module-a/src/main/java/demo/Sample.java
-java -jar cli/target/crap4java-cli-0.1.0.jar src/main/java/demo/Sample.java
-java -jar cli/target/crap4java-cli-0.1.0.jar module-a module-b
+java -jar cli/target/crap4java-cli-0.1.1.jar --help
+java -jar cli/target/crap4java-cli-0.1.1.jar
+java -jar cli/target/crap4java-cli-0.1.1.jar --changed
+java -jar cli/target/crap4java-cli-0.1.1.jar --build-tool gradle
+java -jar cli/target/crap4java-cli-0.1.1.jar --build-tool maven module-a/src/main/java/demo/Sample.java
+java -jar cli/target/crap4java-cli-0.1.1.jar src/main/java/demo/Sample.java
+java -jar cli/target/crap4java-cli-0.1.1.jar module-a module-b
 ```
 
 ## GitHub Packages
 
-Release `0.1.0` publishes these coordinates to GitHub Packages:
+Release `0.1.1` publishes these coordinates to GitHub Packages:
 
-- `media.barney:crap4java-core:0.1.0`
-- `media.barney:crap4java-cli:0.1.0`
-- `media.barney:crap4java-maven-plugin:0.1.0`
-- Gradle plugin id `media.barney.crap4java` version `0.1.0`
+- `media.barney:crap4java-core:0.1.1`
+- `media.barney:crap4java-cli:0.1.1`
+- `media.barney:crap4java-maven-plugin:0.1.1`
+- Gradle plugin id `media.barney.crap4java` version `0.1.1`
 
 ### Gradle
 
@@ -127,7 +127,7 @@ Apply the plugin in `build.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("media.barney.crap4java") version "0.1.0"
+    id("media.barney.crap4java") version "0.1.1"
 }
 ```
 
@@ -172,7 +172,7 @@ Add the plugin:
     <plugin>
       <groupId>media.barney</groupId>
       <artifactId>crap4java-maven-plugin</artifactId>
-      <version>0.1.0</version>
+      <version>0.1.1</version>
       <executions>
         <execution>
           <goals>
@@ -193,7 +193,7 @@ mvn verify
 
 ## Release
 
-Tag `v0.1.0` from `main` after the pull request checks are green. The tag-triggered release workflow publishes the Maven artifacts, publishes the Gradle plugin publications, and creates the GitHub release.
+Tag `v0.1.1` from `main` after the pull request checks are green. The tag-triggered release workflow publishes the Maven artifacts, publishes the Gradle plugin publications, and creates the GitHub release.
 
 ## Exit Codes
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap4java-parent</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
   </parent>
 
   <artifactId>crap4java-cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap4java-parent</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
   </parent>
 
   <artifactId>crap4java-core</artifactId>

--- a/core/src/main/java/media/barney/crap4java/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap4java/core/ChangedFileDetector.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 final class ChangedFileDetector {
 
+    private static final Path PRODUCTION_SOURCE_ROOT = Path.of("src", "main", "java");
+
     private ChangedFileDetector() {
     }
 
@@ -75,11 +77,20 @@ final class ChangedFileDetector {
 
     private static boolean isUnderSourceTree(Path projectRoot, Path file) {
         Path normalized = projectRoot.normalize().relativize(file.normalize());
-        for (Path segment : normalized) {
-            if ("src".equals(segment.toString())) {
+        for (int index = 0; index <= normalized.getNameCount() - PRODUCTION_SOURCE_ROOT.getNameCount(); index++) {
+            if (matchesProductionSourceRoot(normalized, index)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static boolean matchesProductionSourceRoot(Path relativePath, int startIndex) {
+        for (int offset = 0; offset < PRODUCTION_SOURCE_ROOT.getNameCount(); offset++) {
+            if (!PRODUCTION_SOURCE_ROOT.getName(offset).toString().equals(relativePath.getName(startIndex + offset).toString())) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/core/src/main/java/media/barney/crap4java/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap4java/core/CliApplication.java
@@ -17,12 +17,18 @@ final class CliApplication {
     private final PrintStream out;
     private final PrintStream err;
     private final CoverageRunner coverageRunner;
+    private final boolean useExistingCoverage;
 
-    CliApplication(Path projectRoot, PrintStream out, PrintStream err, CoverageRunner coverageRunner) {
+    CliApplication(Path projectRoot,
+                   PrintStream out,
+                   PrintStream err,
+                   CoverageRunner coverageRunner,
+                   boolean useExistingCoverage) {
         this.projectRoot = projectRoot;
         this.out = out;
         this.err = err;
         this.coverageRunner = coverageRunner;
+        this.useExistingCoverage = useExistingCoverage;
     }
 
     int execute(String[] args) throws Exception {
@@ -61,7 +67,9 @@ final class CliApplication {
         for (Map.Entry<ProjectModule, List<Path>> entry : groupByModule(filesToAnalyze, buildToolSelection).entrySet()) {
             ProjectModule module = entry.getKey();
             Path jacocoXml = module.jacocoXmlPath();
-            coverageRunner.generateCoverage(module);
+            if (!useExistingCoverage) {
+                coverageRunner.generateCoverage(module);
+            }
             if (!Files.exists(jacocoXml)) {
                 err.println("Warning: JaCoCo XML not found at " + jacocoXml + ". Coverage will be N/A.");
             }

--- a/core/src/main/java/media/barney/crap4java/core/Main.java
+++ b/core/src/main/java/media/barney/crap4java/core/Main.java
@@ -17,11 +17,11 @@ public final class Main {
                                               Path projectRoot,
                                               PrintStream out,
                                               PrintStream err) throws Exception {
-        return run(args, projectRoot, out, err, new CoverageRunner((command, directory) -> 0));
+        return run(args, projectRoot, out, err, new CoverageRunner((command, directory) -> 0), true);
     }
 
     public static int run(String[] args, Path projectRoot, PrintStream out, PrintStream err) throws Exception {
-        return run(args, projectRoot, out, err, new CoverageRunner(new ProcessCommandExecutor()));
+        return run(args, projectRoot, out, err, new CoverageRunner(new ProcessCommandExecutor()), false);
     }
 
     static int run(String[] args,
@@ -29,17 +29,26 @@ public final class Main {
                    PrintStream out,
                    PrintStream err,
                    CoverageRunner coverageRunner) throws Exception {
-        return new CliApplication(projectRoot, out, err, coverageRunner).execute(args);
+        return run(args, projectRoot, out, err, coverageRunner, false);
+    }
+
+    static int run(String[] args,
+                   Path projectRoot,
+                   PrintStream out,
+                   PrintStream err,
+                   CoverageRunner coverageRunner,
+                   boolean useExistingCoverage) throws Exception {
+        return new CliApplication(projectRoot, out, err, coverageRunner, useExistingCoverage).execute(args);
     }
 
     static String usage() {
         return """
                 Usage:
-                  crap4java                                Analyze all Java files under src/
-                  crap4java --changed                      Analyze changed Java files under src/
+                  crap4java                                Analyze all Java files under src/main/java/
+                  crap4java --changed                      Analyze changed Java files under src/main/java/
                   crap4java --build-tool gradle           Force Gradle for all resolved modules
                   crap4java --build-tool maven --changed  Force Maven for changed files
-                  crap4java <path...>                     Analyze files, or for directory args analyze <dir>/**/src/**/*.java
+                  crap4java <path...>                     Analyze files, or for directory args analyze <dir>/**/src/main/java/**/*.java
                   crap4java --help                        Print this help message
                 """;
     }

--- a/core/src/main/java/media/barney/crap4java/core/SourceFileFinder.java
+++ b/core/src/main/java/media/barney/crap4java/core/SourceFileFinder.java
@@ -11,6 +11,8 @@ final class SourceFileFinder {
     private SourceFileFinder() {
     }
 
+    private static final Path PRODUCTION_SOURCE_ROOT = Path.of("src", "main", "java");
+
     static List<Path> findAllJavaFilesUnderSourceRoots(Path projectRoot) throws IOException {
         if (!Files.exists(projectRoot)) {
             return List.of();
@@ -27,11 +29,20 @@ final class SourceFileFinder {
 
     private static boolean isUnderSourceTree(Path projectRoot, Path file) {
         Path normalized = projectRoot.normalize().relativize(file.normalize());
-        for (Path segment : normalized) {
-            if ("src".equals(segment.toString())) {
+        for (int index = 0; index <= normalized.getNameCount() - PRODUCTION_SOURCE_ROOT.getNameCount(); index++) {
+            if (matchesProductionSourceRoot(normalized, index)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static boolean matchesProductionSourceRoot(Path relativePath, int startIndex) {
+        for (int offset = 0; offset < PRODUCTION_SOURCE_ROOT.getNameCount(); offset++) {
+            if (!PRODUCTION_SOURCE_ROOT.getName(offset).toString().equals(relativePath.getName(startIndex + offset).toString())) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/core/src/test/java/media/barney/crap4java/core/ChangedFileDetectorTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/ChangedFileDetectorTest.java
@@ -61,9 +61,11 @@ class ChangedFileDetectorTest {
 
         Path mainSrc = tempDir.resolve("src/main/java/demo");
         Path moduleTestSrc = tempDir.resolve("module-a/src/test/java/demo");
+        Path nestedMainSrc = tempDir.resolve("module-b/src/main/java/demo");
         Path nonSourceTree = tempDir.resolve("test/crap4java");
         Files.createDirectories(mainSrc);
         Files.createDirectories(moduleTestSrc);
+        Files.createDirectories(nestedMainSrc);
         Files.createDirectories(nonSourceTree);
 
         Path tracked = mainSrc.resolve("Tracked.java");
@@ -74,12 +76,14 @@ class ChangedFileDetectorTest {
         Files.writeString(tracked, "class Tracked { int x = 1; }\n");
         Path nested = moduleTestSrc.resolve("NestedChanged.java");
         Files.writeString(nested, "class NestedChanged {}\n");
+        Path nestedMain = nestedMainSrc.resolve("NestedMainChanged.java");
+        Files.writeString(nestedMain, "class NestedMainChanged {}\n");
         Files.writeString(nonSourceTree.resolve("ChangedFileDetectorTest.java"), "class ChangedFileDetectorTest {}\n");
 
         List<Path> changed = ChangedFileDetector.changedJavaFilesUnderSourceRoots(tempDir);
 
         assertEquals(List.of(
-                tempDir.resolve("module-a/src/test/java/demo/NestedChanged.java"),
+                tempDir.resolve("module-b/src/main/java/demo/NestedMainChanged.java"),
                 tempDir.resolve("src/main/java/demo/Tracked.java")
         ), changed);
     }

--- a/core/src/test/java/media/barney/crap4java/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/CliApplicationTest.java
@@ -27,7 +27,7 @@ class CliApplicationTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
 
-        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), NOOP_COVERAGE)
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), NOOP_COVERAGE, false)
                 .execute(new String[]{"--changed", "src/main/java/demo/Sample.java"});
 
         assertEquals(1, exit);
@@ -39,7 +39,7 @@ class CliApplicationTest {
     void returnsZeroWhenNoFilesAreFound() throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(new ByteArrayOutputStream()), NOOP_COVERAGE)
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(new ByteArrayOutputStream()), NOOP_COVERAGE, false)
                 .execute(new String[0]);
 
         assertEquals(0, exit);
@@ -81,7 +81,7 @@ class CliApplicationTest {
             return 0;
         });
 
-        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), coverageRunner)
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), coverageRunner, false)
                 .execute(new String[]{"src/main/java/demo/Sample.java"});
 
         assertEquals(0, exit);
@@ -126,7 +126,7 @@ class CliApplicationTest {
             return 0;
         });
 
-        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), coverageRunner)
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), coverageRunner, false)
                 .execute(new String[]{"tools/mutate4java/src/mutate4java/Sample.java"});
 
         assertEquals(0, exit);
@@ -175,7 +175,7 @@ class CliApplicationTest {
             return 0;
         });
 
-        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), coverageRunner)
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), coverageRunner, false)
                 .execute(new String[]{"apps/demo/src/main/java/demo/Sample.java"});
 
         assertEquals(0, exit);
@@ -216,7 +216,7 @@ class CliApplicationTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
 
-        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), NOOP_COVERAGE)
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), NOOP_COVERAGE, false)
                 .execute(new String[]{"demo/src/main/java/demo/Sample.java"});
 
         assertEquals(1, exit);

--- a/core/src/test/java/media/barney/crap4java/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/MainTest.java
@@ -122,6 +122,52 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageKeepsTheExistingJacocoXml() throws Exception {
+        Files.writeString(tempDir.resolve("settings.gradle"), "rootProject.name = 'workspace'");
+        Files.writeString(tempDir.resolve("build.gradle"), "plugins { id 'java' }");
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int alpha() {
+                        return 1;
+                    }
+                }
+                """);
+        Path jacocoXml = tempDir.resolve("build/reports/jacoco/test/jacocoTestReport.xml");
+        Files.createDirectories(jacocoXml.getParent());
+        Files.writeString(jacocoXml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()I" line="4">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                new String[]{"src/main/java/demo/Sample.java"},
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        assertEquals(0, exit);
+        assertTrue(Files.exists(jacocoXml));
+        assertTrue(out.toString().contains("100.0%"));
+        assertEquals("", err.toString());
+    }
+
+    @Test
     void maxCrapReturnsLargestNonNullScore() {
         List<MethodMetrics> metrics = List.of(
                 new MethodMetrics("alpha", "demo.Sample", 1, null, null),

--- a/core/src/test/java/media/barney/crap4java/core/SourceFileFinderTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/SourceFileFinderTest.java
@@ -15,7 +15,7 @@ class SourceFileFinderTest {
     Path tempDir;
 
     @Test
-    void findsAllJavaFilesUnderSrcOnly() throws Exception {
+    void findsAllJavaFilesUnderProductionSourceRootsOnly() throws Exception {
         Path rootSrc = tempDir.resolve("src/main/java/demo");
         Files.createDirectories(rootSrc);
         Path inRootSrc = rootSrc.resolve("Sample.java");
@@ -26,12 +26,17 @@ class SourceFileFinderTest {
         Path inNestedSrc = nestedModuleSrc.resolve("NestedSample.java");
         Files.writeString(inNestedSrc, "class NestedSample {}\n");
 
+        Path generatedSrc = tempDir.resolve("build/generated/src/demo");
+        Files.createDirectories(generatedSrc);
+        Path generated = generatedSrc.resolve("Generated.java");
+        Files.writeString(generated, "class Generated {}\n");
+
         Path outOfSrc = tempDir.resolve("other/Elsewhere.java");
         Files.createDirectories(outOfSrc.getParent());
         Files.writeString(outOfSrc, "class Elsewhere {}\n");
 
         List<Path> files = SourceFileFinder.findAllJavaFilesUnderSourceRoots(tempDir);
 
-        assertEquals(List.of(inNestedSrc, inRootSrc), files);
+        assertEquals(List.of(inRootSrc), files);
     }
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "media.barney"
-version = "0.1.0"
+version = "0.1.1"
 
 repositories {
     mavenCentral()

--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap4java-parent</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap4java-parent</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
   </parent>
 
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>media.barney</groupId>
   <artifactId>crap4java-parent</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <packaging>pom</packaging>
 
   <name>crap4java Parent</name>


### PR DESCRIPTION
## Summary
- fix `runWithExistingCoverage` so the Gradle path reads the existing JaCoCo XML instead of deleting the report directory first
- narrow default source discovery and `--changed` filtering to `src/main/java`, which restores the intended production-source gate scope for Gradle consumers
- bump the shared release line to `0.1.1` and update the CLI/package docs to match the corrected behavior

## Validation
- `mvn -B -pl cli -am package`
- `gradle-plugin\\gradlew.bat test publishToMavenLocal`
- `mvn -B -pl maven-plugin -am verify`

## Consumer Repro Covered
- `ai-agents` migration no longer needs the repo-local helper once this patch release is consumed
- `runWithExistingCoverage` keeps the existing Gradle JaCoCo XML on disk and no longer sweeps `src/test/java` into the default analysis set

Closes #11