### PR TITLE
Harden stale coverage cleanup

### DIFF
--- a/core/src/main/java/media/barney/crap4java/core/CoverageRunner.java
+++ b/core/src/main/java/media/barney/crap4java/core/CoverageRunner.java
@@ -1,9 +1,11 @@
 package media.barney.crap4java.core;
 
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.util.Comparator;
+import java.nio.file.attribute.BasicFileAttributes;
 
 final class CoverageRunner {
 
@@ -14,8 +16,9 @@ final class CoverageRunner {
     }
 
     void generateCoverage(ProjectModule module) throws Exception {
+        Path moduleRootRealPath = module.moduleRoot().toRealPath();
         for (Path staleCoveragePath : module.staleCoveragePaths()) {
-            deleteIfExists(staleCoveragePath);
+            deleteIfExists(module.moduleRoot(), moduleRootRealPath, staleCoveragePath);
         }
 
         int exit = executor.run(module.coverageCommand(), module.executionRoot());
@@ -24,23 +27,41 @@ final class CoverageRunner {
         }
     }
 
-    private void deleteIfExists(Path path) throws IOException {
-        if (!Files.exists(path)) {
+    private void deleteIfExists(Path moduleRoot, Path moduleRootRealPath, Path path) throws IOException {
+        Path normalizedPath = path.normalize();
+        if (!normalizedPath.startsWith(moduleRoot.normalize())) {
+            throw new IllegalStateException("Refusing to delete stale coverage outside module root: " + normalizedPath);
+        }
+        if (!Files.exists(normalizedPath, LinkOption.NOFOLLOW_LINKS)) {
             return;
         }
-        if (Files.isDirectory(path)) {
-            try (var walk = Files.walk(path)) {
-                walk.sorted(Comparator.reverseOrder())
-                        .forEach(p -> {
-                            try {
-                                Files.deleteIfExists(p);
-                            } catch (IOException ex) {
-                                throw new IllegalStateException("Failed deleting stale coverage: " + p, ex);
-                            }
-                        });
+        deleteRecursively(moduleRootRealPath, normalizedPath);
+    }
+
+    private void deleteRecursively(Path moduleRootRealPath, Path path) throws IOException {
+        BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        if (isLinkLike(attributes)) {
+            Files.deleteIfExists(path);
+            return;
+        }
+
+        Path realPath = path.toRealPath();
+        if (!realPath.startsWith(moduleRootRealPath)) {
+            throw new IllegalStateException("Refusing to delete stale coverage outside module root: " + path);
+        }
+
+        if (attributes.isDirectory()) {
+            try (DirectoryStream<Path> entries = Files.newDirectoryStream(path)) {
+                for (Path entry : entries) {
+                    deleteRecursively(moduleRootRealPath, entry);
+                }
             }
-            return;
         }
+
         Files.deleteIfExists(path);
+    }
+
+    private boolean isLinkLike(BasicFileAttributes attributes) {
+        return attributes.isSymbolicLink() || attributes.isOther();
     }
 }

--- a/core/src/test/java/media/barney/crap4java/core/CoverageRunnerTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/CoverageRunnerTest.java
@@ -3,7 +3,9 @@ package media.barney.crap4java.core;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +14,7 @@ import java.util.Locale;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CoverageRunnerTest {
 
@@ -57,6 +60,48 @@ class CoverageRunnerTest {
         assertEquals("Coverage command failed with exit 2", ex.getMessage());
     }
 
+    @Test
+    void deletesDirectoryLinkWithoutTouchingLinkTarget() throws Exception {
+        Path moduleRoot = tempDir.resolve("module-a");
+        Files.createDirectories(moduleRoot.resolve("build"));
+        Path externalJacoco = tempDir.resolve("external-jacoco");
+        Files.createDirectories(externalJacoco.resolve("nested"));
+        Path sentinel = externalJacoco.resolve("nested/keep.txt");
+        Files.writeString(sentinel, "keep");
+        Path link = moduleRoot.resolve("build/jacoco");
+        createDirectoryLink(link, externalJacoco);
+
+        RecordingExecutor executor = new RecordingExecutor(0);
+        CoverageRunner runner = new CoverageRunner(executor);
+
+        runner.generateCoverage(new ProjectModule(moduleRoot, moduleRoot, BuildTool.GRADLE));
+
+        assertFalse(Files.exists(link, LinkOption.NOFOLLOW_LINKS));
+        assertTrue(Files.exists(sentinel));
+    }
+
+    @Test
+    void rejectsDeletionWhenResolvedPathEscapesModuleRoot() throws Exception {
+        Path moduleRoot = tempDir.resolve("module-a");
+        Files.createDirectories(moduleRoot);
+        Path externalBuild = tempDir.resolve("external-build");
+        Path externalJacoco = externalBuild.resolve("jacoco");
+        Files.createDirectories(externalJacoco);
+        Path sentinel = externalJacoco.resolve("keep.txt");
+        Files.writeString(sentinel, "keep");
+        createDirectoryLink(moduleRoot.resolve("build"), externalBuild);
+
+        RecordingExecutor executor = new RecordingExecutor(0);
+        CoverageRunner runner = new CoverageRunner(executor);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> runner.generateCoverage(new ProjectModule(moduleRoot, moduleRoot, BuildTool.GRADLE)));
+
+        assertEquals("Refusing to delete stale coverage outside module root: " + moduleRoot.resolve("build/jacoco"), ex.getMessage());
+        assertTrue(Files.exists(sentinel));
+        assertTrue(Files.exists(moduleRoot.resolve("build"), LinkOption.NOFOLLOW_LINKS));
+    }
+
     private static final class RecordingExecutor implements CommandExecutor {
         private final int exitCode;
         private final List<List<String>> commands = new ArrayList<>();
@@ -79,5 +124,21 @@ class CoverageRunnerTest {
             return "mvn.cmd";
         }
         return "mvn";
+    }
+
+    private static void createDirectoryLink(Path link, Path target) throws Exception {
+        if (isWindows()) {
+            Process process = new ProcessBuilder("cmd", "/c", "mklink", "/J", link.toString(), target.toString())
+                    .redirectErrorStream(true)
+                    .start();
+            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            assertEquals(0, process.waitFor(), output);
+            return;
+        }
+        Files.createSymbolicLink(link, target);
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows");
     }
 }


### PR DESCRIPTION
## Summary
- stop stale coverage cleanup from traversing symlink and junction targets
- enforce module-root confinement when deleting stale coverage paths
- add regression tests for safe link deletion and escaped ancestor links

## Testing
- mvn -B test