### PR TITLE
Tighten JaCoCo XML parser

### DIFF
--- a/core/src/main/java/media/barney/crap4java/core/JacocoCoverageParser.java
+++ b/core/src/main/java/media/barney/crap4java/core/JacocoCoverageParser.java
@@ -52,7 +52,9 @@ final class JacocoCoverageParser {
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", true);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         factory.setXIncludeAware(false);
         factory.setExpandEntityReferences(false);
         return factory;

--- a/core/src/test/java/media/barney/crap4java/core/JacocoCoverageParserTest.java
+++ b/core/src/test/java/media/barney/crap4java/core/JacocoCoverageParserTest.java
@@ -90,7 +90,9 @@ class JacocoCoverageParserTest {
         assertFalse(factory.getFeature("http://apache.org/xml/features/disallow-doctype-decl"));
         assertFalse(factory.getFeature("http://xml.org/sax/features/external-general-entities"));
         assertFalse(factory.getFeature("http://xml.org/sax/features/external-parameter-entities"));
-        assertTrue(factory.getFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd"));
+        assertFalse(factory.getFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd"));
+        assertEquals("", factory.getAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD));
+        assertEquals("", factory.getAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA));
         assertFalse(factory.isXIncludeAware());
         assertFalse(factory.isExpandEntityReferences());
     }


### PR DESCRIPTION
## Summary
- stop the JaCoCo XML parser from loading external DTD and schema resources
- keep support for JaCoCo reports that include a DOCTYPE declaration
- update parser tests to cover the stricter factory configuration

## Testing
- mvn -B test