### PR TITLE
Release 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mvn -B -pl cli -am -DskipTests package
 From the project root you want to analyze:
 
 ```bash
-java -jar cli/target/crap4java-cli-0.1.1.jar
+java -jar cli/target/crap4java-cli-0.1.2.jar
 ```
 
 ## CLI
@@ -81,23 +81,23 @@ java -jar cli/target/crap4java-cli-0.1.1.jar
 Examples:
 
 ```bash
-java -jar cli/target/crap4java-cli-0.1.1.jar --help
-java -jar cli/target/crap4java-cli-0.1.1.jar
-java -jar cli/target/crap4java-cli-0.1.1.jar --changed
-java -jar cli/target/crap4java-cli-0.1.1.jar --build-tool gradle
-java -jar cli/target/crap4java-cli-0.1.1.jar --build-tool maven module-a/src/main/java/demo/Sample.java
-java -jar cli/target/crap4java-cli-0.1.1.jar src/main/java/demo/Sample.java
-java -jar cli/target/crap4java-cli-0.1.1.jar module-a module-b
+java -jar cli/target/crap4java-cli-0.1.2.jar --help
+java -jar cli/target/crap4java-cli-0.1.2.jar
+java -jar cli/target/crap4java-cli-0.1.2.jar --changed
+java -jar cli/target/crap4java-cli-0.1.2.jar --build-tool gradle
+java -jar cli/target/crap4java-cli-0.1.2.jar --build-tool maven module-a/src/main/java/demo/Sample.java
+java -jar cli/target/crap4java-cli-0.1.2.jar src/main/java/demo/Sample.java
+java -jar cli/target/crap4java-cli-0.1.2.jar module-a module-b
 ```
 
 ## GitHub Packages
 
-Release `0.1.1` publishes these coordinates to GitHub Packages:
+Release `0.1.2` publishes these coordinates to GitHub Packages:
 
-- `media.barney:crap4java-core:0.1.1`
-- `media.barney:crap4java-cli:0.1.1`
-- `media.barney:crap4java-maven-plugin:0.1.1`
-- Gradle plugin id `media.barney.crap4java` version `0.1.1`
+- `media.barney:crap4java-core:0.1.2`
+- `media.barney:crap4java-cli:0.1.2`
+- `media.barney:crap4java-maven-plugin:0.1.2`
+- Gradle plugin id `media.barney.crap4java` version `0.1.2`
 
 ### Gradle
 
@@ -127,7 +127,7 @@ Apply the plugin in `build.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("media.barney.crap4java") version "0.1.1"
+    id("media.barney.crap4java") version "0.1.2"
 }
 ```
 
@@ -172,7 +172,7 @@ Add the plugin:
     <plugin>
       <groupId>media.barney</groupId>
       <artifactId>crap4java-maven-plugin</artifactId>
-      <version>0.1.1</version>
+      <version>0.1.2</version>
       <executions>
         <execution>
           <goals>
@@ -193,7 +193,7 @@ mvn verify
 
 ## Release
 
-Tag `v0.1.1` from `main` after the pull request checks are green. The tag-triggered release workflow publishes the Maven artifacts, publishes the Gradle plugin publications, and creates the GitHub release.
+Tag `v0.1.2` from `main` after the pull request checks are green. The tag-triggered release workflow publishes the Maven artifacts, publishes the Gradle plugin publications, and creates the GitHub release.
 
 ## Exit Codes
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap4java-parent</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
   </parent>
 
   <artifactId>crap4java-cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap4java-parent</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
   </parent>
 
   <artifactId>crap4java-core</artifactId>

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "media.barney"
-version = "0.1.1"
+version = "0.1.2"
 
 repositories {
     mavenCentral()

--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap4java-parent</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap4java-parent</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
   </parent>
 
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>media.barney</groupId>
   <artifactId>crap4java-parent</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <packaging>pom</packaging>
 
   <name>crap4java Parent</name>


### PR DESCRIPTION
## Summary
- bump the published project and plugin version to 0.1.2
- update the Gradle plugin build metadata to the same version
- refresh README examples and release coordinates for 0.1.2

## Testing
- mvn -B test