### PR TITLE
Introduce JSpecify and NullAway checks

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>crap-java-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,6 +15,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/core/src/main/java/media/barney/crapjava/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crapjava/core/ChangedFileDetector.java
@@ -1,9 +1,11 @@
 package media.barney.crapjava.core;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 final class ChangedFileDetector {
 
@@ -17,13 +19,13 @@ final class ChangedFileDetector {
 
         int exit = process.waitFor();
         if (exit != 0) {
-            String output = new String(process.getInputStream().readAllBytes());
+            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
             throw new IllegalStateException("git status failed: " + output);
         }
 
-        String output = new String(process.getInputStream().readAllBytes());
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         List<Path> files = new ArrayList<>();
-        for (String line : output.split("\\R")) {
+        for (String line : output.lines().toList()) {
             Path file = parseStatusLine(projectRoot, line);
             if (file != null) {
                 files.add(file);
@@ -39,7 +41,7 @@ final class ChangedFileDetector {
                 .toList();
     }
 
-    private static Path parseStatusLine(Path root, String line) {
+    private static @Nullable Path parseStatusLine(Path root, String line) {
         if (!isCandidateLine(line)) {
             return null;
         }
@@ -51,7 +53,7 @@ final class ChangedFileDetector {
         return root.resolve(finalPath).normalize();
     }
 
-    static boolean isCandidateLine(String line) {
+    static boolean isCandidateLine(@Nullable String line) {
         if (line == null) {
             return false;
         }

--- a/core/src/main/java/media/barney/crapjava/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crapjava/core/CliApplication.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 final class CliApplication {
 
@@ -36,7 +37,7 @@ final class CliApplication {
         if (parse.exitCode >= 0) {
             return parse.exitCode;
         }
-        CliArguments parsed = parse.arguments;
+        CliArguments parsed = parse.arguments();
         try {
             List<Path> filesToAnalyze = filesForMode(parsed);
             if (filesToAnalyze.isEmpty()) {
@@ -135,10 +136,10 @@ final class CliApplication {
     }
 
     private static final class ParseOutcome {
-        private final CliArguments arguments;
+        private final @Nullable CliArguments arguments;
         private final int exitCode;
 
-        private ParseOutcome(CliArguments arguments, int exitCode) {
+        private ParseOutcome(@Nullable CliArguments arguments, int exitCode) {
             this.arguments = arguments;
             this.exitCode = exitCode;
         }
@@ -149,6 +150,13 @@ final class CliApplication {
 
         private static ParseOutcome exit(int code) {
             return new ParseOutcome(null, code);
+        }
+
+        private CliArguments arguments() {
+            if (arguments == null) {
+                throw new IllegalStateException("No parsed arguments are available");
+            }
+            return arguments;
         }
     }
 }

--- a/core/src/main/java/media/barney/crapjava/core/CrapAnalyzer.java
+++ b/core/src/main/java/media/barney/crapjava/core/CrapAnalyzer.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
 
 final class CrapAnalyzer {
 
@@ -49,10 +50,10 @@ final class CrapAnalyzer {
         return matcher.group(1) + "." + simpleName;
     }
 
-    static Double lookupCoverage(Map<String, CoverageData> coverageMap,
-                                 String className,
-                                 String methodName,
-                                 int line) {
+    static @Nullable Double lookupCoverage(Map<String, CoverageData> coverageMap,
+                                           String className,
+                                           String methodName,
+                                           int line) {
         Double exactCoverage = exactCoverage(coverageMap, className, methodName, line);
         if (exactCoverage != null) {
             return exactCoverage;
@@ -65,10 +66,10 @@ final class CrapAnalyzer {
         return nearest.coveragePercent();
     }
 
-    static Double exactCoverage(Map<String, CoverageData> coverageMap,
-                                String className,
-                                String methodName,
-                                int line) {
+    static @Nullable Double exactCoverage(Map<String, CoverageData> coverageMap,
+                                          String className,
+                                          String methodName,
+                                          int line) {
         String exactKey = className + "#" + methodName + ":" + line;
         CoverageData exact = coverageMap.get(exactKey);
         if (exact == null) {
@@ -77,10 +78,10 @@ final class CrapAnalyzer {
         return exact.coveragePercent();
     }
 
-    static CoverageData nearestCoverage(Map<String, CoverageData> coverageMap,
-                                        String className,
-                                        String methodName,
-                                        int line) {
+    static @Nullable CoverageData nearestCoverage(Map<String, CoverageData> coverageMap,
+                                                  String className,
+                                                  String methodName,
+                                                  int line) {
         String prefix = className + "#" + methodName + ":";
         CoverageData nearest = null;
         int nearestDistance = Integer.MAX_VALUE;

--- a/core/src/main/java/media/barney/crapjava/core/CrapScore.java
+++ b/core/src/main/java/media/barney/crapjava/core/CrapScore.java
@@ -1,11 +1,13 @@
 package media.barney.crapjava.core;
 
+import org.jspecify.annotations.Nullable;
+
 final class CrapScore {
 
     private CrapScore() {
     }
 
-    static Double calculate(int complexity, Double coveragePercent) {
+    static @Nullable Double calculate(int complexity, @Nullable Double coveragePercent) {
         if (coveragePercent == null) {
             return null;
         }

--- a/core/src/main/java/media/barney/crapjava/core/JacocoCoverageParser.java
+++ b/core/src/main/java/media/barney/crapjava/core/JacocoCoverageParser.java
@@ -13,13 +13,14 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.io.StringReader;
+import org.jspecify.annotations.Nullable;
 
 final class JacocoCoverageParser {
 
     private JacocoCoverageParser() {
     }
 
-    static Map<String, CoverageData> parse(Path jacocoXmlPath) {
+    static Map<String, CoverageData> parse(@Nullable Path jacocoXmlPath) {
         if (jacocoXmlPath == null || !Files.exists(jacocoXmlPath)) {
             return Map.of();
         }
@@ -76,7 +77,7 @@ final class JacocoCoverageParser {
         }
     }
 
-    private static CoverageData readInstructionCoverage(Element method) {
+    private static @Nullable CoverageData readInstructionCoverage(Element method) {
         for (Node node = method.getFirstChild(); node != null; node = node.getNextSibling()) {
             if (!(node instanceof Element counter) || !"counter".equals(counter.getTagName())) {
                 continue;

--- a/core/src/main/java/media/barney/crapjava/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crapjava/core/JavaMethodParser.java
@@ -127,49 +127,49 @@ final class JavaMethodParser {
         @Override
         public Void visitIf(IfTree node, Void unused) {
             complexity++;
-            return super.visitIf(node, unused);
+            return super.visitIf(node, null);
         }
 
         @Override
         public Void visitForLoop(ForLoopTree node, Void unused) {
             complexity++;
-            return super.visitForLoop(node, unused);
+            return super.visitForLoop(node, null);
         }
 
         @Override
         public Void visitEnhancedForLoop(EnhancedForLoopTree node, Void unused) {
             complexity++;
-            return super.visitEnhancedForLoop(node, unused);
+            return super.visitEnhancedForLoop(node, null);
         }
 
         @Override
         public Void visitWhileLoop(WhileLoopTree node, Void unused) {
             complexity++;
-            return super.visitWhileLoop(node, unused);
+            return super.visitWhileLoop(node, null);
         }
 
         @Override
         public Void visitDoWhileLoop(DoWhileLoopTree node, Void unused) {
             complexity++;
-            return super.visitDoWhileLoop(node, unused);
+            return super.visitDoWhileLoop(node, null);
         }
 
         @Override
         public Void visitCatch(CatchTree node, Void unused) {
             complexity++;
-            return super.visitCatch(node, unused);
+            return super.visitCatch(node, null);
         }
 
         @Override
         public Void visitConditionalExpression(ConditionalExpressionTree node, Void unused) {
             complexity++;
-            return super.visitConditionalExpression(node, unused);
+            return super.visitConditionalExpression(node, null);
         }
 
         @Override
         public Void visitCase(CaseTree node, Void unused) {
             complexity++;
-            return super.visitCase(node, unused);
+            return super.visitCase(node, null);
         }
 
         @Override
@@ -177,7 +177,7 @@ final class JavaMethodParser {
             if (node.getKind() == Tree.Kind.CONDITIONAL_AND || node.getKind() == Tree.Kind.CONDITIONAL_OR) {
                 complexity++;
             }
-            return super.visitBinary(node, unused);
+            return super.visitBinary(node, null);
         }
     }
 

--- a/core/src/main/java/media/barney/crapjava/core/MethodMetrics.java
+++ b/core/src/main/java/media/barney/crapjava/core/MethodMetrics.java
@@ -1,11 +1,13 @@
 package media.barney.crapjava.core;
 
+import org.jspecify.annotations.Nullable;
+
 record MethodMetrics(
         String methodName,
         String className,
         int complexity,
-        Double coveragePercent,
-        Double crapScore
+        @Nullable Double coveragePercent,
+        @Nullable Double crapScore
 ) {
 }
 

--- a/core/src/main/java/media/barney/crapjava/core/ProjectModule.java
+++ b/core/src/main/java/media/barney/crapjava/core/ProjectModule.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 record ProjectModule(Path moduleRoot, Path executionRoot, BuildTool buildTool) {
 
@@ -107,6 +108,6 @@ record ProjectModule(Path moduleRoot, Path executionRoot, BuildTool buildTool) {
     }
 
     private static boolean isWindows() {
-        return System.getProperty("os.name").toLowerCase().startsWith("windows");
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows");
     }
 }

--- a/core/src/main/java/media/barney/crapjava/core/ProjectModuleResolver.java
+++ b/core/src/main/java/media/barney/crapjava/core/ProjectModuleResolver.java
@@ -3,6 +3,8 @@ package media.barney.crapjava.core;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumSet;
+import java.util.Locale;
+import org.jspecify.annotations.Nullable;
 
 final class ProjectModuleResolver {
 
@@ -41,7 +43,7 @@ final class ProjectModuleResolver {
             return requested;
         }
         throw new IllegalArgumentException(
-                "Requested build tool " + selection.name().toLowerCase()
+                "Requested build tool " + selection.name().toLowerCase(Locale.ROOT)
                         + " does not match the detected module at " + moduleRoot + "."
         );
     }
@@ -73,7 +75,7 @@ final class ProjectModuleResolver {
         return match != null ? match : start.normalize();
     }
 
-    private static Path topmostAncestorOrNull(Path workspaceRoot, Path start, DirectoryPredicate predicate) {
+    private static @Nullable Path topmostAncestorOrNull(Path workspaceRoot, Path start, DirectoryPredicate predicate) {
         Path normalizedWorkspaceRoot = workspaceRoot.normalize();
         Path current = start.normalize();
         Path match = null;

--- a/core/src/main/java/media/barney/crapjava/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crapjava/core/ReportFormatter.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import org.jspecify.annotations.Nullable;
 
 final class ReportFormatter {
 
@@ -37,14 +38,14 @@ final class ReportFormatter {
         return builder.toString();
     }
 
-    private static String formatCoverage(Double coverage) {
+    private static String formatCoverage(@Nullable Double coverage) {
         if (coverage == null) {
             return "  N/A ";
         }
         return String.format(Locale.ROOT, "%5.1f%%", coverage);
     }
 
-    private static String formatCrap(Double score) {
+    private static String formatCrap(@Nullable Double score) {
         if (score == null) {
             return "     N/A";
         }

--- a/core/src/test/java/media/barney/crapjava/core/ChangedFileDetectorTest.java
+++ b/core/src/test/java/media/barney/crapjava/core/ChangedFileDetectorTest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -50,7 +51,7 @@ class ChangedFileDetectorTest {
         IllegalStateException error = assertThrows(IllegalStateException.class,
                 () -> ChangedFileDetector.changedJavaFiles(tempDir));
 
-        assertTrue(error.getMessage().contains("not a git repository"));
+        assertTrue(Objects.requireNonNull(error.getMessage()).contains("not a git repository"));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crapjava/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crapjava/core/CliApplicationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -31,8 +32,8 @@ class CliApplicationTest {
                 .execute(new String[]{"--changed", "src/main/java/demo/Sample.java"});
 
         assertEquals(1, exit);
-        assertTrue(out.toString().contains("Usage:"));
-        assertTrue(err.toString().contains("--changed cannot be combined with file arguments"));
+        assertTrue(utf8(out).contains("Usage:"));
+        assertTrue(utf8(err).contains("--changed cannot be combined with file arguments"));
     }
 
     @Test
@@ -43,7 +44,7 @@ class CliApplicationTest {
                 .execute(new String[0]);
 
         assertEquals(0, exit);
-        assertTrue(out.toString().contains("No Java files to analyze."));
+        assertTrue(utf8(out).contains("No Java files to analyze."));
     }
 
     @Test
@@ -85,8 +86,8 @@ class CliApplicationTest {
                 .execute(new String[]{"src/main/java/demo/Sample.java"});
 
         assertEquals(0, exit);
-        assertTrue(out.toString().contains("Sample"));
-        assertFalse(err.toString().contains("Warning: JaCoCo XML not found"));
+        assertTrue(utf8(out).contains("Sample"));
+        assertFalse(utf8(err).contains("Warning: JaCoCo XML not found"));
     }
 
     @Test
@@ -131,8 +132,8 @@ class CliApplicationTest {
 
         assertEquals(0, exit);
         assertEquals(List.of(moduleRoot), directories);
-        assertTrue(out.toString().contains("mutate4java.Sample"));
-        assertFalse(err.toString().contains("Warning: JaCoCo XML not found"));
+        assertTrue(utf8(out).contains("mutate4java.Sample"));
+        assertFalse(utf8(err).contains("Warning: JaCoCo XML not found"));
     }
 
     @Test
@@ -181,8 +182,8 @@ class CliApplicationTest {
         assertEquals(0, exit);
         assertEquals(List.of(tempDir), directories);
         assertEquals(List.of(List.of("gradle", "--no-daemon", "-q", ":apps:demo:test", ":apps:demo:jacocoTestReport")), commands);
-        assertTrue(out.toString().contains("demo.Sample"));
-        assertFalse(err.toString().contains("Warning: JaCoCo XML not found"));
+        assertTrue(utf8(out).contains("demo.Sample"));
+        assertFalse(utf8(err).contains("Warning: JaCoCo XML not found"));
     }
 
     @Test
@@ -220,7 +221,11 @@ class CliApplicationTest {
                 .execute(new String[]{"demo/src/main/java/demo/Sample.java"});
 
         assertEquals(1, exit);
-        assertEquals("", out.toString());
-        assertTrue(err.toString().contains("Ambiguous build tool for module"));
+        assertEquals("", utf8(out));
+        assertTrue(utf8(err).contains("Ambiguous build tool for module"));
+    }
+
+    private static String utf8(ByteArrayOutputStream output) {
+        return output.toString(StandardCharsets.UTF_8);
     }
 }

--- a/core/src/test/java/media/barney/crapjava/core/CrapAnalyzerTest.java
+++ b/core/src/test/java/media/barney/crapjava/core/CrapAnalyzerTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -59,8 +60,8 @@ class CrapAnalyzerTest {
         assertEquals("alpha", metric.methodName());
         assertEquals("demo.Sample", metric.className());
         assertEquals(2, metric.complexity());
-        assertEquals(75.0, metric.coveragePercent(), 0.001);
-        assertEquals(2.0625, metric.crapScore(), 0.00001);
+        assertEquals(75.0, Objects.requireNonNull(metric.coveragePercent()), 0.001);
+        assertEquals(2.0625, Objects.requireNonNull(metric.crapScore()), 0.00001);
     }
 
     @Test
@@ -85,7 +86,7 @@ class CrapAnalyzerTest {
 
         Double coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 10);
 
-        assertEquals(75.0, coverage, 0.001);
+        assertEquals(75.0, Objects.requireNonNull(coverage), 0.001);
     }
 
     @Test
@@ -97,7 +98,7 @@ class CrapAnalyzerTest {
 
         Double coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 13);
 
-        assertEquals(100.0, coverage, 0.001);
+        assertEquals(100.0, Objects.requireNonNull(coverage), 0.001);
     }
 
     @Test
@@ -106,7 +107,7 @@ class CrapAnalyzerTest {
         coverageMap.put("demo.Sample#alpha:10", new CoverageData(1, 3));
         coverageMap.put("demo.Sample#alpha:14", new CoverageData(0, 8));
 
-        CoverageData nearest = CrapAnalyzer.nearestCoverage(coverageMap, "demo.Sample", "alpha", 12);
+        CoverageData nearest = Objects.requireNonNull(CrapAnalyzer.nearestCoverage(coverageMap, "demo.Sample", "alpha", 12));
 
         assertEquals(75.0, nearest.coveragePercent(), 0.001);
     }

--- a/core/src/test/java/media/barney/crapjava/core/CrapScoreTest.java
+++ b/core/src/test/java/media/barney/crapjava/core/CrapScoreTest.java
@@ -2,6 +2,8 @@ package media.barney.crapjava.core;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Objects;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -9,17 +11,17 @@ class CrapScoreTest {
 
     @Test
     void returnsComplexityWhenFullyCovered() {
-        assertEquals(5.0, CrapScore.calculate(5, 100.0), 0.0001);
+        assertEquals(5.0, Objects.requireNonNull(CrapScore.calculate(5, 100.0)), 0.0001);
     }
 
     @Test
     void returnsCcSquaredPlusCcWhenUncovered() {
-        assertEquals(30.0, CrapScore.calculate(5, 0.0), 0.0001);
+        assertEquals(30.0, Objects.requireNonNull(CrapScore.calculate(5, 0.0)), 0.0001);
     }
 
     @Test
     void computesPartialCoverage() {
-        assertEquals(18.648, CrapScore.calculate(8, 45.0), 0.01);
+        assertEquals(18.648, Objects.requireNonNull(CrapScore.calculate(8, 45.0)), 0.01);
     }
 
     @Test

--- a/core/src/test/java/media/barney/crapjava/core/JacocoCoverageParserTest.java
+++ b/core/src/test/java/media/barney/crapjava/core/JacocoCoverageParserTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,8 +38,8 @@ class JacocoCoverageParserTest {
 
         Map<String, CoverageData> result = JacocoCoverageParser.parse(xml);
 
-        assertEquals(90.0, result.get("demo.Sample#alpha:10").coveragePercent(), 0.001);
-        assertEquals(0.0, result.get("demo.Sample#beta:20").coveragePercent(), 0.001);
+        assertEquals(90.0, Objects.requireNonNull(result.get("demo.Sample#alpha:10")).coveragePercent(), 0.001);
+        assertEquals(0.0, Objects.requireNonNull(result.get("demo.Sample#beta:20")).coveragePercent(), 0.001);
     }
 
     @Test
@@ -59,7 +60,7 @@ class JacocoCoverageParserTest {
 
         Map<String, CoverageData> result = JacocoCoverageParser.parse(xml);
 
-        assertEquals(90.0, result.get("demo.Sample#alpha:10").coveragePercent(), 0.001);
+        assertEquals(90.0, Objects.requireNonNull(result.get("demo.Sample#alpha:10")).coveragePercent(), 0.001);
     }
 
     @Test
@@ -79,7 +80,7 @@ class JacocoCoverageParserTest {
 
         Map<String, CoverageData> result = JacocoCoverageParser.parse(xml);
 
-        assertEquals(90.0, result.get("demo.Sample#alpha:0").coveragePercent(), 0.001);
+        assertEquals(90.0, Objects.requireNonNull(result.get("demo.Sample#alpha:0")).coveragePercent(), 0.001);
     }
 
     @Test

--- a/core/src/test/java/media/barney/crapjava/core/MainTest.java
+++ b/core/src/test/java/media/barney/crapjava/core/MainTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -28,8 +29,8 @@ class MainTest {
         int exit = Main.run(new String[]{"--help"}, tempDir, new PrintStream(out), new PrintStream(err), NOOP_COVERAGE);
 
         assertEquals(0, exit);
-        assertTrue(out.toString().contains("Usage:"));
-        assertTrue(out.toString().contains("--build-tool"));
+        assertTrue(utf8(out).contains("Usage:"));
+        assertTrue(utf8(out).contains("--build-tool"));
     }
 
     @Test
@@ -89,8 +90,8 @@ class MainTest {
         );
 
         assertEquals(0, exit);
-        assertTrue(out.toString().contains("Sample"));
-        assertTrue(out.toString().contains("alpha"));
+        assertTrue(utf8(out).contains("Sample"));
+        assertTrue(utf8(out).contains("alpha"));
     }
 
     @Test
@@ -117,8 +118,8 @@ class MainTest {
         int exit = Main.run(new String[]{"module-a"}, tempDir, new PrintStream(out), new PrintStream(err), NOOP_COVERAGE);
 
         assertEquals(0, exit);
-        assertTrue(out.toString().contains("Sample"));
-        assertTrue(out.toString().contains("alpha"));
+        assertTrue(utf8(out).contains("Sample"));
+        assertTrue(utf8(out).contains("alpha"));
     }
 
     @Test
@@ -163,8 +164,8 @@ class MainTest {
 
         assertEquals(0, exit);
         assertTrue(Files.exists(jacocoXml));
-        assertTrue(out.toString().contains("100.0%"));
-        assertEquals("", err.toString());
+        assertTrue(utf8(out).contains("100.0%"));
+        assertEquals("", utf8(err));
     }
 
     @Test
@@ -176,5 +177,9 @@ class MainTest {
         );
 
         assertEquals(7.0, Main.maxCrap(metrics));
+    }
+
+    private static String utf8(ByteArrayOutputStream output) {
+        return output.toString(StandardCharsets.UTF_8);
     }
 }

--- a/core/src/test/java/media/barney/crapjava/core/ProcessCommandExecutorTest.java
+++ b/core/src/test/java/media/barney/crapjava/core/ProcessCommandExecutorTest.java
@@ -5,8 +5,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Locale;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,9 +32,10 @@ class ProcessCommandExecutorTest {
         IllegalStateException error = assertThrows(IllegalStateException.class,
                 () -> executor.run(sleepCommand(), tempDir));
 
-        assertTrue(error.getMessage().contains("Command timed out"));
-        assertTrue(error.getMessage().contains(Duration.ofMillis(100).toString()));
-        assertTrue(error.getMessage().contains(String.join(" ", sleepCommand())));
+        String message = Objects.requireNonNull(error.getMessage());
+        assertTrue(message.contains("Command timed out"));
+        assertTrue(message.contains(Duration.ofMillis(100).toString()));
+        assertTrue(message.contains(String.join(" ", sleepCommand())));
     }
 
     private static List<String> exitCommand(int exitCode) {

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -21,6 +21,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>3.9.9</version>

--- a/maven-plugin/src/main/java/media/barney/crapjava/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crapjava/maven/CrapJavaCheckMojo.java
@@ -9,23 +9,26 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.jspecify.annotations.Nullable;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, aggregator = true, threadSafe = true)
 public class CrapJavaCheckMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${session}", readonly = true, required = true)
-    private MavenSession session;
+    private @Nullable MavenSession session;
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
-    private MavenProject project;
+    private @Nullable MavenProject project;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         Path executionRoot = executionRoot();
+        MavenProject project = project();
         if (!project.getBasedir().toPath().normalize().equals(executionRoot)) {
             getLog().debug("Skipping crap-java check for non-root project " + project.getArtifactId());
             return;
@@ -58,15 +61,23 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     }
 
     private List<MavenProject> reactorProjects() {
-        List<MavenProject> projects = session.getProjects();
-        return projects == null || projects.isEmpty() ? List.of(project) : projects;
+        List<MavenProject> projects = session().getProjects();
+        return projects == null || projects.isEmpty() ? List.of(project()) : projects;
     }
 
     private Path executionRoot() {
-        java.io.File multiModuleRoot = session.getRequest().getMultiModuleProjectDirectory();
+        java.io.File multiModuleRoot = session().getRequest().getMultiModuleProjectDirectory();
         if (multiModuleRoot != null) {
             return multiModuleRoot.toPath().normalize();
         }
-        return project.getBasedir().toPath().normalize();
+        return project().getBasedir().toPath().normalize();
+    }
+
+    private MavenSession session() {
+        return Objects.requireNonNull(session, "Maven session must be injected");
+    }
+
+    private MavenProject project() {
+        return Objects.requireNonNull(project, "Maven project must be injected");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,9 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>5.10.2</junit.version>
+    <jspecify.version>1.0.0</jspecify.version>
+    <errorprone.version>2.48.0</errorprone.version>
+    <nullaway.version>0.13.1</nullaway.version>
   </properties>
 
   <dependencyManagement>
@@ -33,6 +36,12 @@
         <version>${junit.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>${jspecify.version}</version>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -84,4 +93,53 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>nullaway</id>
+      <activation>
+        <jdk>[25,26)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <!-- Error Prone/NullAway on JDK 25 need javac internals opened/exported. -->
+              <compilerArgs>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>--should-stop=ifError=FLOW</arg>
+                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                <arg>-Xplugin:ErrorProne -Xep:NullAway:ERROR -XepOpt:NullAway:AnnotatedPackages=media.barney.crapjava</arg>
+              </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${errorprone.version}</version>
+                </path>
+                <path>
+                  <groupId>com.uber.nullaway</groupId>
+                  <artifactId>nullaway</artifactId>
+                  <version>${nullaway.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## Summary
- add JSpecify as a provided dependency to the Maven-built code modules
- mirror the 	rading-bot-os JDK-25-gated Error Prone and NullAway compiler profile in the parent POM
- annotate and refactor nullable paths so the stricter compiler run passes cleanly in main code, tests, and the Maven plugin
## Verification
- mvn -B verify
- gradle-plugin\\gradlew.bat test
Closes #20