### PR TITLE
#23 Exercise JDK 25 NullAway profile in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,24 @@ jobs:
       - name: Run Maven plugin integration tests
         run: mvn -B -pl maven-plugin -am verify
 
+  nullaway-jdk25:
+    name: NullAway JDK 25
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Verify Maven build with NullAway profile
+        run: mvn -B verify
+
   crap-java-gate:
     name: crap-java Gate
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a dedicated JDK 25 Maven CI job so the JDK-25-gated `nullaway` profile is exercised on every PR and push to `main`
- keep the existing JDK 17 CI jobs unchanged
- intentionally leave `pom.xml` untouched because the unresolved combined-`<arg>` comment from PR #21 did not reproduce as a real issue

## Testing
- `mvn -B verify`

Closes #23