### PR TITLE
Publish Gradle plugin to Maven Central and prepare v0.3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,11 @@ jobs:
           %commit
           EOF
           gpg --batch --pinentry-mode loopback --generate-key gpg-batch.txt
+          {
+            echo "MAVEN_GPG_PRIVATE_KEY<<EOF"
+            gpg --batch --pinentry-mode loopback --passphrase "${MAVEN_GPG_PASSPHRASE}" --armor --export-secret-keys preflight@example.com
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Run Maven publishing preflight
         run: mvn -B -Prelease -Dcentral.skipPublishing=true -pl .,cli,maven-plugin -am deploy
@@ -180,7 +185,7 @@ jobs:
 
       - name: Validate Gradle plugin publication metadata
         working-directory: gradle-plugin
-        run: ./gradlew test validatePlugins
+        run: ./gradlew test validatePlugins publishToMavenLocal
 
       - name: Verify GitHub Packages references are gone
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,26 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: mvn -B -Prelease -pl .,cli,maven-plugin -am deploy
 
+      - name: Publish Gradle plugin artifacts to Maven Central
+        env:
+          MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        working-directory: gradle-plugin
+        run: ./gradlew publishAllPublicationsToCentralPortalOssrhStagingRepository
+
+      - name: Finalize Gradle plugin Maven Central deployment
+        env:
+          MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+        shell: bash
+        run: |
+          auth="$(printf '%s:%s' "${MAVEN_CENTRAL_TOKEN_USERNAME}" "${MAVEN_CENTRAL_TOKEN_PASSWORD}" | base64 -w 0)"
+          curl --fail --request POST \
+            --header "Authorization: Bearer ${auth}" \
+            "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/media.barney?publishing_type=automatic"
+
       - name: Publish Gradle plugin
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.2 - 2026-04-05
+
+### Added
+
+- Published the Gradle plugin implementation artifact to Maven Central as a secondary channel.
+- Published the Gradle plugin marker artifact to Maven Central so Gradle builds can resolve `media.barney.crap-java` via `pluginManagement.repositories`.
+
+### Changed
+
+- Updated the release workflow to upload the Gradle plugin Maven publications through Sonatype's OSSRH compatibility endpoint and finalize the deployment automatically.
+- Expanded publishing preflight to build and sign the Gradle plugin's Maven publications locally.
+- Documented the Maven Central plugin-consumption path in the README for use before Plugin Portal approval completes.
+
 ## 0.3.1 - 2026-04-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mvn -B -pl cli -am -DskipTests package
 From the project root you want to analyze:
 
 ```bash
-java -jar cli/target/crap-java-cli-0.3.1.jar
+java -jar cli/target/crap-java-cli-0.3.2.jar
 ```
 
 ## CLI
@@ -81,18 +81,18 @@ java -jar cli/target/crap-java-cli-0.3.1.jar
 Examples:
 
 ```bash
-java -jar cli/target/crap-java-cli-0.3.1.jar --help
-java -jar cli/target/crap-java-cli-0.3.1.jar
-java -jar cli/target/crap-java-cli-0.3.1.jar --changed
-java -jar cli/target/crap-java-cli-0.3.1.jar --build-tool gradle
-java -jar cli/target/crap-java-cli-0.3.1.jar --build-tool maven module-a/src/main/java/demo/Sample.java
-java -jar cli/target/crap-java-cli-0.3.1.jar src/main/java/demo/Sample.java
-java -jar cli/target/crap-java-cli-0.3.1.jar module-a module-b
+java -jar cli/target/crap-java-cli-0.3.2.jar --help
+java -jar cli/target/crap-java-cli-0.3.2.jar
+java -jar cli/target/crap-java-cli-0.3.2.jar --changed
+java -jar cli/target/crap-java-cli-0.3.2.jar --build-tool gradle
+java -jar cli/target/crap-java-cli-0.3.2.jar --build-tool maven module-a/src/main/java/demo/Sample.java
+java -jar cli/target/crap-java-cli-0.3.2.jar src/main/java/demo/Sample.java
+java -jar cli/target/crap-java-cli-0.3.2.jar module-a module-b
 ```
 
 ## Distribution
 
-Public releases are intended to ship through Maven Central and the Gradle Plugin Portal:
+Public releases ship through Maven Central, with the Gradle Plugin Portal as the primary Gradle plugin channel once approved:
 
 - `media.barney:crap-java-core:<version>`
 - `media.barney:crap-java-cli:<version>`
@@ -116,6 +116,29 @@ Run:
 ```bash
 ./gradlew crap-java-check
 ```
+
+### Maven Central Gradle Plugin
+
+If you want to resolve the Gradle plugin from Maven Central instead of waiting for Plugin Portal availability, add Maven Central to plugin resolution in `settings.gradle(.kts)`:
+
+```kotlin
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+```
+
+Then apply the same plugin id in `build.gradle(.kts)`:
+
+```kotlin
+plugins {
+    id("media.barney.crap-java") version "<version>"
+}
+```
+
+The marker publication lives at `media.barney.crap-java:media.barney.crap-java.gradle.plugin:<version>` and resolves to the implementation artifact `media.barney:crap-java-gradle-plugin:<version>`.
 
 ### Maven Central
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>crap-java-cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
   </parent>
 
   <artifactId>crap-java-core</artifactId>

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "media.barney"
-version = "0.3.1"
+version = "0.3.2"
 
 repositories {
     mavenCentral()
@@ -27,6 +27,10 @@ val projectVersion = version.toString()
 val coreJar = layout.projectDirectory.file("../core/target/crap-java-core-${projectVersion}.jar")
 val gpgPrivateKey = providers.environmentVariable("MAVEN_GPG_PRIVATE_KEY")
 val gpgPassphrase = providers.environmentVariable("MAVEN_GPG_PASSPHRASE")
+val mavenCentralTokenUsername = providers.gradleProperty("mavenCentralTokenUsername")
+    .orElse(providers.environmentVariable("MAVEN_CENTRAL_TOKEN_USERNAME"))
+val mavenCentralTokenPassword = providers.gradleProperty("mavenCentralTokenPassword")
+    .orElse(providers.environmentVariable("MAVEN_CENTRAL_TOKEN_PASSWORD"))
 
 val verifyCoreJar = tasks.register("verifyCoreJar") {
     doLast {
@@ -99,6 +103,18 @@ publishing {
                 connection.set("scm:git:https://github.com/fabian-barney/crap-java.git")
                 developerConnection.set("scm:git:ssh://git@github.com/fabian-barney/crap-java.git")
                 url.set("https://github.com/fabian-barney/crap-java")
+            }
+        }
+    }
+    if (mavenCentralTokenUsername.isPresent && mavenCentralTokenPassword.isPresent) {
+        repositories {
+            maven {
+                name = "centralPortalOssrhStaging"
+                url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
+                credentials {
+                    username = mavenCentralTokenUsername.get()
+                    password = mavenCentralTokenPassword.get()
+                }
             }
         }
     }

--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
   </parent>
 
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>media.barney</groupId>
   <artifactId>crap-java-parent</artifactId>
-  <version>0.3.1</version>
+  <version>0.3.2</version>
   <packaging>pom</packaging>
 
   <name>crap-java Parent</name>


### PR DESCRIPTION
﻿## Summary

- publish the Gradle plugin marker and implementation artifacts to Maven Central as a secondary channel
- finalize the Sonatype OSSRH compatibility upload in the release workflow
- prepare the `0.3.2` patch release

## Testing

- `mvn -B -pl cli -am package`
- `mvn -B -pl maven-plugin -am verify`
- `cmd /c "mvn -s C:\workspaces\crap-java\target\central-settings.xml -B -Prelease -Dcentral.skipPublishing=true -pl .,cli,maven-plugin -am deploy"`
- `cd gradle-plugin && .\gradlew.bat test validatePlugins publishToMavenLocal`
- `cd gradle-plugin && .\gradlew.bat -m publishAllPublicationsToCentralPortalOssrhStagingRepository`
