### PR TITLE
Support Gradle configuration cache

### DIFF
--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -1,7 +1,9 @@
 package media.barney.crap.core;
 
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 public final class Main {
@@ -18,6 +20,12 @@ public final class Main {
                                               PrintStream out,
                                               PrintStream err) throws Exception {
         return run(args, projectRoot, out, err, new CoverageRunner((command, directory) -> 0), CoverageMode.USE_EXISTING);
+    }
+
+    public static int runWithExistingCoverage(List<ResolvedCoverageModule> modules,
+                                              PrintStream out,
+                                              PrintStream err) throws Exception {
+        return runResolvedModules(modules, out, err);
     }
 
     public static int run(String[] args, Path projectRoot, PrintStream out, PrintStream err) throws Exception {
@@ -41,6 +49,34 @@ public final class Main {
         return new CliApplication(projectRoot, out, err, coverageRunner, coverageMode).execute(args);
     }
 
+    private static int runResolvedModules(List<ResolvedCoverageModule> modules,
+                                          PrintStream out,
+                                          PrintStream err) throws Exception {
+        List<MethodMetrics> metrics = new ArrayList<>();
+        for (ResolvedCoverageModule module : modules) {
+            if (module.sourceFiles().isEmpty()) {
+                continue;
+            }
+            if (!Files.exists(module.coverageReport())) {
+                err.println("Warning: JaCoCo XML not found at " + module.coverageReport() + ". Coverage will be N/A.");
+            }
+            metrics.addAll(CrapAnalyzer.analyze(module.moduleRoot(), module.sourceFiles(), module.coverageReport()));
+        }
+        if (metrics.isEmpty()) {
+            out.println("No Java files to analyze.");
+            return 0;
+        }
+
+        out.print(ReportFormatter.format(metrics));
+
+        double max = Main.maxCrap(metrics);
+        if (CliApplication.thresholdExceeded(max)) {
+            err.printf("CRAP threshold exceeded: %.1f > 8.0%n", max);
+            return 2;
+        }
+        return 0;
+    }
+
     static String usage() {
         return """
                 Usage:
@@ -61,6 +97,18 @@ public final class Main {
             }
         }
         return max;
+    }
+
+    public record ResolvedCoverageModule(Path moduleRoot, Path coverageReport, List<Path> sourceFiles) {
+
+        public ResolvedCoverageModule {
+            moduleRoot = moduleRoot.toAbsolutePath().normalize();
+            coverageReport = coverageReport.toAbsolutePath().normalize();
+            sourceFiles = sourceFiles.stream()
+                    .map(path -> path.toAbsolutePath().normalize())
+                    .sorted()
+                    .toList();
+        }
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -169,6 +169,48 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageAnalyzesPreResolvedModules() throws Exception {
+        Path moduleRoot = tempDir.resolve("app");
+        Path source = moduleRoot.resolve("src/main/java/demo/Sample.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int alpha() {
+                        return 1;
+                    }
+                }
+                """);
+        Path jacocoXml = moduleRoot.resolve("build/reports/jacoco/test/jacocoTestReport.xml");
+        Files.createDirectories(jacocoXml.getParent());
+        Files.writeString(jacocoXml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()I" line="4">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(moduleRoot, jacocoXml, List.of(source))),
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        assertEquals(0, exit);
+        assertTrue(utf8(out).contains("100.0%"));
+        assertEquals("", utf8(err));
+    }
+
+    @Test
     void maxCrapReturnsLargestNonNullScore() {
         List<MethodMetrics> metrics = List.of(
                 new MethodMetrics("alpha", "demo.Sample", 1, null, null),

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -140,7 +140,7 @@ gradlePlugin {
             tags.set(listOf("java", "jacoco", "quality", "metrics", "verification"))
             compatibility {
                 features {
-                    configurationCache = false
+                    configurationCache = true
                 }
             }
         }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -5,6 +5,8 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -12,8 +14,12 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public abstract class CrapJavaCheckTask extends DefaultTask {
 
@@ -29,33 +35,95 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     @PathSensitive(PathSensitivity.RELATIVE)
     public abstract ConfigurableFileCollection getCoverageReports();
 
-    @InputFiles
-    @Optional
-    @PathSensitive(PathSensitivity.RELATIVE)
-    public abstract ConfigurableFileCollection getAnalysisMetadata();
+    @Input
+    public abstract MapProperty<String, String> getModuleCoverageReports();
 
     @TaskAction
     void runCheck() throws Exception {
-        List<String> arguments = getAnalysisSources().getFiles().stream()
-                .map(file -> getAnalysisRoot().get().getAsFile().toPath().relativize(file.toPath()).toString())
-                .sorted(Comparator.naturalOrder())
+        List<Path> sourceFiles = getAnalysisSources().getFiles().stream()
+                .map(file -> file.toPath().toAbsolutePath().normalize())
+                .sorted()
                 .toList();
-        if (arguments.isEmpty()) {
+        if (sourceFiles.isEmpty()) {
             getLogger().lifecycle("No Java files to analyze.");
             return;
         }
+        List<Main.ResolvedCoverageModule> modules = resolvedModules(sourceFiles);
         try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
              var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
-            int exit = Main.runWithExistingCoverage(
-                    arguments.toArray(String[]::new),
-                    getAnalysisRoot().get().getAsFile().toPath(),
-                    out,
-                    err
-            );
+            int exit = Main.runWithExistingCoverage(modules, out, err);
             if (exit != 0) {
                 throw new GradleException("crap-java-check failed with exit " + exit);
             }
         }
+    }
+
+    private List<Main.ResolvedCoverageModule> resolvedModules(List<Path> sourceFiles) {
+        Path analysisRoot = getAnalysisRoot().get().getAsFile().toPath().toAbsolutePath().normalize();
+        Map<String, String> configuredModules = new LinkedHashMap<>(getModuleCoverageReports().get());
+        List<String> orderedModulePaths = configuredModules.keySet().stream()
+                .sorted(Comparator.naturalOrder())
+                .toList();
+        List<String> matchingModulePaths = orderedModulePaths.stream()
+                .sorted(Comparator.comparingInt(String::length).reversed().thenComparing(Comparator.naturalOrder()))
+                .toList();
+
+        Map<String, List<Path>> sourceFilesByModule = new LinkedHashMap<>();
+        for (String modulePath : orderedModulePaths) {
+            sourceFilesByModule.put(modulePath, new ArrayList<>());
+        }
+        for (Path sourceFile : sourceFiles) {
+            String modulePath = matchingModulePath(analysisRoot, sourceFile, matchingModulePaths);
+            sourceFilesByModule.get(modulePath).add(sourceFile);
+        }
+
+        List<Main.ResolvedCoverageModule> modules = new ArrayList<>();
+        for (String modulePath : orderedModulePaths) {
+            List<Path> moduleSources = sourceFilesByModule.get(modulePath);
+            if (moduleSources.isEmpty()) {
+                continue;
+            }
+            String coverageReport = configuredModules.get(modulePath);
+            modules.add(new Main.ResolvedCoverageModule(
+                    resolveModuleRoot(analysisRoot, modulePath),
+                    resolveRelativePath(analysisRoot, coverageReport),
+                    moduleSources
+            ));
+        }
+        return modules;
+    }
+
+    private String matchingModulePath(Path analysisRoot, Path sourceFile, List<String> matchingModulePaths) {
+        String relativeSourcePath = normalizeRelativePath(analysisRoot.relativize(sourceFile));
+        return matchingModulePaths.stream()
+                .filter(modulePath -> matchesModulePath(relativeSourcePath, modulePath))
+                .findFirst()
+                .orElseThrow(() -> new GradleException("No configured Gradle module matches " + relativeSourcePath));
+    }
+
+    private static boolean matchesModulePath(String relativeSourcePath, String modulePath) {
+        if (".".equals(modulePath)) {
+            return true;
+        }
+        return relativeSourcePath.equals(modulePath) || relativeSourcePath.startsWith(modulePath + "/");
+    }
+
+    private static Path resolveModuleRoot(Path analysisRoot, String modulePath) {
+        if (".".equals(modulePath)) {
+            return analysisRoot;
+        }
+        return analysisRoot.resolve(modulePath).normalize();
+    }
+
+    private static Path resolveRelativePath(Path analysisRoot, String relativePath) {
+        if (".".equals(relativePath)) {
+            return analysisRoot;
+        }
+        return analysisRoot.resolve(relativePath).normalize();
+    }
+
+    private static String normalizeRelativePath(Path path) {
+        return path.normalize().toString().replace('\\', '/');
     }
 }
 

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
@@ -9,8 +9,11 @@ import org.gradle.testing.jacoco.tasks.JacocoReport;
 
 import java.util.Collection;
 import java.util.List;
+import java.nio.file.Path;
 
 public class CrapJavaGradlePlugin implements Plugin<Project> {
+
+    private static final String JACOCO_XML_RELATIVE_PATH = "build/reports/jacoco/test/jacocoTestReport.xml";
 
     @Override
     public void apply(Project project) {
@@ -21,19 +24,11 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
                     task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
                     task.setDescription("Runs the crap-java CRAP metric gate.");
                     task.getAnalysisRoot().set(project.getLayout().getProjectDirectory());
-                    task.getAnalysisMetadata().from(
-                            project.getLayout().getProjectDirectory().file("settings.gradle"),
-                            project.getLayout().getProjectDirectory().file("settings.gradle.kts"),
-                            project.getLayout().getProjectDirectory().file("build.gradle"),
-                            project.getLayout().getProjectDirectory().file("build.gradle.kts"),
-                            project.getLayout().getProjectDirectory().file("gradlew"),
-                            project.getLayout().getProjectDirectory().file("gradlew.bat")
-                    );
                 }
         );
 
         for (Project candidate : projectsToConfigure(project)) {
-            candidate.getPluginManager().withPlugin("java", ignored -> configureJavaProject(candidate, checkTask));
+            candidate.getPluginManager().withPlugin("java", ignored -> configureJavaProject(project, candidate, checkTask));
         }
     }
 
@@ -44,13 +39,16 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
         return List.of(project);
     }
 
-    private void configureJavaProject(Project candidate, TaskProvider<CrapJavaCheckTask> checkTask) {
+    private void configureJavaProject(Project analysisProject,
+                                      Project candidate,
+                                      TaskProvider<CrapJavaCheckTask> checkTask) {
         candidate.getPluginManager().apply("jacoco");
 
         TaskProvider<Test> testTask = candidate.getTasks().named("test", Test.class);
         TaskProvider<JacocoReport> jacocoReportTask = candidate.getTasks().named("jacocoTestReport", JacocoReport.class, report ->
                 report.getReports().getXml().getRequired().set(true)
         );
+        String modulePath = relativeModulePath(analysisProject, candidate);
 
         checkTask.configure(task -> {
             task.dependsOn(testTask);
@@ -59,11 +57,24 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
                     tree.include("src/main/java/**/*.java")
             ));
             task.getCoverageReports().from(candidate.getLayout().getBuildDirectory().file("reports/jacoco/test/jacocoTestReport.xml"));
-            task.getAnalysisMetadata().from(
-                    candidate.getLayout().getProjectDirectory().file("build.gradle"),
-                    candidate.getLayout().getProjectDirectory().file("build.gradle.kts")
-            );
+            task.getModuleCoverageReports().put(modulePath, coverageReportPath(modulePath));
         });
+    }
+
+    private static String relativeModulePath(Project analysisProject, Project candidate) {
+        Path analysisRoot = analysisProject.getProjectDir().toPath().toAbsolutePath().normalize();
+        Path candidateRoot = candidate.getProjectDir().toPath().toAbsolutePath().normalize();
+        if (analysisRoot.equals(candidateRoot)) {
+            return ".";
+        }
+        return analysisRoot.relativize(candidateRoot).toString().replace('\\', '/');
+    }
+
+    private static String coverageReportPath(String modulePath) {
+        if (".".equals(modulePath)) {
+            return JACOCO_XML_RELATIVE_PATH;
+        }
+        return modulePath + "/" + JACOCO_XML_RELATIVE_PATH;
     }
 }
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -23,7 +23,20 @@ class CrapJavaGradlePluginFunctionalTest {
 
     @Test
     void singleModuleProjectRunsCrapJavaCheck() throws Exception {
-        writeFile("settings.gradle.kts", "rootProject.name = \"demo\"");
+        writeSingleModuleProject();
+
+        BuildResult result = runBuild("crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
+        assertEquals(TaskOutcome.SUCCESS, result.task(":jacocoTestReport").getOutcome());
+    }
+
+    @Test
+    void rootTaskAggregatesSubprojectCoverageForMultiModuleBuilds() throws Exception {
+        writeFile("settings.gradle.kts", """
+                rootProject.name = "workspace"
+                include("app", "lib")
+                """);
         writeFile("build.gradle.kts", """
                 plugins {
                     java
@@ -42,50 +55,6 @@ class CrapJavaGradlePluginFunctionalTest {
                 tasks.test {
                     useJUnitPlatform()
                 }
-                """);
-        writeFile("src/main/java/demo/Sample.java", """
-                package demo;
-
-                public class Sample {
-                    public int alpha(boolean value) {
-                        if (value) {
-                            return 1;
-                        }
-                        return 0;
-                    }
-                }
-                """);
-        writeFile("src/test/java/demo/SampleTest.java", """
-                package demo;
-
-                import org.junit.jupiter.api.Test;
-
-                import static org.junit.jupiter.api.Assertions.assertEquals;
-
-                class SampleTest {
-                    @Test
-                    void alphaReturnsOneForTrue() {
-                        assertEquals(1, new Sample().alpha(true));
-                    }
-                }
-                """);
-
-        BuildResult result = runBuild("crap-java-check");
-
-        assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
-        assertEquals(TaskOutcome.SUCCESS, result.task(":jacocoTestReport").getOutcome());
-    }
-
-    @Test
-    void rootTaskAggregatesSubprojectCoverageForMultiModuleBuilds() throws Exception {
-        writeFile("settings.gradle.kts", """
-                rootProject.name = "workspace"
-                include("app", "lib")
-                """);
-        writeFile("build.gradle.kts", """
-                plugins {
-                    id("media.barney.crap-java")
-                }
 
                 subprojects {
                     apply(plugin = "java")
@@ -101,6 +70,29 @@ class CrapJavaGradlePluginFunctionalTest {
 
                     tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
                         useJUnitPlatform()
+                    }
+                }
+                """);
+        writeFile("src/main/java/demo/root/RootSample.java", """
+                package demo.root;
+
+                public class RootSample {
+                    public int zero() {
+                        return 0;
+                    }
+                }
+                """);
+        writeFile("src/test/java/demo/root/RootSampleTest.java", """
+                package demo.root;
+
+                import org.junit.jupiter.api.Test;
+
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+
+                class RootSampleTest {
+                    @Test
+                    void zeroReturnsZero() {
+                        assertEquals(0, new RootSample().zero());
                     }
                 }
                 """);
@@ -154,8 +146,21 @@ class CrapJavaGradlePluginFunctionalTest {
         BuildResult result = runBuild("crap-java-check");
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
+        assertTrue(Files.exists(tempDir.resolve("build/reports/jacoco/test/jacocoTestReport.xml")));
         assertTrue(Files.exists(tempDir.resolve("app/build/reports/jacoco/test/jacocoTestReport.xml")));
         assertTrue(Files.exists(tempDir.resolve("lib/build/reports/jacoco/test/jacocoTestReport.xml")));
+    }
+
+    @Test
+    void singleModuleProjectReusesConfigurationCache() throws Exception {
+        writeSingleModuleProject();
+
+        BuildResult first = runBuild("--configuration-cache", "crap-java-check");
+        BuildResult second = runBuild("--configuration-cache", "crap-java-check");
+
+        assertTrue(first.getOutput().contains("Configuration cache entry stored."));
+        assertTrue(second.getOutput().contains("Configuration cache entry reused."));
+        assertEquals(TaskOutcome.SUCCESS, second.task(":crap-java-check").getOutcome());
     }
 
     private BuildResult runBuild(String... arguments) {
@@ -168,6 +173,55 @@ class CrapJavaGradlePluginFunctionalTest {
                 .withArguments(gradleArguments)
                 .withPluginClasspath()
                 .build();
+    }
+
+    private void writeSingleModuleProject() throws IOException {
+        writeFile("settings.gradle.kts", "rootProject.name = \"demo\"");
+        writeFile("build.gradle.kts", """
+                plugins {
+                    java
+                    id("media.barney.crap-java")
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+                    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+                }
+
+                tasks.test {
+                    useJUnitPlatform()
+                }
+                """);
+        writeFile("src/main/java/demo/Sample.java", """
+                package demo;
+
+                public class Sample {
+                    public int alpha(boolean value) {
+                        if (value) {
+                            return 1;
+                        }
+                        return 0;
+                    }
+                }
+                """);
+        writeFile("src/test/java/demo/SampleTest.java", """
+                package demo;
+
+                import org.junit.jupiter.api.Test;
+
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+
+                class SampleTest {
+                    @Test
+                    void alphaReturnsOneForTrue() {
+                        assertEquals(1, new Sample().alpha(true));
+                    }
+                }
+                """);
     }
 
     private void writeFile(String relativePath, String content) throws IOException {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -35,6 +36,7 @@ class CrapJavaGradlePluginTest {
                 .map(Task::getName)
                 .collect(Collectors.toSet());
         assertEquals(Set.of("test", "jacocoTestReport"), dependencyNames);
+        assertEquals(Map.of(".", "build/reports/jacoco/test/jacocoTestReport.xml"), checkTask.getModuleCoverageReports().get());
         assertNotNull(project.getTasks().findByName("jacocoTestReport"));
     }
 
@@ -72,6 +74,7 @@ class CrapJavaGradlePluginTest {
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getAnalysisSources().from(source);
         task.getCoverageReports().from(jacocoXml);
+        task.getModuleCoverageReports().put(".", "build/reports/jacoco/test/jacocoTestReport.xml");
 
         task.runCheck();
 


### PR DESCRIPTION
Closes #53

## Summary
- replace Gradle plugin execution-time module discovery with configuration-time module/report mapping
- add a pre-resolved core analysis entry point so the plugin can execute from explicit module inputs
- prove Configuration Cache support with root-plus-subproject coverage tests and a reuse test, then advertise support in the plugin metadata

## Validation
- `mvn -B -pl cli -am package`
- `mvn -B -pl maven-plugin -am verify`
- `gradle-plugin\\gradlew.bat test validatePlugins`
- throwaway consumer build run twice with `--configuration-cache` and confirmed store/reuse
