### PR TITLE
Harmonize quality gate execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Verify Maven build with NullAway profile
         run: mvn -B verify
 
+  # Keep the self-hosted CRAP gate split by build tool so the metric job owns
+  # every source tree in this repo, including gradle-plugin/src/main/java.
   crap-java-gate:
     name: crap-java Gate
     runs-on: ubuntu-latest
@@ -125,15 +127,17 @@ jobs:
           fi
           echo "CLI_JAR=${filtered[0]}" >> "$GITHUB_ENV"
 
-      - name: Run Maven crap-java gate
+      - name: Run Maven-source crap-java gate
         run: java -jar "$CLI_JAR" --build-tool maven core/src/main/java cli/src/main/java maven-plugin/src/main/java
 
       - name: Set up Gradle wrapper permissions
         run: chmod +x gradle-plugin/gradlew
 
-      - name: Run Gradle crap-java gate
+      - name: Run Gradle-plugin crap-java gate
         run: java -jar "$CLI_JAR" --build-tool gradle gradle-plugin/src/main/java
 
+  # Keep the self-hosted cognitive gate separate from the Gradle plugin test job
+  # so complexity violations in gradle-plugin/src/main/java fail this metric job.
   cognitive-java-gate:
     name: cognitive-java Gate
     runs-on: ubuntu-latest
@@ -149,7 +153,7 @@ jobs:
           java-version: "17"
           cache: maven
 
-      - name: Run cognitive-java gate
+      - name: Run full-repo cognitive-java gate
         run: mvn -B cognitive-java:check
 
   publishing-preflight:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ mvn -B cognitive-java:check
 
 `mvn -B verify` now also includes the cognitive gate at the reactor root.
 
+## Self-Hosting Gate Scope
+
+Consumer Maven repos standardize on `mvn -B -ntp verify`, but this repository
+keeps dedicated self-hosting gate jobs where needed to preserve full-repo metric
+ownership across the embedded `gradle-plugin/` source tree.
+
+In CI:
+
+- `crap-java Gate` owns `core`, `cli`, `maven-plugin`, and `gradle-plugin/src/main/java`
+- `cognitive-java Gate` owns the same full-repo source scope
+- `gradle-plugin` validates Gradle plugin build and test behavior only
+
+The standalone `gradle-plugin` job is not the owner of metric failures for
+`gradle-plugin/src/main/java`; those failures still belong to the metric gate
+jobs.
+
 ## Run
 
 Build the CLI jar:

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ In CI:
 
 - `crap-java Gate` owns `core`, `cli`, `maven-plugin`, and `gradle-plugin/src/main/java`
 - `cognitive-java Gate` owns the same full-repo source scope
-- `gradle-plugin` validates Gradle plugin build and test behavior only
+- `Gradle Plugin` validates Gradle plugin build and test behavior only
 
-The standalone `gradle-plugin` job is not the owner of metric failures for
+The standalone `Gradle Plugin` job is not the owner of metric failures for
 `gradle-plugin/src/main/java`; those failures still belong to the metric gate
 jobs.
 


### PR DESCRIPTION
Closes #60

## Summary
- document the self-hosting exception that keeps metric jobs responsible for the embedded Gradle plugin sources
- clarify in the workflow which jobs own metric failures versus plugin build/test behavior
- keep the existing full-repo gate behavior unchanged while making the ownership model explicit
