### PR TITLE
Add CI-friendly CRAP report formats

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,13 +128,33 @@ jobs:
           echo "CLI_JAR=${filtered[0]}" >> "$GITHUB_ENV"
 
       - name: Run Maven-source crap-java gate
-        run: java -jar "$CLI_JAR" --build-tool maven core/src/main/java cli/src/main/java maven-plugin/src/main/java
+        run: |
+          mkdir -p target/crap-java
+          java -jar "$CLI_JAR" \
+            --format text \
+            --junit-report target/crap-java/TEST-crap-java-maven-sources.xml \
+            --build-tool maven \
+            core/src/main/java cli/src/main/java maven-plugin/src/main/java
 
       - name: Set up Gradle wrapper permissions
         run: chmod +x gradle-plugin/gradlew
 
       - name: Run Gradle-plugin crap-java gate
-        run: java -jar "$CLI_JAR" --build-tool gradle gradle-plugin/src/main/java
+        run: |
+          mkdir -p target/crap-java
+          java -jar "$CLI_JAR" \
+            --format text \
+            --junit-report target/crap-java/TEST-crap-java-gradle-plugin.xml \
+            --build-tool gradle \
+            gradle-plugin/src/main/java
+
+      - name: Upload crap-java JUnit reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: crap-java-junit-reports
+          path: target/crap-java/TEST-crap-java-*.xml
+          if-no-files-found: ignore
 
   # Keep the self-hosted cognitive gate separate from the Gradle plugin test job
   # so complexity violations in gradle-plugin/src/main/java fail this metric job.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ java -jar cli/target/crap-java-cli-0.4.1.jar
 (no args)             Analyze all Java files under any nested src/main/java tree
 --changed             Analyze changed Java files under any nested src/main/java tree
 --build-tool <tool>   Force `auto`, `maven`, or `gradle`
+--format <format>     Write `toon`, `json`, `text`, or `junit` output (`toon` by default)
+--output <path>       Write the selected output format to a file instead of stdout
+--junit-report <path> Also write a JUnit XML report for CI test-report UIs
 <file ...>            Analyze only these files
 <directory ...>       Analyze all Java files under each directory's nested src/main/java trees
 ```
@@ -116,10 +119,24 @@ java -jar cli/target/crap-java-cli-0.4.1.jar --help
 java -jar cli/target/crap-java-cli-0.4.1.jar
 java -jar cli/target/crap-java-cli-0.4.1.jar --changed
 java -jar cli/target/crap-java-cli-0.4.1.jar --build-tool gradle
+java -jar cli/target/crap-java-cli-0.4.1.jar --format json
+java -jar cli/target/crap-java-cli-0.4.1.jar --format text
+java -jar cli/target/crap-java-cli-0.4.1.jar --format junit --output target/crap-java/TEST-crap-java.xml
+java -jar cli/target/crap-java-cli-0.4.1.jar --junit-report target/crap-java/TEST-crap-java.xml
 java -jar cli/target/crap-java-cli-0.4.1.jar --build-tool maven module-a/src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.4.1.jar src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.4.1.jar module-a module-b
 ```
+
+The CLI writes only the requested report format to stdout, making the default
+TOON output suitable for agent workflows. Warnings and threshold errors are
+written to stderr. Machine-readable reports include `coverageKind:
+instruction`; later releases may add more coverage kinds.
+
+The JUnit XML format exposes each analyzed method as a testcase. Methods with
+CRAP scores over `8.0` fail, methods with unavailable coverage are skipped, and
+the testcase properties include the score, threshold, complexity, coverage
+percent, coverage kind, source path, and line range.
 
 ## Distribution
 
@@ -147,6 +164,9 @@ Run:
 ```bash
 ./gradlew crap-java-check
 ```
+
+The Gradle task writes a JUnit XML report by default to
+`build/reports/crap-java/TEST-crap-java.xml`.
 
 ### Maven Central Gradle Plugin
 
@@ -222,6 +242,17 @@ Run:
 ```bash
 mvn verify
 ```
+
+The Maven plugin writes a JUnit XML report by default to
+`target/crap-java/TEST-crap-java.xml`. Override the path with:
+
+```bash
+mvn verify -DcrapJava.junitReportPath=target/custom-crap-java.xml
+```
+
+In GitLab CI, upload the generated XML with `artifacts:reports:junit`. In
+GitHub Actions, upload the file as an artifact or feed it into a JUnit
+test-report action.
 
 ## Exit Codes
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,6 +15,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>dev.toonformat</groupId>
+      <artifactId>jtoon</artifactId>
+      <version>${jtoon.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
       <scope>provided</scope>

--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -41,14 +41,16 @@ final class CliApplication {
         try {
             List<Path> filesToAnalyze = filesForMode(parsed);
             if (filesToAnalyze.isEmpty()) {
-                out.println("No Java files to analyze.");
+                CrapReport report = CrapReport.from(List.of(), ReportPublisher.THRESHOLD);
+                ReportPublisher.publish(report, reportOptions(parsed), out);
                 return 0;
             }
 
             List<MethodMetrics> metrics = analyzeByModule(filesToAnalyze, parsed.buildToolSelection());
             metrics.sort(Comparator.comparing(MethodMetrics::crapScore,
                     Comparator.nullsLast(Comparator.reverseOrder())));
-            out.print(ReportFormatter.format(metrics));
+            CrapReport report = CrapReport.from(metrics, ReportPublisher.THRESHOLD);
+            ReportPublisher.publish(report, reportOptions(parsed), out);
 
             double max = Main.maxCrap(metrics);
             if (thresholdExceeded(max)) {
@@ -74,13 +76,13 @@ final class CliApplication {
             if (!Files.exists(jacocoXml)) {
                 err.println("Warning: JaCoCo XML not found at " + jacocoXml + ". Coverage will be N/A.");
             }
-            metrics.addAll(CrapAnalyzer.analyze(module.moduleRoot(), entry.getValue(), jacocoXml));
+            metrics.addAll(CrapAnalyzer.analyze(projectRoot, entry.getValue(), jacocoXml));
         }
         return metrics;
     }
 
     static boolean thresholdExceeded(double max) {
-        return Double.compare(max, 8.0) > 0;
+        return Double.compare(max, ReportPublisher.THRESHOLD) > 0;
     }
 
     private ParseOutcome parseArguments(String[] args) {
@@ -105,6 +107,21 @@ final class CliApplication {
             case EXPLICIT_FILES -> explicitFiles(parsed.fileArgs());
             case HELP -> List.of();
         };
+    }
+
+    private ReportOptions reportOptions(CliArguments parsed) {
+        return new ReportOptions(
+                parsed.reportFormat(),
+                outputPath(parsed.outputPath()),
+                outputPath(parsed.junitReportPath())
+        );
+    }
+
+    private @Nullable Path outputPath(@Nullable String path) {
+        if (path == null) {
+            return null;
+        }
+        return projectRoot.resolve(path).normalize();
     }
 
     private List<Path> explicitFiles(List<String> args) throws Exception {

--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.jspecify.annotations.Nullable;
@@ -54,7 +55,7 @@ final class CliApplication {
 
             double max = Main.maxCrap(metrics);
             if (thresholdExceeded(max)) {
-                err.printf("CRAP threshold exceeded: %.1f > 8.0%n", max);
+                err.printf(Locale.ROOT, "CRAP threshold exceeded: %.1f > %.1f%n", max, ReportPublisher.THRESHOLD);
                 return 2;
             }
             return 0;

--- a/core/src/main/java/media/barney/crap/core/CliArguments.java
+++ b/core/src/main/java/media/barney/crap/core/CliArguments.java
@@ -1,7 +1,15 @@
 package media.barney.crap.core;
 
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
-record CliArguments(CliMode mode, BuildToolSelection buildToolSelection, List<String> fileArgs) {
+record CliArguments(
+        CliMode mode,
+        BuildToolSelection buildToolSelection,
+        ReportFormat reportFormat,
+        @Nullable String outputPath,
+        @Nullable String junitReportPath,
+        List<String> fileArgs
+) {
 }
 

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -2,6 +2,7 @@ package media.barney.crap.core;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 final class CliArgumentsParser {
 
@@ -10,23 +11,51 @@ final class CliArgumentsParser {
 
     static CliArguments parse(String[] args) {
         if (args.length == 0) {
-            return new CliArguments(CliMode.ALL_SRC, BuildToolSelection.AUTO, List.of());
+            return new CliArguments(CliMode.ALL_SRC, BuildToolSelection.AUTO, ReportFormat.TOON, null, null, List.of());
         }
 
         ParseState state = parseState(args);
         if (state.help) {
-            return new CliArguments(CliMode.HELP, state.buildToolSelection, List.of());
+            return new CliArguments(
+                    CliMode.HELP,
+                    state.buildToolSelection,
+                    state.reportFormat,
+                    state.outputPath,
+                    state.junitReportPath,
+                    List.of()
+            );
         }
         boolean changed = state.changed;
         List<String> values = state.fileArgs;
         ensureChangedIsNotCombined(changed, values);
         if (changed) {
-            return new CliArguments(CliMode.CHANGED_SRC, state.buildToolSelection, List.of());
+            return new CliArguments(
+                    CliMode.CHANGED_SRC,
+                    state.buildToolSelection,
+                    state.reportFormat,
+                    state.outputPath,
+                    state.junitReportPath,
+                    List.of()
+            );
         }
         if (values.isEmpty()) {
-            return new CliArguments(CliMode.ALL_SRC, state.buildToolSelection, List.of());
+            return new CliArguments(
+                    CliMode.ALL_SRC,
+                    state.buildToolSelection,
+                    state.reportFormat,
+                    state.outputPath,
+                    state.junitReportPath,
+                    List.of()
+            );
         }
-        return new CliArguments(CliMode.EXPLICIT_FILES, state.buildToolSelection, List.copyOf(values));
+        return new CliArguments(
+                CliMode.EXPLICIT_FILES,
+                state.buildToolSelection,
+                state.reportFormat,
+                state.outputPath,
+                state.junitReportPath,
+                List.copyOf(values)
+        );
     }
 
     private static ParseState parseState(String[] args) {
@@ -52,6 +81,21 @@ final class CliArgumentsParser {
             state.buildToolSeen = true;
             return index + 1;
         }
+        if ("--format".equals(arg)) {
+            state.reportFormat = parseReportFormat(args, index, state.reportFormatSeen);
+            state.reportFormatSeen = true;
+            return index + 1;
+        }
+        if ("--output".equals(arg)) {
+            state.outputPath = parsePathOption(args, index, state.outputPathSeen, "--output");
+            state.outputPathSeen = true;
+            return index + 1;
+        }
+        if ("--junit-report".equals(arg)) {
+            state.junitReportPath = parsePathOption(args, index, state.junitReportPathSeen, "--junit-report");
+            state.junitReportPathSeen = true;
+            return index + 1;
+        }
         if (arg.startsWith("--")) {
             throw new IllegalArgumentException("Unknown option: " + arg);
         }
@@ -69,6 +113,26 @@ final class CliArgumentsParser {
         return BuildToolSelection.parse(args[index + 1]);
     }
 
+    private static ReportFormat parseReportFormat(String[] args, int index, boolean reportFormatSeen) {
+        if (reportFormatSeen) {
+            throw new IllegalArgumentException("--format can only be provided once");
+        }
+        if (index + 1 >= args.length) {
+            throw new IllegalArgumentException("--format requires one of: toon, json, text, junit");
+        }
+        return ReportFormat.parse(args[index + 1]);
+    }
+
+    private static String parsePathOption(String[] args, int index, boolean seen, String option) {
+        if (seen) {
+            throw new IllegalArgumentException(option + " can only be provided once");
+        }
+        if (index + 1 >= args.length) {
+            throw new IllegalArgumentException(option + " requires a path");
+        }
+        return args[index + 1];
+    }
+
     private static void ensureChangedIsNotCombined(boolean changed, List<String> values) {
         if (changed && !values.isEmpty()) {
             throw new IllegalArgumentException("--changed cannot be combined with file arguments");
@@ -78,6 +142,9 @@ final class CliArgumentsParser {
     private record ParseState(boolean help,
                               boolean changed,
                               BuildToolSelection buildToolSelection,
+                              ReportFormat reportFormat,
+                              @Nullable String outputPath,
+                              @Nullable String junitReportPath,
                               List<String> fileArgs) {
     }
 
@@ -86,10 +153,16 @@ final class CliArgumentsParser {
         private boolean changed;
         private BuildToolSelection buildToolSelection = BuildToolSelection.AUTO;
         private boolean buildToolSeen;
+        private ReportFormat reportFormat = ReportFormat.TOON;
+        private boolean reportFormatSeen;
+        private @Nullable String outputPath;
+        private boolean outputPathSeen;
+        private @Nullable String junitReportPath;
+        private boolean junitReportPathSeen;
         private final List<String> values = new ArrayList<>();
 
         private ParseState build() {
-            return new ParseState(help, changed, buildToolSelection, values);
+            return new ParseState(help, changed, buildToolSelection, reportFormat, outputPath, junitReportPath, values);
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
+++ b/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
@@ -21,24 +21,40 @@ final class CrapAnalyzer {
     static List<MethodMetrics> analyze(Path projectRoot, List<Path> changedFiles, Path jacocoXml) throws IOException {
         Map<String, CoverageData> coverageMap = JacocoCoverageParser.parse(jacocoXml);
         List<MethodMetrics> metrics = new ArrayList<>();
+        Path normalizedProjectRoot = projectRoot.toAbsolutePath().normalize();
 
         for (Path file : changedFiles) {
             if (!Files.exists(file)) {
                 continue;
             }
+            Path normalizedFile = file.toAbsolutePath().normalize();
             String source = Files.readString(file);
             String primaryClassName = classNameFromSource(file, source);
             List<MethodDescriptor> methods = JavaMethodParser.parse(primaryClassName, source);
             for (MethodDescriptor method : methods) {
                 Double coverage = lookupCoverage(coverageMap, method.className(), method.name(), method.startLine());
                 Double crap = CrapScore.calculate(method.complexity(), coverage);
-                metrics.add(new MethodMetrics(method.name(), method.className(), method.complexity(), coverage, crap));
+                metrics.add(new MethodMetrics(
+                        method.name(),
+                        method.className(),
+                        sourcePath(normalizedProjectRoot, normalizedFile),
+                        method.startLine(),
+                        method.endLine(),
+                        method.complexity(),
+                        coverage,
+                        crap
+                ));
             }
         }
 
         metrics.sort(Comparator.comparing(MethodMetrics::crapScore,
                 Comparator.nullsLast(Comparator.reverseOrder())));
         return metrics;
+    }
+
+    private static String sourcePath(Path projectRoot, Path file) {
+        Path path = file.startsWith(projectRoot) ? projectRoot.relativize(file) : file;
+        return path.normalize().toString().replace('\\', '/');
     }
 
     static String classNameFromSource(Path file, String source) {

--- a/core/src/main/java/media/barney/crap/core/CrapReport.java
+++ b/core/src/main/java/media/barney/crap/core/CrapReport.java
@@ -1,0 +1,105 @@
+package media.barney.crap.core;
+
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+record CrapReport(
+        int schemaVersion,
+        String tool,
+        double threshold,
+        String coverageKind,
+        ReportSummary summary,
+        List<MethodReport> methods
+) {
+    private static final int SCHEMA_VERSION = 1;
+    private static final String TOOL = "crap-java";
+    private static final String COVERAGE_KIND = "instruction";
+
+    static CrapReport from(List<MethodMetrics> metrics, double threshold) {
+        List<MethodReport> methods = metrics.stream()
+                .map(metric -> MethodReport.from(metric, threshold))
+                .toList();
+        return new CrapReport(
+                SCHEMA_VERSION,
+                TOOL,
+                threshold,
+                COVERAGE_KIND,
+                ReportSummary.from(methods),
+                methods
+        );
+    }
+
+    record ReportSummary(
+            String status,
+            int total,
+            int passed,
+            int failed,
+            int skipped,
+            @Nullable Double maxCrapScore
+    ) {
+        private static ReportSummary from(List<MethodReport> methods) {
+            int passed = 0;
+            int failed = 0;
+            int skipped = 0;
+            double max = 0.0;
+            boolean hasScore = false;
+            for (MethodReport method : methods) {
+                if (method.status() == MethodStatus.PASSED) {
+                    passed++;
+                } else if (method.status() == MethodStatus.FAILED) {
+                    failed++;
+                } else {
+                    skipped++;
+                }
+                if (method.crapScore() != null) {
+                    max = Math.max(max, method.crapScore());
+                    hasScore = true;
+                }
+            }
+            return new ReportSummary(
+                    failed > 0 ? "failed" : "passed",
+                    methods.size(),
+                    passed,
+                    failed,
+                    skipped,
+                    hasScore ? max : null
+            );
+        }
+    }
+
+    record MethodReport(
+            MethodStatus status,
+            String methodName,
+            String className,
+            String sourcePath,
+            int startLine,
+            int endLine,
+            int complexity,
+            @Nullable Double coveragePercent,
+            @Nullable Double crapScore
+    ) {
+        private static MethodReport from(MethodMetrics metric, double threshold) {
+            return new MethodReport(
+                    status(metric, threshold),
+                    metric.methodName(),
+                    metric.className(),
+                    metric.sourcePath(),
+                    metric.startLine(),
+                    metric.endLine(),
+                    metric.complexity(),
+                    metric.coveragePercent(),
+                    metric.crapScore()
+            );
+        }
+
+        private static MethodStatus status(MethodMetrics metric, double threshold) {
+            if (metric.crapScore() == null) {
+                return MethodStatus.SKIPPED;
+            }
+            if (Double.compare(metric.crapScore(), threshold) > 0) {
+                return MethodStatus.FAILED;
+            }
+            return MethodStatus.PASSED;
+        }
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -25,7 +25,21 @@ public final class Main {
     public static int runWithExistingCoverage(List<ResolvedCoverageModule> modules,
                                               PrintStream out,
                                               PrintStream err) throws Exception {
-        return runResolvedModules(modules, out, err);
+        return runResolvedModules(modules, commonRoot(modules), out, err, ReportOptions.textWithOptionalJunit(null));
+    }
+
+    public static int runWithExistingCoverage(List<ResolvedCoverageModule> modules,
+                                              Path reportRoot,
+                                              PrintStream out,
+                                              PrintStream err,
+                                              Path junitReportPath) throws Exception {
+        return runResolvedModules(
+                modules,
+                reportRoot.toAbsolutePath().normalize(),
+                out,
+                err,
+                ReportOptions.textWithOptionalJunit(junitReportPath.toAbsolutePath().normalize())
+        );
     }
 
     public static int run(String[] args, Path projectRoot, PrintStream out, PrintStream err) throws Exception {
@@ -50,8 +64,10 @@ public final class Main {
     }
 
     private static int runResolvedModules(List<ResolvedCoverageModule> modules,
+                                          Path reportRoot,
                                           PrintStream out,
-                                          PrintStream err) throws Exception {
+                                          PrintStream err,
+                                          ReportOptions reportOptions) throws Exception {
         List<MethodMetrics> metrics = new ArrayList<>();
         for (ResolvedCoverageModule module : modules) {
             if (module.sourceFiles().isEmpty()) {
@@ -60,14 +76,11 @@ public final class Main {
             if (!Files.exists(module.coverageReport())) {
                 err.println("Warning: JaCoCo XML not found at " + module.coverageReport() + ". Coverage will be N/A.");
             }
-            metrics.addAll(CrapAnalyzer.analyze(module.moduleRoot(), module.sourceFiles(), module.coverageReport()));
-        }
-        if (metrics.isEmpty()) {
-            out.println("No Java files to analyze.");
-            return 0;
+            metrics.addAll(CrapAnalyzer.analyze(reportRoot, module.sourceFiles(), module.coverageReport()));
         }
 
-        out.print(ReportFormatter.format(metrics));
+        CrapReport report = CrapReport.from(metrics, ReportPublisher.THRESHOLD);
+        ReportPublisher.publish(report, reportOptions, out);
 
         double max = Main.maxCrap(metrics);
         if (CliApplication.thresholdExceeded(max)) {
@@ -84,9 +97,36 @@ public final class Main {
                   crap-java --changed                      Analyze changed Java files under any nested src/main/java tree
                   crap-java --build-tool gradle           Force Gradle for all resolved modules
                   crap-java --build-tool maven --changed  Force Maven for changed files
+                  crap-java --format json                 Write report as toon, json, text, or junit (default: toon)
+                  crap-java --output report.toon          Write the selected report format to a file
+                  crap-java --junit-report report.xml     Also write a JUnit XML report for CI
                   crap-java <path...>                     Analyze files, or for directory args analyze nested src/main/java trees under each path
                   crap-java --help                        Print this help message
                 """;
+    }
+
+    private static Path commonRoot(List<ResolvedCoverageModule> modules) {
+        Path common = null;
+        for (ResolvedCoverageModule module : modules) {
+            Path root = module.moduleRoot();
+            if (common == null) {
+                common = root;
+            } else {
+                common = commonRoot(common, root);
+            }
+        }
+        return common == null ? Path.of(".").toAbsolutePath().normalize() : common;
+    }
+
+    private static Path commonRoot(Path left, Path right) {
+        Path absoluteLeft = left.toAbsolutePath().normalize();
+        Path absoluteRight = right.toAbsolutePath().normalize();
+        Path common = absoluteLeft.getRoot();
+        int max = Math.min(absoluteLeft.getNameCount(), absoluteRight.getNameCount());
+        for (int index = 0; index < max && absoluteLeft.getName(index).equals(absoluteRight.getName(index)); index++) {
+            common = common == null ? absoluteLeft.getName(index) : common.resolve(absoluteLeft.getName(index));
+        }
+        return common == null ? absoluteLeft : common;
     }
 
     static double maxCrap(List<MethodMetrics> metrics) {

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public final class Main {
 
@@ -84,7 +85,7 @@ public final class Main {
 
         double max = Main.maxCrap(metrics);
         if (CliApplication.thresholdExceeded(max)) {
-            err.printf("CRAP threshold exceeded: %.1f > 8.0%n", max);
+            err.printf(Locale.ROOT, "CRAP threshold exceeded: %.1f > %.1f%n", max, ReportPublisher.THRESHOLD);
             return 2;
         }
         return 0;

--- a/core/src/main/java/media/barney/crap/core/MethodMetrics.java
+++ b/core/src/main/java/media/barney/crap/core/MethodMetrics.java
@@ -5,6 +5,9 @@ import org.jspecify.annotations.Nullable;
 record MethodMetrics(
         String methodName,
         String className,
+        String sourcePath,
+        int startLine,
+        int endLine,
         int complexity,
         @Nullable Double coveragePercent,
         @Nullable Double crapScore

--- a/core/src/main/java/media/barney/crap/core/MethodStatus.java
+++ b/core/src/main/java/media/barney/crap/core/MethodStatus.java
@@ -1,0 +1,17 @@
+package media.barney.crap.core;
+
+enum MethodStatus {
+    PASSED("passed"),
+    FAILED("failed"),
+    SKIPPED("skipped");
+
+    private final String value;
+
+    MethodStatus(String value) {
+        this.value = value;
+    }
+
+    String value() {
+        return value;
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
@@ -32,6 +32,7 @@ final class ProcessCommandExecutor implements CommandExecutor {
         Process process = new ProcessBuilder(command)
                 .directory(directory.toFile())
                 .start();
+        process.getOutputStream().close();
         Thread stdout = pipe(process.getInputStream());
         Thread stderr = pipe(process.getErrorStream());
         if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {

--- a/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
@@ -1,5 +1,7 @@
 package media.barney.crap.core;
 
+import java.io.InputStream;
+import java.io.PrintStream;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -10,21 +12,28 @@ final class ProcessCommandExecutor implements CommandExecutor {
     private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
 
     private final Duration timeout;
+    private final PrintStream processOutput;
 
     ProcessCommandExecutor() {
-        this(Duration.ofMinutes(10));
+        this(Duration.ofMinutes(10), System.err);
     }
 
     ProcessCommandExecutor(Duration timeout) {
+        this(timeout, System.err);
+    }
+
+    ProcessCommandExecutor(Duration timeout, PrintStream processOutput) {
         this.timeout = timeout;
+        this.processOutput = processOutput;
     }
 
     @Override
     public int run(List<String> command, Path directory) throws Exception {
         Process process = new ProcessBuilder(command)
                 .directory(directory.toFile())
-                .inheritIO()
                 .start();
+        Thread stdout = pipe(process.getInputStream());
+        Thread stderr = pipe(process.getErrorStream());
         if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
             process.destroyForcibly();
             if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
@@ -34,7 +43,22 @@ final class ProcessCommandExecutor implements CommandExecutor {
             }
             throw new IllegalStateException("Command timed out after " + timeout + ": " + String.join(" ", command));
         }
+        stdout.join();
+        stderr.join();
         return process.exitValue();
+    }
+
+    private Thread pipe(InputStream input) {
+        Thread thread = new Thread(() -> {
+            try (input) {
+                input.transferTo(processOutput);
+            } catch (Exception ex) {
+                processOutput.println("Failed to read process output: " + ex.getMessage());
+            }
+        }, "crap-java-process-output");
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
     }
 }
 

--- a/core/src/main/java/media/barney/crap/core/ReportFormat.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormat.java
@@ -1,0 +1,20 @@
+package media.barney.crap.core;
+
+import java.util.Locale;
+
+enum ReportFormat {
+    TOON,
+    JSON,
+    TEXT,
+    JUNIT;
+
+    static ReportFormat parse(String value) {
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "toon" -> TOON;
+            case "json" -> JSON;
+            case "text" -> TEXT;
+            case "junit" -> JUNIT;
+            default -> throw new IllegalArgumentException("Unknown report format: " + value);
+        };
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -1,5 +1,6 @@
 package media.barney.crap.core;
 
+import dev.toonformat.jtoon.JToon;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -11,45 +12,247 @@ final class ReportFormatter {
     private ReportFormatter() {
     }
 
-    static String format(List<MethodMetrics> entries) {
-        List<MethodMetrics> sorted = new ArrayList<>(entries);
-        sorted.sort(Comparator
-                .comparing((MethodMetrics e) -> e.crapScore() == null)
-                .thenComparing(e -> e.crapScore() == null ? 0.0 : -e.crapScore()));
+    static String format(CrapReport report, ReportFormat format) {
+        return switch (format) {
+            case TOON -> JToon.encodeJson(formatJson(report));
+            case JSON -> formatJson(report);
+            case TEXT -> formatText(report);
+            case JUNIT -> formatJunit(report);
+        };
+    }
 
-        String header = String.format("%-30s %-35s %4s %7s %8s", "Method", "Class", "CC", "Cov%", "CRAP");
+    private static String formatText(CrapReport report) {
+        List<CrapReport.MethodReport> sorted = sortedMethods(report.methods());
+        String header = String.format("%-8s %-30s %-35s %4s %7s %8s", "Status", "Method", "Class", "CC", "Cov%", "CRAP");
         String separator = "-".repeat(header.length());
         StringBuilder builder = new StringBuilder();
         builder.append("CRAP Report\n");
         builder.append("===========\n");
+        builder.append("Coverage kind: ").append(report.coverageKind()).append('\n');
+        builder.append(String.format(Locale.ROOT, "Summary: %d total, %d passed, %d failed, %d skipped%n",
+                report.summary().total(),
+                report.summary().passed(),
+                report.summary().failed(),
+                report.summary().skipped()));
         builder.append(header).append('\n');
         builder.append(separator).append('\n');
 
-        for (MethodMetrics entry : sorted) {
-            builder.append(String.format(Locale.ROOT, "%-30s %-35s %4d %7s %8s",
+        for (CrapReport.MethodReport entry : sorted) {
+            builder.append(String.format(Locale.ROOT, "%-8s %-30s %-35s %4d %7s %8s",
+                    entry.status().value(),
                     entry.methodName(),
                     entry.className(),
                     entry.complexity(),
                     formatCoverage(entry.coveragePercent()),
-                    formatCrap(entry.crapScore())));
+                    formatDisplayNumber(entry.crapScore())));
             builder.append('\n');
         }
 
         return builder.toString();
     }
 
+    private static String formatJson(CrapReport report) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{\n");
+        field(builder, 1, "schemaVersion", Integer.toString(report.schemaVersion()), true);
+        field(builder, 1, "tool", quote(report.tool()), true);
+        field(builder, 1, "threshold", number(report.threshold()), true);
+        field(builder, 1, "coverageKind", quote(report.coverageKind()), true);
+        builder.append("  \"summary\": {\n");
+        field(builder, 2, "status", quote(report.summary().status()), true);
+        field(builder, 2, "total", Integer.toString(report.summary().total()), true);
+        field(builder, 2, "passed", Integer.toString(report.summary().passed()), true);
+        field(builder, 2, "failed", Integer.toString(report.summary().failed()), true);
+        field(builder, 2, "skipped", Integer.toString(report.summary().skipped()), true);
+        field(builder, 2, "maxCrapScore", nullableNumber(report.summary().maxCrapScore()), false);
+        builder.append("  },\n");
+        builder.append("  \"methods\": [\n");
+        List<CrapReport.MethodReport> methods = sortedMethods(report.methods());
+        for (int index = 0; index < methods.size(); index++) {
+            appendMethodJson(builder, methods.get(index), index < methods.size() - 1);
+        }
+        builder.append("  ]\n");
+        builder.append("}\n");
+        return builder.toString();
+    }
+
+    private static void appendMethodJson(StringBuilder builder, CrapReport.MethodReport method, boolean comma) {
+        builder.append("    {\n");
+        field(builder, 3, "status", quote(method.status().value()), true);
+        field(builder, 3, "methodName", quote(method.methodName()), true);
+        field(builder, 3, "className", quote(method.className()), true);
+        field(builder, 3, "sourcePath", quote(method.sourcePath()), true);
+        field(builder, 3, "startLine", Integer.toString(method.startLine()), true);
+        field(builder, 3, "endLine", Integer.toString(method.endLine()), true);
+        field(builder, 3, "complexity", Integer.toString(method.complexity()), true);
+        field(builder, 3, "coveragePercent", nullableNumber(method.coveragePercent()), true);
+        field(builder, 3, "crapScore", nullableNumber(method.crapScore()), false);
+        builder.append("    }");
+        if (comma) {
+            builder.append(',');
+        }
+        builder.append('\n');
+    }
+
+    private static void field(StringBuilder builder, int indent, String name, String value, boolean comma) {
+        builder.append("  ".repeat(indent))
+                .append(quote(name))
+                .append(": ")
+                .append(value);
+        if (comma) {
+            builder.append(',');
+        }
+        builder.append('\n');
+    }
+
+    private static String formatJunit(CrapReport report) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        builder.append("<testsuites tests=\"").append(report.summary().total())
+                .append("\" failures=\"").append(report.summary().failed())
+                .append("\" errors=\"0\" skipped=\"").append(report.summary().skipped())
+                .append("\" time=\"0\">\n");
+        builder.append("  <testsuite name=\"crap-java\" tests=\"").append(report.summary().total())
+                .append("\" failures=\"").append(report.summary().failed())
+                .append("\" errors=\"0\" skipped=\"").append(report.summary().skipped())
+                .append("\" time=\"0\">\n");
+        builder.append("    <properties>\n");
+        property(builder, 3, "schemaVersion", Integer.toString(report.schemaVersion()));
+        property(builder, 3, "threshold", number(report.threshold()));
+        property(builder, 3, "coverageKind", report.coverageKind());
+        builder.append("    </properties>\n");
+        for (CrapReport.MethodReport method : sortedMethods(report.methods())) {
+            testcase(builder, report, method);
+        }
+        builder.append("  </testsuite>\n");
+        builder.append("</testsuites>\n");
+        return builder.toString();
+    }
+
+    private static void testcase(StringBuilder builder, CrapReport report, CrapReport.MethodReport method) {
+        builder.append("    <testcase classname=\"").append(xml(method.className()))
+                .append("\" name=\"").append(xml(testcaseName(method)))
+                .append("\" file=\"").append(xml(method.sourcePath()))
+                .append("\" line=\"").append(method.startLine())
+                .append("\" time=\"0\">\n");
+        builder.append("      <properties>\n");
+        property(builder, 4, "status", method.status().value());
+        property(builder, 4, "methodName", method.methodName());
+        property(builder, 4, "className", method.className());
+        property(builder, 4, "sourcePath", method.sourcePath());
+        property(builder, 4, "startLine", Integer.toString(method.startLine()));
+        property(builder, 4, "endLine", Integer.toString(method.endLine()));
+        property(builder, 4, "complexity", Integer.toString(method.complexity()));
+        property(builder, 4, "coverageKind", report.coverageKind());
+        property(builder, 4, "coveragePercent", nullableProperty(method.coveragePercent()));
+        property(builder, 4, "crapScore", nullableProperty(method.crapScore()));
+        property(builder, 4, "threshold", number(report.threshold()));
+        builder.append("      </properties>\n");
+        if (method.status() == MethodStatus.FAILED) {
+            String message = "CRAP threshold exceeded: "
+                    + formatDisplayNumber(method.crapScore()) + " > " + formatDisplayNumber(report.threshold());
+            builder.append("      <failure message=\"").append(xml(message))
+                    .append("\" type=\"crap-java.threshold\">")
+                    .append(xml(message))
+                    .append("</failure>\n");
+        } else if (method.status() == MethodStatus.SKIPPED) {
+            builder.append("      <skipped message=\"CRAP score unavailable\">")
+                    .append("Coverage data unavailable for ")
+                    .append(xml(method.className()))
+                    .append("#")
+                    .append(xml(method.methodName()))
+                    .append("</skipped>\n");
+        }
+        builder.append("    </testcase>\n");
+    }
+
+    private static void property(StringBuilder builder, int indent, String name, String value) {
+        builder.append("  ".repeat(indent))
+                .append("<property name=\"")
+                .append(xml(name))
+                .append("\" value=\"")
+                .append(xml(value))
+                .append("\"/>\n");
+    }
+
+    private static String testcaseName(CrapReport.MethodReport method) {
+        return method.status().value().toUpperCase(Locale.ROOT)
+                + " " + method.methodName()
+                + ":" + method.startLine()
+                + " CRAP " + formatDisplayNumber(method.crapScore());
+    }
+
+    private static List<CrapReport.MethodReport> sortedMethods(List<CrapReport.MethodReport> entries) {
+        List<CrapReport.MethodReport> sorted = new ArrayList<>(entries);
+        sorted.sort(Comparator
+                .comparing((CrapReport.MethodReport e) -> e.crapScore() == null)
+                .thenComparing(e -> e.crapScore() == null ? 0.0 : -e.crapScore())
+                .thenComparing(CrapReport.MethodReport::className)
+                .thenComparing(CrapReport.MethodReport::methodName)
+                .thenComparingInt(CrapReport.MethodReport::startLine));
+        return sorted;
+    }
+
     private static String formatCoverage(@Nullable Double coverage) {
         if (coverage == null) {
-            return "  N/A ";
+            return "N/A";
         }
-        return String.format(Locale.ROOT, "%5.1f%%", coverage);
+        return String.format(Locale.ROOT, "%.1f%%", coverage);
     }
 
-    private static String formatCrap(@Nullable Double score) {
+    private static String formatDisplayNumber(@Nullable Double score) {
         if (score == null) {
-            return "     N/A";
+            return "N/A";
         }
-        return String.format(Locale.ROOT, "%8.1f", score);
+        return String.format(Locale.ROOT, "%.1f", score);
+    }
+
+    private static String nullableProperty(@Nullable Double value) {
+        return value == null ? "N/A" : number(value);
+    }
+
+    private static String nullableNumber(@Nullable Double value) {
+        return value == null ? "null" : number(value);
+    }
+
+    private static String number(double value) {
+        return Double.toString(value);
+    }
+
+    private static String quote(String value) {
+        StringBuilder builder = new StringBuilder();
+        builder.append('"');
+        for (int index = 0; index < value.length(); index++) {
+            builder.append(jsonEscape(value.charAt(index)));
+        }
+        builder.append('"');
+        return builder.toString();
+    }
+
+    private static String jsonEscape(char ch) {
+        return switch (ch) {
+            case '"' -> "\\\"";
+            case '\\' -> "\\\\";
+            case '\n' -> "\\n";
+            case '\r' -> "\\r";
+            case '\t' -> "\\t";
+            default -> ch < 0x20 ? String.format(Locale.ROOT, "\\u%04x", (int) ch) : Character.toString(ch);
+        };
+    }
+
+    private static String xml(String value) {
+        StringBuilder builder = new StringBuilder();
+        for (int index = 0; index < value.length(); index++) {
+            char ch = value.charAt(index);
+            switch (ch) {
+                case '&' -> builder.append("&amp;");
+                case '<' -> builder.append("&lt;");
+                case '>' -> builder.append("&gt;");
+                case '"' -> builder.append("&quot;");
+                case '\'' -> builder.append("&apos;");
+                default -> builder.append(ch);
+            }
+        }
+        return builder.toString();
     }
 }
-

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -1,0 +1,14 @@
+package media.barney.crap.core;
+
+import java.nio.file.Path;
+import org.jspecify.annotations.Nullable;
+
+record ReportOptions(
+        ReportFormat format,
+        @Nullable Path outputPath,
+        @Nullable Path junitReportPath
+) {
+    static ReportOptions textWithOptionalJunit(@Nullable Path junitReportPath) {
+        return new ReportOptions(ReportFormat.TEXT, null, junitReportPath);
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/ReportPublisher.java
+++ b/core/src/main/java/media/barney/crap/core/ReportPublisher.java
@@ -1,0 +1,39 @@
+package media.barney.crap.core;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+final class ReportPublisher {
+
+    static final double THRESHOLD = 8.0;
+
+    private ReportPublisher() {
+    }
+
+    static void publish(CrapReport report, ReportOptions options, PrintStream out) throws IOException {
+        publishPrimary(report, options, out);
+        if (options.junitReportPath() != null) {
+            write(options.junitReportPath(), ReportFormatter.format(report, ReportFormat.JUNIT));
+        }
+    }
+
+    private static void publishPrimary(CrapReport report, ReportOptions options, PrintStream out) throws IOException {
+        String content = ReportFormatter.format(report, options.format());
+        if (options.outputPath() == null) {
+            out.print(content);
+            return;
+        }
+        write(options.outputPath(), content);
+    }
+
+    private static void write(Path path, String content) throws IOException {
+        Path parent = path.toAbsolutePath().normalize().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
@@ -57,7 +57,8 @@ class CliApplicationTest {
                 .execute(new String[0]);
 
         assertEquals(0, exit);
-        assertTrue(utf8(out).contains("No Java files to analyze."));
+        assertTrue(utf8(out).contains("schemaVersion: 1"));
+        assertTrue(utf8(out).contains("methods[0]"));
     }
 
     @Test
@@ -79,7 +80,7 @@ class CliApplicationTest {
                 .execute(new String[]{"--changed"});
 
         assertEquals(0, exit);
-        assertTrue(utf8(out).contains("No Java files to analyze."));
+        assertTrue(utf8(out).contains("methods[0]"));
         assertEquals("", utf8(err));
     }
 

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -14,6 +14,7 @@ class CliArgumentsParserTest {
         CliArguments args = CliArgumentsParser.parse(new String[]{});
         assertEquals(CliMode.ALL_SRC, args.mode());
         assertEquals(BuildToolSelection.AUTO, args.buildToolSelection());
+        assertEquals(ReportFormat.TOON, args.reportFormat());
     }
 
     @Test
@@ -28,6 +29,7 @@ class CliArgumentsParserTest {
         CliArguments args = CliArgumentsParser.parse(new String[]{"src/main/java/demo/A.java", "src/main/java/demo/B.java"});
         assertEquals(CliMode.EXPLICIT_FILES, args.mode());
         assertEquals(BuildToolSelection.AUTO, args.buildToolSelection());
+        assertEquals(ReportFormat.TOON, args.reportFormat());
         assertEquals(List.of("src/main/java/demo/A.java", "src/main/java/demo/B.java"), args.fileArgs());
     }
 
@@ -43,6 +45,63 @@ class CliArgumentsParserTest {
 
         assertEquals(CliMode.CHANGED_SRC, args.mode());
         assertEquals(BuildToolSelection.GRADLE, args.buildToolSelection());
+    }
+
+    @Test
+    void reportOptionsAreParsed() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{
+                "--format", "json",
+                "--output", "target/crap-java/report.json",
+                "--junit-report", "target/crap-java/TEST-crap-java.xml",
+                "src/main/java/demo/A.java"
+        });
+
+        assertEquals(ReportFormat.JSON, args.reportFormat());
+        assertEquals("target/crap-java/report.json", args.outputPath());
+        assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
+        assertEquals(List.of("src/main/java/demo/A.java"), args.fileArgs());
+    }
+
+    @Test
+    void reportFormatRequiresKnownValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--format", "yaml"}));
+    }
+
+    @Test
+    void reportFormatRequiresValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--format"}));
+    }
+
+    @Test
+    void reportFormatCanOnlyBeProvidedOnce() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--format", "json", "--format", "toon"}));
+    }
+
+    @Test
+    void outputRequiresValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--output"}));
+    }
+
+    @Test
+    void outputCanOnlyBeProvidedOnce() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--output", "one.json", "--output", "two.json"}));
+    }
+
+    @Test
+    void junitReportRequiresValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--junit-report"}));
+    }
+
+    @Test
+    void junitReportCanOnlyBeProvidedOnce() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--junit-report", "one.xml", "--junit-report", "two.xml"}));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -31,6 +31,7 @@ class MainTest {
         assertEquals(0, exit);
         assertTrue(utf8(out).contains("Usage:"));
         assertTrue(utf8(out).contains("--build-tool"));
+        assertTrue(utf8(out).contains("--format"));
     }
 
     @Test
@@ -90,6 +91,8 @@ class MainTest {
         );
 
         assertEquals(0, exit);
+        assertTrue(utf8(out).contains("schemaVersion: 1"));
+        assertTrue(utf8(out).contains("coverageKind: instruction"));
         assertTrue(utf8(out).contains("Sample"));
         assertTrue(utf8(out).contains("alpha"));
     }
@@ -156,7 +159,7 @@ class MainTest {
         ByteArrayOutputStream err = new ByteArrayOutputStream();
 
         int exit = Main.runWithExistingCoverage(
-                new String[]{"src/main/java/demo/Sample.java"},
+                new String[]{"--format", "text", "src/main/java/demo/Sample.java"},
                 tempDir,
                 new PrintStream(out),
                 new PrintStream(err)
@@ -166,6 +169,58 @@ class MainTest {
         assertTrue(Files.exists(jacocoXml));
         assertTrue(utf8(out).contains("100.0%"));
         assertEquals("", utf8(err));
+    }
+
+    @Test
+    void writesPrimaryOutputAndAdditionalJunitReportFiles() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int alpha() {
+                        return 1;
+                    }
+                }
+                """);
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Files.createDirectories(jacocoXml.getParent());
+        Files.writeString(jacocoXml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()I" line="4">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+        Path jsonReport = tempDir.resolve("target/crap-java/report.json");
+        Path junitReport = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                new String[]{
+                        "--format", "json",
+                        "--output", "target/crap-java/report.json",
+                        "--junit-report", "target/crap-java/TEST-crap-java.xml",
+                        "src/main/java/demo/Sample.java"
+                },
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        assertEquals(0, exit);
+        assertEquals("", utf8(out));
+        assertEquals("", utf8(err));
+        assertTrue(Files.readString(jsonReport).contains("\"coverageKind\": \"instruction\""));
+        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
     }
 
     @Test
@@ -211,11 +266,60 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageUsesCommonRootForPreResolvedModules() throws Exception {
+        Path appRoot = tempDir.resolve("app");
+        Path libRoot = tempDir.resolve("lib");
+        Path appSource = appRoot.resolve("src/main/java/demo/app/AppSample.java");
+        Path libSource = libRoot.resolve("src/main/java/demo/lib/LibSample.java");
+        Files.createDirectories(appSource.getParent());
+        Files.createDirectories(libSource.getParent());
+        Files.writeString(appSource, """
+                package demo.app;
+
+                class AppSample {
+                    int alpha() {
+                        return 1;
+                    }
+                }
+                """);
+        Files.writeString(libSource, """
+                package demo.lib;
+
+                class LibSample {
+                    int beta() {
+                        return 2;
+                    }
+                }
+                """);
+        Path appJacocoXml = appRoot.resolve("build/reports/jacoco/test/jacocoTestReport.xml");
+        Path libJacocoXml = libRoot.resolve("build/reports/jacoco/test/jacocoTestReport.xml");
+        writeCoverageXml(appJacocoXml, "demo/app/AppSample", "alpha", 4);
+        writeCoverageXml(libJacocoXml, "demo/lib/LibSample", "beta", 4);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                List.of(
+                        new Main.ResolvedCoverageModule(appRoot, appJacocoXml, List.of(appSource)),
+                        new Main.ResolvedCoverageModule(libRoot, libJacocoXml, List.of(libSource))
+                ),
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        assertEquals(0, exit);
+        assertTrue(utf8(out).contains("demo.app.AppSample"));
+        assertTrue(utf8(out).contains("demo.lib.LibSample"));
+        assertEquals("", utf8(err));
+    }
+
+    @Test
     void maxCrapReturnsLargestNonNullScore() {
         List<MethodMetrics> metrics = List.of(
-                new MethodMetrics("alpha", "demo.Sample", 1, null, null),
-                new MethodMetrics("beta", "demo.Sample", 1, 75.0, 4.5),
-                new MethodMetrics("gamma", "demo.Sample", 1, 85.0, 7.0)
+                new MethodMetrics("alpha", "demo.Sample", "src/main/java/demo/Sample.java", 1, 2, 1, null, null),
+                new MethodMetrics("beta", "demo.Sample", "src/main/java/demo/Sample.java", 3, 4, 1, 75.0, 4.5),
+                new MethodMetrics("gamma", "demo.Sample", "src/main/java/demo/Sample.java", 5, 6, 1, 85.0, 7.0)
         );
 
         assertEquals(7.0, Main.maxCrap(metrics));
@@ -223,6 +327,21 @@ class MainTest {
 
     private static String utf8(ByteArrayOutputStream output) {
         return output.toString(StandardCharsets.UTF_8);
+    }
+
+    private static void writeCoverageXml(Path path, String className, String methodName, int line) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="%s" sourcefilename="Sample.java">
+                      <method name="%s" desc="()I" line="%d">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """.formatted(className, methodName, line));
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -1,6 +1,7 @@
 package media.barney.crap.core;
 
 import org.junit.jupiter.api.Test;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -10,48 +11,155 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ReportFormatterTest {
 
     @Test
-    void formatsExactReportWithScoresAndNaValues() {
-        MethodMetrics scored = new MethodMetrics("foo", "demo.Sample", 3, 85.0, 4.5);
-        MethodMetrics unknown = new MethodMetrics("bar", "demo.Sample", 2, null, null);
+    void formatsTextReportWithStatusAndCoverageKind() {
+        String report = ReportFormatter.format(report(
+                metric("foo", "demo.Sample", 4, 3, 85.0, 4.5),
+                metric("bar", "demo.Sample", 9, 2, null, null)
+        ), ReportFormat.TEXT);
 
-        String report = ReportFormatter.format(List.of(scored, unknown));
+        assertTrue(report.contains("Coverage kind: instruction"));
+        assertTrue(report.contains("Summary: 2 total, 1 passed, 0 failed, 1 skipped"));
+        assertTrue(report.contains("passed"));
+        assertTrue(report.contains("skipped"));
+        assertTrue(report.contains("85.0%"));
+        assertTrue(report.contains("N/A"));
+    }
 
-        String header = String.format("%-30s %-35s %4s %7s %8s", "Method", "Class", "CC", "Cov%", "CRAP");
-        String separator = "-".repeat(header.length());
+    @Test
+    void formatsJsonReportWithSchemaSummaryAndMethods() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.JSON);
+
         String expected = """
-                CRAP Report
-                ===========
-                %s
-                %s
-                %-30s %-35s %4d %7s %8s
-                %-30s %-35s %4d %7s %8s
-                """.formatted(
-                header,
-                separator,
-                "foo",
-                "demo.Sample",
-                3,
-                "85.0%",
-                "4.5",
-                "bar",
-                "demo.Sample",
-                2,
-                "  N/A ",
-                "     N/A");
+                {
+                  "schemaVersion": 1,
+                  "tool": "crap-java",
+                  "threshold": 8.0,
+                  "coverageKind": "instruction",
+                  "summary": {
+                    "status": "failed",
+                    "total": 2,
+                    "passed": 0,
+                    "failed": 1,
+                    "skipped": 1,
+                    "maxCrapScore": 9.645
+                  },
+                  "methods": [
+                    {
+                      "status": "failed",
+                      "methodName": "danger",
+                      "className": "demo.Sample",
+                      "sourcePath": "src/main/java/demo/Sample.java",
+                      "startLine": 4,
+                      "endLine": 6,
+                      "complexity": 5,
+                      "coveragePercent": 10.0,
+                      "crapScore": 9.645
+                    },
+                    {
+                      "status": "skipped",
+                      "methodName": "unknown",
+                      "className": "demo.Sample",
+                      "sourcePath": "src/main/java/demo/Sample.java",
+                      "startLine": 20,
+                      "endLine": 22,
+                      "complexity": 2,
+                      "coveragePercent": null,
+                      "crapScore": null
+                    }
+                  ]
+                }
+                """;
 
         assertEquals(expected, report);
     }
 
     @Test
-    void sortsScoredEntriesAheadOfNaEntriesAndHigherScoresFirst() {
-        MethodMetrics lowerScore = new MethodMetrics("low", "demo.Sample", 2, 100.0, 2.0);
-        MethodMetrics unknown = new MethodMetrics("unknown", "demo.Sample", 2, null, null);
-        MethodMetrics higherScore = new MethodMetrics("high", "demo.Sample", 5, 10.0, 9.0);
+    void formatsToonReportByTranscodingJson() {
+        String report = ReportFormatter.format(report(
+                metric("foo", "demo.Sample", 4, 3, 85.0, 4.5),
+                metric("bar", "demo.Sample", 9, 2, null, null)
+        ), ReportFormat.TOON);
 
-        String report = ReportFormatter.format(List.of(lowerScore, unknown, higherScore));
+        assertTrue(report.contains("schemaVersion: 1"));
+        assertTrue(report.contains("coverageKind: instruction"));
+        assertTrue(report.contains("methods[2]{status,methodName,className,sourcePath,startLine,endLine,complexity,coveragePercent,crapScore}:"));
+        assertTrue(report.contains("passed,foo,demo.Sample,src/main/java/demo/Sample.java,4,6,3,85,4.5"));
+        assertTrue(report.contains("skipped,bar,demo.Sample,src/main/java/demo/Sample.java,9,11,2,null,null"));
+    }
 
-        assertTrue(report.indexOf("high") < report.indexOf("low"));
-        assertTrue(report.indexOf("low") < report.indexOf("unknown"));
+    @Test
+    void formatsJunitReportWithFailuresSkippedAndProperties() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.JUNIT);
+
+        assertTrue(report.contains("<testsuites tests=\"2\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(report.contains("<property name=\"coverageKind\" value=\"instruction\"/>"));
+        assertTrue(report.contains("<testcase classname=\"demo.Sample\" name=\"FAILED danger:4 CRAP 9.6\""));
+        assertTrue(report.contains("<failure message=\"CRAP threshold exceeded: 9.6 &gt; 8.0\""));
+        assertTrue(report.contains("<testcase classname=\"demo.Sample\" name=\"SKIPPED unknown:20 CRAP N/A\""));
+        assertTrue(report.contains("<skipped message=\"CRAP score unavailable\">"));
+    }
+
+    @Test
+    void escapesJsonSpecialCharacters() {
+        MethodMetrics metric = new MethodMetrics(
+                "quote\"slash\\line\nreturn\rtab\tcontrol\u0001",
+                "demo.Special",
+                "src/main/java/demo/Special.java",
+                1,
+                2,
+                1,
+                100.0,
+                1.0
+        );
+
+        String json = ReportFormatter.format(report(metric), ReportFormat.JSON);
+
+        assertTrue(json.contains("\"methodName\": \"quote\\\"slash\\\\line\\nreturn\\rtab\\tcontrol\\u0001\""));
+    }
+
+    @Test
+    void escapesXmlSpecialCharacters() {
+        MethodMetrics metric = new MethodMetrics(
+                "amp&apos'quote\"lt<gt>",
+                "demo.Special",
+                "src/main/java/demo/Special.java",
+                1,
+                2,
+                1,
+                100.0,
+                1.0
+        );
+
+        String junit = ReportFormatter.format(report(metric), ReportFormat.JUNIT);
+
+        assertTrue(junit.contains("amp&amp;apos&apos;quote&quot;lt&lt;gt&gt;"));
+    }
+
+    private static CrapReport report(MethodMetrics... metrics) {
+        return CrapReport.from(List.of(metrics), ReportPublisher.THRESHOLD);
+    }
+
+    private static MethodMetrics metric(String method,
+                                        String className,
+                                        int startLine,
+                                        int complexity,
+                                        @Nullable Double coverage,
+                                        @Nullable Double score) {
+        return new MethodMetrics(
+                method,
+                className,
+                "src/main/java/demo/Sample.java",
+                startLine,
+                startLine + 2,
+                complexity,
+                coverage,
+                score
+        );
     }
 }
-

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -49,6 +49,7 @@ tasks.withType<JavaCompile>().configureEach {
 
 dependencies {
     implementation(files(coreJar.asFile))
+    implementation("dev.toonformat:jtoon:1.0.9")
     testImplementation(platform("org.junit:junit-bom:5.10.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation(gradleTestKit())

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -4,6 +4,7 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.jvm.tasks.Jar
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.testing.jacoco.tasks.JacocoReport
+import javax.xml.parsers.DocumentBuilderFactory
 
 plugins {
     `java-gradle-plugin`
@@ -24,6 +25,7 @@ jacoco {
 }
 
 val projectVersion = version.toString()
+val jtoonVersion = parentPomProperty("jtoon.version")
 val coreJar = layout.projectDirectory.file("../core/target/crap-java-core-${projectVersion}.jar")
 val gpgPrivateKey = providers.environmentVariable("MAVEN_GPG_PRIVATE_KEY")
 val gpgPassphrase = providers.environmentVariable("MAVEN_GPG_PASSPHRASE")
@@ -49,11 +51,19 @@ tasks.withType<JavaCompile>().configureEach {
 
 dependencies {
     implementation(files(coreJar.asFile))
-    implementation("dev.toonformat:jtoon:1.0.9")
+    implementation("dev.toonformat:jtoon:$jtoonVersion")
     testImplementation(platform("org.junit:junit-bom:5.10.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation(gradleTestKit())
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+fun parentPomProperty(name: String): String {
+    val factory = DocumentBuilderFactory.newInstance()
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+    val document = factory.newDocumentBuilder().parse(layout.projectDirectory.file("../pom.xml").asFile)
+    return document.getElementsByTagName(name).item(0)?.textContent
+        ?: throw GradleException("Missing parent POM property: $name")
 }
 
 tasks.withType<Test>().configureEach {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -5,11 +5,13 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
@@ -38,20 +40,28 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     @Input
     public abstract MapProperty<String, String> getModuleCoverageReports();
 
+    @OutputFile
+    public abstract RegularFileProperty getJunitReport();
+
     @TaskAction
     void runCheck() throws Exception {
         List<Path> sourceFiles = getAnalysisSources().getFiles().stream()
                 .map(file -> file.toPath().toAbsolutePath().normalize())
                 .sorted()
                 .toList();
+        Path analysisRoot = getAnalysisRoot().get().getAsFile().toPath().toAbsolutePath().normalize();
+        Path junitReport = getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize();
         if (sourceFiles.isEmpty()) {
-            getLogger().lifecycle("No Java files to analyze.");
+            try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
+                 var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
+                Main.runWithExistingCoverage(List.of(), analysisRoot, out, err, junitReport);
+            }
             return;
         }
         List<Main.ResolvedCoverageModule> modules = resolvedModules(sourceFiles);
         try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
              var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
-            int exit = Main.runWithExistingCoverage(modules, out, err);
+            int exit = Main.runWithExistingCoverage(modules, analysisRoot, out, err, junitReport);
             if (exit != 0) {
                 throw new GradleException("crap-java-check failed with exit " + exit);
             }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
@@ -24,6 +24,8 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
                     task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
                     task.setDescription("Runs the crap-java CRAP metric gate.");
                     task.getAnalysisRoot().set(project.getLayout().getProjectDirectory());
+                    task.getJunitReport().convention(project.getLayout().getBuildDirectory()
+                            .file("reports/crap-java/TEST-crap-java.xml"));
                 }
         );
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -29,6 +29,7 @@ class CrapJavaGradlePluginFunctionalTest {
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
         assertEquals(TaskOutcome.SUCCESS, result.task(":jacocoTestReport").getOutcome());
+        assertTrue(Files.exists(tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml")));
     }
 
     @Test
@@ -149,6 +150,7 @@ class CrapJavaGradlePluginFunctionalTest {
         assertTrue(Files.exists(tempDir.resolve("build/reports/jacoco/test/jacocoTestReport.xml")));
         assertTrue(Files.exists(tempDir.resolve("app/build/reports/jacoco/test/jacocoTestReport.xml")));
         assertTrue(Files.exists(tempDir.resolve("lib/build/reports/jacoco/test/jacocoTestReport.xml")));
+        assertTrue(Files.exists(tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml")));
     }
 
     @Test
@@ -160,7 +162,8 @@ class CrapJavaGradlePluginFunctionalTest {
 
         assertTrue(first.getOutput().contains("Configuration cache entry stored."));
         assertTrue(second.getOutput().contains("Configuration cache entry reused."));
-        assertEquals(TaskOutcome.SUCCESS, second.task(":crap-java-check").getOutcome());
+        TaskOutcome outcome = second.task(":crap-java-check").getOutcome();
+        assertTrue(outcome == TaskOutcome.SUCCESS || outcome == TaskOutcome.UP_TO_DATE);
     }
 
     private BuildResult runBuild(String... arguments) {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -37,6 +37,9 @@ class CrapJavaGradlePluginTest {
                 .collect(Collectors.toSet());
         assertEquals(Set.of("test", "jacocoTestReport"), dependencyNames);
         assertEquals(Map.of(".", "build/reports/jacoco/test/jacocoTestReport.xml"), checkTask.getModuleCoverageReports().get());
+        assertTrue(checkTask.getJunitReport().get().getAsFile().toPath().normalize().toString()
+                .replace('\\', '/')
+                .endsWith("build/reports/crap-java/TEST-crap-java.xml"));
         assertNotNull(project.getTasks().findByName("jacocoTestReport"));
     }
 
@@ -75,10 +78,13 @@ class CrapJavaGradlePluginTest {
         task.getAnalysisSources().from(source);
         task.getCoverageReports().from(jacocoXml);
         task.getModuleCoverageReports().put(".", "build/reports/jacoco/test/jacocoTestReport.xml");
+        Path junitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        task.getJunitReport().fileValue(junitReport.toFile());
 
         task.runCheck();
 
         assertTrue(Files.exists(jacocoXml));
+        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
     }
 }
 

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -11,6 +11,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.jspecify.annotations.Nullable;
 
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,6 +30,9 @@ public class CrapJavaCheckMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private @Nullable MavenProject project;
+
+    @Parameter(property = "crapJava.junitReportPath")
+    private @Nullable File junitReportPath;
 
     public CrapJavaCheckMojo() {
         this((useExistingCoverage, args, projectRoot, out, err) -> useExistingCoverage
@@ -60,13 +64,30 @@ public class CrapJavaCheckMojo extends AbstractMojo {
 
     private void runCheck(Path executionRoot) throws MojoExecutionException, MojoFailureException {
         try {
-            int exit = runner.run(true, new String[0], executionRoot, System.out, System.err);
+            int exit = runner.run(true, reportArgs(executionRoot), executionRoot, System.out, System.err);
             handleExitCode(exit);
         } catch (MojoFailureException | MojoExecutionException ex) {
             throw ex;
         } catch (Exception ex) {
             throw new MojoExecutionException("Failed to execute crap-java", ex);
         }
+    }
+
+    private String[] reportArgs(Path executionRoot) {
+        return new String[]{
+                "--format",
+                "text",
+                "--junit-report",
+                junitReportPath(executionRoot).toString()
+        };
+    }
+
+    private Path junitReportPath(Path executionRoot) {
+        File configured = junitReportPath;
+        if (configured != null) {
+            return configured.toPath().normalize();
+        }
+        return executionRoot.resolve("target/crap-java/TEST-crap-java.xml").normalize();
     }
 
     private void ensureCoverageReportsExist() throws MojoFailureException {

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -61,6 +61,29 @@ class CrapJavaCheckMojoTest {
         assertTrue(runner.invoked);
         assertTrue(runner.useExistingCoverage);
         assertEquals(root, runner.projectRoot);
+        assertEquals(List.of(
+                "--format",
+                "text",
+                "--junit-report",
+                root.resolve("target/crap-java/TEST-crap-java.xml").toString()
+        ), List.of(runner.args));
+    }
+
+    @Test
+    void usesConfiguredJunitReportPath() throws Exception {
+        Path root = tempDir.resolve("root");
+        writeCoverageReport(root);
+        Path report = root.resolve("custom/crap.xml");
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        setField(mojo, "session", session(List.of(project(root, "root")), root));
+        setField(mojo, "project", project(root, "root"));
+        setField(mojo, "junitReportPath", report.toFile());
+
+        mojo.execute();
+
+        assertEquals(List.of("--format", "text", "--junit-report", report.toString()), List.of(runner.args));
     }
 
     @Test
@@ -225,6 +248,7 @@ class CrapJavaCheckMojoTest {
     private static final class RecordingRunner implements CrapJavaCheckMojo.CrapJavaRunner {
         private boolean invoked;
         private boolean useExistingCoverage;
+        private String[] args = new String[0];
         private @Nullable Path projectRoot;
         private int exitCode;
         private @Nullable Exception failure;
@@ -234,6 +258,7 @@ class CrapJavaCheckMojoTest {
                 throws Exception {
             invoked = true;
             this.useExistingCoverage = useExistingCoverage;
+            this.args = args.clone();
             this.projectRoot = projectRoot;
             if (failure != null) {
                 throw failure;

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <cognitive-java.version>0.4.0</cognitive-java.version>
     <junit.version>5.10.2</junit.version>
     <jspecify.version>1.0.0</jspecify.version>
+    <jtoon.version>1.0.9</jtoon.version>
     <errorprone.version>2.48.0</errorprone.version>
     <nullaway.version>0.13.1</nullaway.version>
     <maven.source.plugin.version>3.3.1</maven.source.plugin.version>


### PR DESCRIPTION
## Summary

Closes #64.

- add `toon`, `json`, `text`, and `junit` report formats with TOON as the CLI default
- add `--output` and `--junit-report` CLI options while keeping stdout limited to the selected report format
- include `coverageKind: instruction`, source paths, line ranges, scores, and pass/fail/skipped status in machine-readable reports
- write JUnit XML by default from Maven and Gradle plugin runs
- upload self-hosted crap-java gate JUnit artifacts in CI

## Validation

- `mvn -B -pl core -am package`
- `mvn -B -pl cli -am package`
- `mvn -B -pl maven-plugin -am verify`
- `cd gradle-plugin && ./gradlew test`
- `java -jar cli/target/crap-java-cli-0.4.1.jar --format text --build-tool maven core/src/main/java cli/src/main/java maven-plugin/src/main/java`
- `java -jar cli/target/crap-java-cli-0.4.1.jar --format text --build-tool gradle gradle-plugin/src/main/java`