### PR TITLE
Use worst coverage input for CRAP scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- CRAP scoring now uses the worse method coverage out of JaCoCo instruction and branch counters, reporting the selected coverage kind per method.
+- Simplified machine-readable reports to a top-level status plus method-level entries.
+
 ## 0.4.1 - 2026-04-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ The toolkit resolves Maven and Gradle modules natively, including standard multi
 `CRAP = CC^2 * (1 - coverage)^3 + CC`
 
 - `CC` is cyclomatic complexity.
-- `coverage` is method coverage fraction from JaCoCo `INSTRUCTION` counters.
+- `coverage` is the lower available method coverage fraction from JaCoCo
+  `INSTRUCTION` and `BRANCH` counters. JaCoCo omits `BRANCH` counters for
+  branchless methods, so those methods use instruction coverage.
 
 ## Coverage Pipeline
 
@@ -130,8 +132,9 @@ java -jar cli/target/crap-java-cli-0.4.1.jar module-a module-b
 
 The CLI writes only the requested report format to stdout, making the default
 TOON output suitable for agent workflows. Warnings and threshold errors are
-written to stderr. Machine-readable reports include `coverageKind:
-instruction`; later releases may add more coverage kinds.
+written to stderr. Machine-readable reports include a top-level `status`
+(`passed` or `failed`) and method-level `coverageKind` values identifying the
+coverage input used for each CRAP score (`instruction`, `branch`, or `N/A`).
 
 The JUnit XML format exposes each analyzed method as a testcase. Methods with
 CRAP scores over `8.0` fail, methods with unavailable coverage are skipped, and

--- a/core/src/main/java/media/barney/crap/core/BuildToolSelection.java
+++ b/core/src/main/java/media/barney/crap/core/BuildToolSelection.java
@@ -1,13 +1,14 @@
 package media.barney.crap.core;
 
 import java.util.Locale;
+import org.jspecify.annotations.Nullable;
 
 enum BuildToolSelection {
     AUTO,
     MAVEN,
     GRADLE;
 
-    static BuildToolSelection parse(String value) {
+    static BuildToolSelection parse(@Nullable String value) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("--build-tool requires one of: auto, maven, gradle");
         }

--- a/core/src/main/java/media/barney/crap/core/CoverageData.java
+++ b/core/src/main/java/media/barney/crap/core/CoverageData.java
@@ -1,13 +1,57 @@
 package media.barney.crap.core;
 
-record CoverageData(int missedInstructions, int coveredInstructions) {
+import org.jspecify.annotations.Nullable;
+
+record CoverageData(CoverageCounter instructionCoverage, @Nullable CoverageCounter branchCoverage) {
+
+    static final String INSTRUCTION_KIND = "instruction";
+    static final String BRANCH_KIND = "branch";
+    static final String UNAVAILABLE_KIND = "N/A";
+
+    CoverageData(int missedInstructions, int coveredInstructions) {
+        this(new CoverageCounter(missedInstructions, coveredInstructions), null);
+    }
+
+    CoverageData(int missedInstructions, int coveredInstructions, int missedBranches, int coveredBranches) {
+        this(
+                new CoverageCounter(missedInstructions, coveredInstructions),
+                new CoverageCounter(missedBranches, coveredBranches)
+        );
+    }
+
+    EffectiveCoverage effectiveCoverage() {
+        double instructionPercent = instructionCoverage.coveragePercent();
+        if (branchCoverage == null) {
+            return new EffectiveCoverage(instructionPercent, INSTRUCTION_KIND);
+        }
+
+        double branchPercent = branchCoverage.coveragePercent();
+        if (Double.compare(branchPercent, instructionPercent) < 0) {
+            return new EffectiveCoverage(branchPercent, BRANCH_KIND);
+        }
+        return new EffectiveCoverage(instructionPercent, INSTRUCTION_KIND);
+    }
 
     double coveragePercent() {
-        int total = missedInstructions + coveredInstructions;
+        return effectiveCoverage().percent();
+    }
+
+    String coverageKind() {
+        return effectiveCoverage().kind();
+    }
+}
+
+record CoverageCounter(int missed, int covered) {
+
+    double coveragePercent() {
+        int total = missed + covered;
         if (total == 0) {
             return 0.0;
         }
-        return (coveredInstructions * 100.0) / total;
+        return (covered * 100.0) / total;
     }
+}
+
+record EffectiveCoverage(double percent, String kind) {
 }
 

--- a/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
+++ b/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
@@ -32,8 +32,10 @@ final class CrapAnalyzer {
             String primaryClassName = classNameFromSource(file, source);
             List<MethodDescriptor> methods = JavaMethodParser.parse(primaryClassName, source);
             for (MethodDescriptor method : methods) {
-                Double coverage = lookupCoverage(coverageMap, method.className(), method.name(), method.startLine());
-                Double crap = CrapScore.calculate(method.complexity(), coverage);
+                EffectiveCoverage coverage = lookupCoverage(coverageMap, method.className(), method.name(), method.startLine());
+                Double coveragePercent = coverage == null ? null : coverage.percent();
+                String coverageKind = coverage == null ? CoverageData.UNAVAILABLE_KIND : coverage.kind();
+                Double crap = CrapScore.calculate(method.complexity(), coveragePercent);
                 metrics.add(new MethodMetrics(
                         method.name(),
                         method.className(),
@@ -41,7 +43,8 @@ final class CrapAnalyzer {
                         method.startLine(),
                         method.endLine(),
                         method.complexity(),
-                        coverage,
+                        coveragePercent,
+                        coverageKind,
                         crap
                 ));
             }
@@ -66,11 +69,11 @@ final class CrapAnalyzer {
         return matcher.group(1) + "." + simpleName;
     }
 
-    static @Nullable Double lookupCoverage(Map<String, CoverageData> coverageMap,
-                                           String className,
-                                           String methodName,
-                                           int line) {
-        Double exactCoverage = exactCoverage(coverageMap, className, methodName, line);
+    static @Nullable EffectiveCoverage lookupCoverage(Map<String, CoverageData> coverageMap,
+                                                      String className,
+                                                      String methodName,
+                                                      int line) {
+        EffectiveCoverage exactCoverage = exactCoverage(coverageMap, className, methodName, line);
         if (exactCoverage != null) {
             return exactCoverage;
         }
@@ -79,19 +82,19 @@ final class CrapAnalyzer {
         if (nearest == null) {
             return null;
         }
-        return nearest.coveragePercent();
+        return nearest.effectiveCoverage();
     }
 
-    static @Nullable Double exactCoverage(Map<String, CoverageData> coverageMap,
-                                          String className,
-                                          String methodName,
-                                          int line) {
+    static @Nullable EffectiveCoverage exactCoverage(Map<String, CoverageData> coverageMap,
+                                                     String className,
+                                                     String methodName,
+                                                     int line) {
         String exactKey = className + "#" + methodName + ":" + line;
         CoverageData exact = coverageMap.get(exactKey);
         if (exact == null) {
             return null;
         }
-        return exact.coveragePercent();
+        return exact.effectiveCoverage();
     }
 
     static @Nullable CoverageData nearestCoverage(Map<String, CoverageData> coverageMap,

--- a/core/src/main/java/media/barney/crap/core/CrapReport.java
+++ b/core/src/main/java/media/barney/crap/core/CrapReport.java
@@ -4,67 +4,20 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 record CrapReport(
-        int schemaVersion,
-        String tool,
-        double threshold,
-        String coverageKind,
-        ReportSummary summary,
+        String status,
         List<MethodReport> methods
 ) {
-    private static final int SCHEMA_VERSION = 1;
-    private static final String TOOL = "crap-java";
-    private static final String COVERAGE_KIND = "instruction";
-
     static CrapReport from(List<MethodMetrics> metrics, double threshold) {
         List<MethodReport> methods = metrics.stream()
                 .map(metric -> MethodReport.from(metric, threshold))
                 .toList();
-        return new CrapReport(
-                SCHEMA_VERSION,
-                TOOL,
-                threshold,
-                COVERAGE_KIND,
-                ReportSummary.from(methods),
-                methods
-        );
+        return new CrapReport(status(methods), methods);
     }
 
-    record ReportSummary(
-            String status,
-            int total,
-            int passed,
-            int failed,
-            int skipped,
-            @Nullable Double maxCrapScore
-    ) {
-        private static ReportSummary from(List<MethodReport> methods) {
-            int passed = 0;
-            int failed = 0;
-            int skipped = 0;
-            double max = 0.0;
-            boolean hasScore = false;
-            for (MethodReport method : methods) {
-                if (method.status() == MethodStatus.PASSED) {
-                    passed++;
-                } else if (method.status() == MethodStatus.FAILED) {
-                    failed++;
-                } else {
-                    skipped++;
-                }
-                if (method.crapScore() != null) {
-                    max = Math.max(max, method.crapScore());
-                    hasScore = true;
-                }
-            }
-            return new ReportSummary(
-                    failed > 0 ? "failed" : "passed",
-                    methods.size(),
-                    passed,
-                    failed,
-                    skipped,
-                    hasScore ? max : null
-            );
-        }
+    private static String status(List<MethodReport> methods) {
+        boolean failed = methods.stream()
+                .anyMatch(method -> method.status() == MethodStatus.FAILED);
+        return failed ? MethodStatus.FAILED.value() : MethodStatus.PASSED.value();
     }
 
     record MethodReport(
@@ -76,6 +29,8 @@ record CrapReport(
             int endLine,
             int complexity,
             @Nullable Double coveragePercent,
+            String coverageKind,
+            double threshold,
             @Nullable Double crapScore
     ) {
         private static MethodReport from(MethodMetrics metric, double threshold) {
@@ -88,6 +43,8 @@ record CrapReport(
                     metric.endLine(),
                     metric.complexity(),
                     metric.coveragePercent(),
+                    metric.coverageKind(),
+                    threshold,
                     metric.crapScore()
             );
         }

--- a/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
+++ b/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
@@ -66,7 +66,7 @@ final class JacocoCoverageParser {
             if (!(node instanceof Element method) || !"method".equals(method.getTagName())) {
                 continue;
             }
-            CoverageData data = readInstructionCoverage(method);
+            CoverageData data = readCoverage(method);
             if (data == null) {
                 continue;
             }
@@ -77,19 +77,30 @@ final class JacocoCoverageParser {
         }
     }
 
-    private static @Nullable CoverageData readInstructionCoverage(Element method) {
+    private static @Nullable CoverageData readCoverage(Element method) {
+        CoverageCounter instructionCoverage = null;
+        CoverageCounter branchCoverage = null;
         for (Node node = method.getFirstChild(); node != null; node = node.getNextSibling()) {
             if (!(node instanceof Element counter) || !"counter".equals(counter.getTagName())) {
                 continue;
             }
-            if (!"INSTRUCTION".equals(counter.getAttribute("type"))) {
-                continue;
+            String type = counter.getAttribute("type");
+            if ("INSTRUCTION".equals(type)) {
+                instructionCoverage = readCounter(counter);
+            } else if ("BRANCH".equals(type)) {
+                branchCoverage = readCounter(counter);
             }
-            int missed = parseInt(counter.getAttribute("missed"));
-            int covered = parseInt(counter.getAttribute("covered"));
-            return new CoverageData(missed, covered);
         }
-        return null;
+        if (instructionCoverage == null) {
+            return null;
+        }
+        return new CoverageData(instructionCoverage, branchCoverage);
+    }
+
+    private static CoverageCounter readCounter(Element counter) {
+        int missed = parseInt(counter.getAttribute("missed"));
+        int covered = parseInt(counter.getAttribute("covered"));
+        return new CoverageCounter(missed, covered);
     }
 
     private static int parseInt(String value) {

--- a/core/src/main/java/media/barney/crap/core/MethodMetrics.java
+++ b/core/src/main/java/media/barney/crap/core/MethodMetrics.java
@@ -10,6 +10,7 @@ record MethodMetrics(
         int endLine,
         int complexity,
         @Nullable Double coveragePercent,
+        String coverageKind,
         @Nullable Double crapScore
 ) {
 }

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -23,27 +23,32 @@ final class ReportFormatter {
 
     private static String formatText(CrapReport report) {
         List<CrapReport.MethodReport> sorted = sortedMethods(report.methods());
-        String header = String.format("%-8s %-30s %-35s %4s %7s %8s", "Status", "Method", "Class", "CC", "Cov%", "CRAP");
+        String header = String.format(
+                "%-8s %-30s %-35s %4s %7s %-11s %8s",
+                "Status",
+                "Method",
+                "Class",
+                "CC",
+                "Cov%",
+                "CovKind",
+                "CRAP"
+        );
         String separator = "-".repeat(header.length());
         StringBuilder builder = new StringBuilder();
         builder.append("CRAP Report\n");
         builder.append("===========\n");
-        builder.append("Coverage kind: ").append(report.coverageKind()).append('\n');
-        builder.append(String.format(Locale.ROOT, "Summary: %d total, %d passed, %d failed, %d skipped%n",
-                report.summary().total(),
-                report.summary().passed(),
-                report.summary().failed(),
-                report.summary().skipped()));
+        builder.append("Status: ").append(report.status()).append('\n');
         builder.append(header).append('\n');
         builder.append(separator).append('\n');
 
         for (CrapReport.MethodReport entry : sorted) {
-            builder.append(String.format(Locale.ROOT, "%-8s %-30s %-35s %4d %7s %8s",
+            builder.append(String.format(Locale.ROOT, "%-8s %-30s %-35s %4d %7s %-11s %8s",
                     entry.status().value(),
                     entry.methodName(),
                     entry.className(),
                     entry.complexity(),
                     formatCoverage(entry.coveragePercent()),
+                    entry.coverageKind(),
                     formatDisplayNumber(entry.crapScore())));
             builder.append('\n');
         }
@@ -54,18 +59,7 @@ final class ReportFormatter {
     private static String formatJson(CrapReport report) {
         StringBuilder builder = new StringBuilder();
         builder.append("{\n");
-        field(builder, 1, "schemaVersion", Integer.toString(report.schemaVersion()), true);
-        field(builder, 1, "tool", quote(report.tool()), true);
-        field(builder, 1, "threshold", number(report.threshold()), true);
-        field(builder, 1, "coverageKind", quote(report.coverageKind()), true);
-        builder.append("  \"summary\": {\n");
-        field(builder, 2, "status", quote(report.summary().status()), true);
-        field(builder, 2, "total", Integer.toString(report.summary().total()), true);
-        field(builder, 2, "passed", Integer.toString(report.summary().passed()), true);
-        field(builder, 2, "failed", Integer.toString(report.summary().failed()), true);
-        field(builder, 2, "skipped", Integer.toString(report.summary().skipped()), true);
-        field(builder, 2, "maxCrapScore", nullableNumber(report.summary().maxCrapScore()), false);
-        builder.append("  },\n");
+        field(builder, 1, "status", quote(report.status()), true);
         builder.append("  \"methods\": [\n");
         List<CrapReport.MethodReport> methods = sortedMethods(report.methods());
         for (int index = 0; index < methods.size(); index++) {
@@ -86,6 +80,8 @@ final class ReportFormatter {
         field(builder, 3, "endLine", Integer.toString(method.endLine()), true);
         field(builder, 3, "complexity", Integer.toString(method.complexity()), true);
         field(builder, 3, "coveragePercent", nullableNumber(method.coveragePercent()), true);
+        field(builder, 3, "coverageKind", quote(method.coverageKind()), true);
+        field(builder, 3, "threshold", number(method.threshold()), true);
         field(builder, 3, "crapScore", nullableNumber(method.crapScore()), false);
         builder.append("    }");
         if (comma) {
@@ -107,29 +103,36 @@ final class ReportFormatter {
 
     private static String formatJunit(CrapReport report) {
         StringBuilder builder = new StringBuilder();
+        int failed = countStatus(report.methods(), MethodStatus.FAILED);
+        int skipped = countStatus(report.methods(), MethodStatus.SKIPPED);
         builder.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-        builder.append("<testsuites tests=\"").append(report.summary().total())
-                .append("\" failures=\"").append(report.summary().failed())
-                .append("\" errors=\"0\" skipped=\"").append(report.summary().skipped())
+        builder.append("<testsuites tests=\"").append(report.methods().size())
+                .append("\" failures=\"").append(failed)
+                .append("\" errors=\"0\" skipped=\"").append(skipped)
                 .append("\" time=\"0\">\n");
-        builder.append("  <testsuite name=\"crap-java\" tests=\"").append(report.summary().total())
-                .append("\" failures=\"").append(report.summary().failed())
-                .append("\" errors=\"0\" skipped=\"").append(report.summary().skipped())
+        builder.append("  <testsuite name=\"crap-java\" tests=\"").append(report.methods().size())
+                .append("\" failures=\"").append(failed)
+                .append("\" errors=\"0\" skipped=\"").append(skipped)
                 .append("\" time=\"0\">\n");
-        builder.append("    <properties>\n");
-        property(builder, 3, "schemaVersion", Integer.toString(report.schemaVersion()));
-        property(builder, 3, "threshold", number(report.threshold()));
-        property(builder, 3, "coverageKind", report.coverageKind());
-        builder.append("    </properties>\n");
         for (CrapReport.MethodReport method : sortedMethods(report.methods())) {
-            testcase(builder, report, method);
+            testcase(builder, method);
         }
         builder.append("  </testsuite>\n");
         builder.append("</testsuites>\n");
         return builder.toString();
     }
 
-    private static void testcase(StringBuilder builder, CrapReport report, CrapReport.MethodReport method) {
+    private static int countStatus(List<CrapReport.MethodReport> methods, MethodStatus status) {
+        int count = 0;
+        for (CrapReport.MethodReport method : methods) {
+            if (method.status() == status) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static void testcase(StringBuilder builder, CrapReport.MethodReport method) {
         builder.append("    <testcase classname=\"").append(xml(method.className()))
                 .append("\" name=\"").append(xml(testcaseName(method)))
                 .append("\" file=\"").append(xml(method.sourcePath()))
@@ -143,14 +146,14 @@ final class ReportFormatter {
         property(builder, 4, "startLine", Integer.toString(method.startLine()));
         property(builder, 4, "endLine", Integer.toString(method.endLine()));
         property(builder, 4, "complexity", Integer.toString(method.complexity()));
-        property(builder, 4, "coverageKind", report.coverageKind());
+        property(builder, 4, "coverageKind", method.coverageKind());
         property(builder, 4, "coveragePercent", nullableProperty(method.coveragePercent()));
         property(builder, 4, "crapScore", nullableProperty(method.crapScore()));
-        property(builder, 4, "threshold", number(report.threshold()));
+        property(builder, 4, "threshold", number(method.threshold()));
         builder.append("      </properties>\n");
         if (method.status() == MethodStatus.FAILED) {
             String message = "CRAP threshold exceeded: "
-                    + formatDisplayNumber(method.crapScore()) + " > " + formatDisplayNumber(report.threshold());
+                    + formatDisplayNumber(method.crapScore()) + " > " + formatDisplayNumber(method.threshold());
             builder.append("      <failure message=\"").append(xml(message))
                     .append("\" type=\"crap-java.threshold\">")
                     .append(xml(message))

--- a/core/src/test/java/media/barney/crap/core/BuildToolSelectionTest.java
+++ b/core/src/test/java/media/barney/crap/core/BuildToolSelectionTest.java
@@ -1,0 +1,35 @@
+package media.barney.crap.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BuildToolSelectionTest {
+
+    @Test
+    void parsesKnownSelections() {
+        assertEquals(BuildToolSelection.AUTO, BuildToolSelection.parse("auto"));
+        assertEquals(BuildToolSelection.MAVEN, BuildToolSelection.parse("maven"));
+        assertEquals(BuildToolSelection.GRADLE, BuildToolSelection.parse("gradle"));
+        assertEquals(BuildToolSelection.GRADLE, BuildToolSelection.parse("GRADLE"));
+    }
+
+    @Test
+    void rejectsMissingBlankAndUnknownSelections() {
+        assertThrows(IllegalArgumentException.class, () -> BuildToolSelection.parse(null));
+        assertThrows(IllegalArgumentException.class, () -> BuildToolSelection.parse(" "));
+        assertThrows(IllegalArgumentException.class, () -> BuildToolSelection.parse("ant"));
+    }
+
+    @Test
+    void mapsConcreteSelectionsToBuildTools() {
+        assertEquals(BuildTool.MAVEN, BuildToolSelection.MAVEN.toBuildTool());
+        assertEquals(BuildTool.GRADLE, BuildToolSelection.GRADLE.toBuildTool());
+    }
+
+    @Test
+    void autoSelectionDoesNotMapToConcreteBuildTool() {
+        assertThrows(IllegalStateException.class, () -> BuildToolSelection.AUTO.toBuildTool());
+    }
+}

--- a/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
@@ -57,7 +57,7 @@ class CliApplicationTest {
                 .execute(new String[0]);
 
         assertEquals(0, exit);
-        assertTrue(utf8(out).contains("schemaVersion: 1"));
+        assertTrue(utf8(out).contains("status: passed"));
         assertTrue(utf8(out).contains("methods[0]"));
     }
 

--- a/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
+++ b/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
@@ -62,7 +62,84 @@ class CrapAnalyzerTest {
         assertEquals("demo.Sample", metric.className());
         assertEquals(2, metric.complexity());
         assertEquals(75.0, Objects.requireNonNull(metric.coveragePercent()), 0.001);
+        assertEquals("instruction", metric.coverageKind());
         assertEquals(2.0625, Objects.requireNonNull(metric.crapScore()), 0.00001);
+    }
+
+    @Test
+    void computesScoresFromBranchCoverageWhenBranchCoverageIsWorse() throws IOException {
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+                class Sample {
+                    int alpha(boolean a) {
+                        if (a) {
+                            return 1;
+                        }
+                        return 0;
+                    }
+                }
+                """);
+
+        Path jacoco = tempDir.resolve("jacoco.xml");
+        Files.writeString(jacoco, """
+                <report>
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="(Z)I" line="3">
+                        <counter type="INSTRUCTION" missed="1" covered="3"/>
+                        <counter type="BRANCH" missed="1" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        MethodMetrics metric = CrapAnalyzer.analyze(tempDir, List.of(source), jacoco).get(0);
+
+        assertEquals(50.0, Objects.requireNonNull(metric.coveragePercent()), 0.001);
+        assertEquals("branch", metric.coverageKind());
+        assertEquals(2.5, Objects.requireNonNull(metric.crapScore()), 0.00001);
+    }
+
+    @Test
+    void computesScoresFromInstructionCoverageWhenInstructionCoverageTies() throws IOException {
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+                class Sample {
+                    int alpha(boolean a) {
+                        if (a) {
+                            return 1;
+                        }
+                        return 0;
+                    }
+                }
+                """);
+
+        Path jacoco = tempDir.resolve("jacoco.xml");
+        Files.writeString(jacoco, """
+                <report>
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="(Z)I" line="3">
+                        <counter type="INSTRUCTION" missed="1" covered="1"/>
+                        <counter type="BRANCH" missed="1" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        MethodMetrics metric = CrapAnalyzer.analyze(tempDir, List.of(source), jacoco).get(0);
+
+        assertEquals(50.0, Objects.requireNonNull(metric.coveragePercent()), 0.001);
+        assertEquals("instruction", metric.coverageKind());
+        assertEquals(2.5, Objects.requireNonNull(metric.crapScore()), 0.00001);
     }
 
     @Test
@@ -133,10 +210,13 @@ class CrapAnalyzerTest {
 
         assertEquals("demo.Outer", Objects.requireNonNull(metricsByMethod.get("outer")).className());
         assertEquals(100.0, Objects.requireNonNull(Objects.requireNonNull(metricsByMethod.get("outer")).coveragePercent()), 0.001);
+        assertEquals("instruction", Objects.requireNonNull(metricsByMethod.get("outer")).coverageKind());
         assertEquals("demo.Outer$Inner", Objects.requireNonNull(metricsByMethod.get("inner")).className());
         assertEquals(100.0, Objects.requireNonNull(Objects.requireNonNull(metricsByMethod.get("inner")).coveragePercent()), 0.001);
+        assertEquals("instruction", Objects.requireNonNull(metricsByMethod.get("inner")).coverageKind());
         assertEquals("demo.Secondary", Objects.requireNonNull(metricsByMethod.get("beta")).className());
         assertEquals(100.0, Objects.requireNonNull(Objects.requireNonNull(metricsByMethod.get("beta")).coveragePercent()), 0.001);
+        assertEquals("instruction", Objects.requireNonNull(metricsByMethod.get("beta")).coverageKind());
     }
 
     @Test
@@ -146,9 +226,10 @@ class CrapAnalyzerTest {
                 "demo.Sample#alpha:12", new CoverageData(0, 8)
         );
 
-        Double coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 10);
+        EffectiveCoverage coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 10);
 
-        assertEquals(75.0, Objects.requireNonNull(coverage), 0.001);
+        assertEquals(75.0, Objects.requireNonNull(coverage).percent(), 0.001);
+        assertEquals("instruction", coverage.kind());
     }
 
     @Test
@@ -158,9 +239,22 @@ class CrapAnalyzerTest {
                 "demo.Sample#alpha:15", new CoverageData(0, 8)
         );
 
-        Double coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 13);
+        EffectiveCoverage coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 13);
 
-        assertEquals(100.0, Objects.requireNonNull(coverage), 0.001);
+        assertEquals(100.0, Objects.requireNonNull(coverage).percent(), 0.001);
+        assertEquals("instruction", coverage.kind());
+    }
+
+    @Test
+    void lookupCoverageReturnsBranchKindWhenBranchCoverageIsWorse() {
+        Map<String, CoverageData> coverageMap = Map.of(
+                "demo.Sample#alpha:10", new CoverageData(1, 9, 1, 1)
+        );
+
+        EffectiveCoverage coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 10);
+
+        assertEquals(50.0, Objects.requireNonNull(coverage).percent(), 0.001);
+        assertEquals("branch", coverage.kind());
     }
 
     @Test
@@ -176,7 +270,7 @@ class CrapAnalyzerTest {
 
     @Test
     void lookupCoverageReturnsNullWhenMethodHasNoCoverageEntries() {
-        Double coverage = CrapAnalyzer.lookupCoverage(Map.of(), "demo.Sample", "alpha", 10);
+        EffectiveCoverage coverage = CrapAnalyzer.lookupCoverage(Map.of(), "demo.Sample", "alpha", 10);
 
         assertNull(coverage);
     }

--- a/core/src/test/java/media/barney/crap/core/JacocoCoverageParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JacocoCoverageParserTest.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JacocoCoverageParserTest {
@@ -39,7 +40,117 @@ class JacocoCoverageParserTest {
         Map<String, CoverageData> result = JacocoCoverageParser.parse(xml);
 
         assertEquals(90.0, Objects.requireNonNull(result.get("demo.Sample#alpha:10")).coveragePercent(), 0.001);
+        assertEquals("instruction", Objects.requireNonNull(result.get("demo.Sample#alpha:10")).coverageKind());
         assertEquals(0.0, Objects.requireNonNull(result.get("demo.Sample#beta:20")).coveragePercent(), 0.001);
+        assertEquals("instruction", Objects.requireNonNull(result.get("demo.Sample#beta:20")).coverageKind());
+    }
+
+    @Test
+    void usesBranchCoverageWhenBranchCoverageIsWorse() throws IOException {
+        Path xml = tempDir.resolve("jacoco-branch-worse.xml");
+        Files.writeString(xml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()V" line="10">
+                        <counter type="INSTRUCTION" missed="1" covered="9"/>
+                        <counter type="BRANCH" missed="1" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        CoverageData result = Objects.requireNonNull(JacocoCoverageParser.parse(xml).get("demo.Sample#alpha:10"));
+
+        assertEquals(50.0, result.coveragePercent(), 0.001);
+        assertEquals("branch", result.coverageKind());
+    }
+
+    @Test
+    void usesInstructionCoverageWhenInstructionCoverageIsWorse() throws IOException {
+        Path xml = tempDir.resolve("jacoco-instruction-worse.xml");
+        Files.writeString(xml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()V" line="10">
+                        <counter type="INSTRUCTION" missed="1" covered="3"/>
+                        <counter type="BRANCH" missed="0" covered="2"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        CoverageData result = Objects.requireNonNull(JacocoCoverageParser.parse(xml).get("demo.Sample#alpha:10"));
+
+        assertEquals(75.0, result.coveragePercent(), 0.001);
+        assertEquals("instruction", result.coverageKind());
+    }
+
+    @Test
+    void usesInstructionCoverageWhenCoverageTies() throws IOException {
+        Path xml = tempDir.resolve("jacoco-tie.xml");
+        Files.writeString(xml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()V" line="10">
+                        <counter type="INSTRUCTION" missed="1" covered="1"/>
+                        <counter type="BRANCH" missed="1" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        CoverageData result = Objects.requireNonNull(JacocoCoverageParser.parse(xml).get("demo.Sample#alpha:10"));
+
+        assertEquals(50.0, result.coveragePercent(), 0.001);
+        assertEquals("instruction", result.coverageKind());
+    }
+
+    @Test
+    void zeroTotalCoverageUsesInstructionTieBreak() throws IOException {
+        Path xml = tempDir.resolve("jacoco-zero-total.xml");
+        Files.writeString(xml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()V" line="10">
+                        <counter type="INSTRUCTION" missed="0" covered="0"/>
+                        <counter type="BRANCH" missed="0" covered="0"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        CoverageData result = Objects.requireNonNull(JacocoCoverageParser.parse(xml).get("demo.Sample#alpha:10"));
+
+        assertEquals(0.0, result.coveragePercent(), 0.001);
+        assertEquals("instruction", result.coverageKind());
+    }
+
+    @Test
+    void skipsMethodsWithoutInstructionCounter() throws IOException {
+        Path xml = tempDir.resolve("jacoco-no-instruction.xml");
+        Files.writeString(xml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()V" line="10">
+                        <counter type="BRANCH" missed="0" covered="2"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        Map<String, CoverageData> result = JacocoCoverageParser.parse(xml);
+
+        assertNull(result.get("demo.Sample#alpha:10"));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -91,8 +91,8 @@ class MainTest {
         );
 
         assertEquals(0, exit);
-        assertTrue(utf8(out).contains("schemaVersion: 1"));
-        assertTrue(utf8(out).contains("coverageKind: instruction"));
+        assertTrue(utf8(out).contains("status: passed"));
+        assertTrue(utf8(out).contains("coverageKind"));
         assertTrue(utf8(out).contains("Sample"));
         assertTrue(utf8(out).contains("alpha"));
     }
@@ -317,9 +317,9 @@ class MainTest {
     @Test
     void maxCrapReturnsLargestNonNullScore() {
         List<MethodMetrics> metrics = List.of(
-                new MethodMetrics("alpha", "demo.Sample", "src/main/java/demo/Sample.java", 1, 2, 1, null, null),
-                new MethodMetrics("beta", "demo.Sample", "src/main/java/demo/Sample.java", 3, 4, 1, 75.0, 4.5),
-                new MethodMetrics("gamma", "demo.Sample", "src/main/java/demo/Sample.java", 5, 6, 1, 85.0, 7.0)
+                new MethodMetrics("alpha", "demo.Sample", "src/main/java/demo/Sample.java", 1, 2, 1, null, "N/A", null),
+                new MethodMetrics("beta", "demo.Sample", "src/main/java/demo/Sample.java", 3, 4, 1, 75.0, "instruction", 4.5),
+                new MethodMetrics("gamma", "demo.Sample", "src/main/java/demo/Sample.java", 5, 6, 1, 85.0, "instruction", 7.0)
         );
 
         assertEquals(7.0, Main.maxCrap(metrics));

--- a/core/src/test/java/media/barney/crap/core/ReportFormatTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatTest.java
@@ -1,0 +1,23 @@
+package media.barney.crap.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ReportFormatTest {
+
+    @Test
+    void parsesKnownFormats() {
+        assertEquals(ReportFormat.TOON, ReportFormat.parse("toon"));
+        assertEquals(ReportFormat.JSON, ReportFormat.parse("json"));
+        assertEquals(ReportFormat.TEXT, ReportFormat.parse("text"));
+        assertEquals(ReportFormat.JUNIT, ReportFormat.parse("junit"));
+        assertEquals(ReportFormat.JSON, ReportFormat.parse("JSON"));
+    }
+
+    @Test
+    void rejectsUnknownFormats() {
+        assertThrows(IllegalArgumentException.class, () -> ReportFormat.parse("yaml"));
+    }
+}

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -17,10 +17,11 @@ class ReportFormatterTest {
                 metric("bar", "demo.Sample", 9, 2, null, null)
         ), ReportFormat.TEXT);
 
-        assertTrue(report.contains("Coverage kind: instruction"));
-        assertTrue(report.contains("Summary: 2 total, 1 passed, 0 failed, 1 skipped"));
+        assertTrue(report.contains("Status: passed"));
+        assertTrue(report.contains("CovKind"));
         assertTrue(report.contains("passed"));
         assertTrue(report.contains("skipped"));
+        assertTrue(report.contains("instruction"));
         assertTrue(report.contains("85.0%"));
         assertTrue(report.contains("N/A"));
     }
@@ -34,18 +35,7 @@ class ReportFormatterTest {
 
         String expected = """
                 {
-                  "schemaVersion": 1,
-                  "tool": "crap-java",
-                  "threshold": 8.0,
-                  "coverageKind": "instruction",
-                  "summary": {
-                    "status": "failed",
-                    "total": 2,
-                    "passed": 0,
-                    "failed": 1,
-                    "skipped": 1,
-                    "maxCrapScore": 9.645
-                  },
+                  "status": "failed",
                   "methods": [
                     {
                       "status": "failed",
@@ -56,6 +46,8 @@ class ReportFormatterTest {
                       "endLine": 6,
                       "complexity": 5,
                       "coveragePercent": 10.0,
+                      "coverageKind": "instruction",
+                      "threshold": 8.0,
                       "crapScore": 9.645
                     },
                     {
@@ -67,6 +59,8 @@ class ReportFormatterTest {
                       "endLine": 22,
                       "complexity": 2,
                       "coveragePercent": null,
+                      "coverageKind": "N/A",
+                      "threshold": 8.0,
                       "crapScore": null
                     }
                   ]
@@ -83,11 +77,10 @@ class ReportFormatterTest {
                 metric("bar", "demo.Sample", 9, 2, null, null)
         ), ReportFormat.TOON);
 
-        assertTrue(report.contains("schemaVersion: 1"));
-        assertTrue(report.contains("coverageKind: instruction"));
-        assertTrue(report.contains("methods[2]{status,methodName,className,sourcePath,startLine,endLine,complexity,coveragePercent,crapScore}:"));
-        assertTrue(report.contains("passed,foo,demo.Sample,src/main/java/demo/Sample.java,4,6,3,85,4.5"));
-        assertTrue(report.contains("skipped,bar,demo.Sample,src/main/java/demo/Sample.java,9,11,2,null,null"));
+        assertTrue(report.contains("status: passed"));
+        assertTrue(report.contains("methods[2]{status,methodName,className,sourcePath,startLine,endLine,complexity,coveragePercent,coverageKind,threshold,crapScore}:"));
+        assertTrue(report.contains("passed,foo,demo.Sample,src/main/java/demo/Sample.java,4,6,3,85,instruction,8,4.5"));
+        assertTrue(report.contains("skipped,bar,demo.Sample,src/main/java/demo/Sample.java,9,11,2,null,N/A,8,null"));
     }
 
     @Test
@@ -99,6 +92,8 @@ class ReportFormatterTest {
 
         assertTrue(report.contains("<testsuites tests=\"2\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"instruction\"/>"));
+        assertTrue(report.contains("<property name=\"coverageKind\" value=\"N/A\"/>"));
+        assertTrue(report.contains("<property name=\"threshold\" value=\"8.0\"/>"));
         assertTrue(report.contains("<testcase classname=\"demo.Sample\" name=\"FAILED danger:4 CRAP 9.6\""));
         assertTrue(report.contains("<failure message=\"CRAP threshold exceeded: 9.6 &gt; 8.0\""));
         assertTrue(report.contains("<testcase classname=\"demo.Sample\" name=\"SKIPPED unknown:20 CRAP N/A\""));
@@ -115,6 +110,7 @@ class ReportFormatterTest {
                 2,
                 1,
                 100.0,
+                "instruction",
                 1.0
         );
 
@@ -133,6 +129,7 @@ class ReportFormatterTest {
                 2,
                 1,
                 100.0,
+                "instruction",
                 1.0
         );
 
@@ -159,6 +156,7 @@ class ReportFormatterTest {
                 startLine + 2,
                 complexity,
                 coverage,
+                coverage == null ? "N/A" : "instruction",
                 score
         );
     }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -111,7 +111,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .orElseThrow(() -> new GradleException("No configured Gradle module matches " + relativeSourcePath));
     }
 
-    private static boolean matchesModulePath(String relativeSourcePath, String modulePath) {
+    static boolean matchesModulePath(String relativeSourcePath, String modulePath) {
         if (".".equals(modulePath)) {
             return true;
         }

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,6 +86,26 @@ class CrapJavaGradlePluginTest {
 
         assertTrue(Files.exists(jacocoXml));
         assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
+    }
+
+    @Test
+    void rootModuleMatchesEverySourcePath() {
+        assertTrue(CrapJavaCheckTask.matchesModulePath("app/src/main/java/demo/Sample.java", "."));
+    }
+
+    @Test
+    void modulePathMatchesExactModuleRoot() {
+        assertTrue(CrapJavaCheckTask.matchesModulePath("app", "app"));
+    }
+
+    @Test
+    void modulePathMatchesNestedSourcePath() {
+        assertTrue(CrapJavaCheckTask.matchesModulePath("app/src/main/java/demo/Sample.java", "app"));
+    }
+
+    @Test
+    void modulePathDoesNotMatchPartialPathSegment() {
+        assertFalse(CrapJavaCheckTask.matchesModulePath("application/src/main/java/demo/Sample.java", "app"));
     }
 }
 


### PR DESCRIPTION
## Summary
- use the lower available JaCoCo method coverage between `INSTRUCTION` and `BRANCH` when calculating CRAP scores
- report method-level `coverageKind` as `instruction`, `branch`, or `N/A`
- simplify machine-readable reports to top-level `status` plus method entries

Closes #66

## Verification
- `mvn -B -pl core test`
- `mvn -B -pl cli -am package`
- `mvn -B -pl maven-plugin -am verify`
- `mvn -B verify`
- `gradle-plugin\\gradlew.bat test`