### PR TITLE
Make CRAP threshold configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - CRAP scoring now uses the worse method coverage out of JaCoCo instruction and branch counters, reporting the selected coverage kind per method.
 - Simplified machine-readable reports to a top-level status plus method-level entries.
+- CRAP threshold is now configurable through the CLI, Maven plugin, and Gradle plugin, and reports expose the threshold as a global value.
 
 ## 0.4.1 - 2026-04-08
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ java -jar cli/target/crap-java-cli-0.4.1.jar
 --format <format>     Write `toon`, `json`, `text`, or `junit` output (`toon` by default)
 --output <path>       Write the selected output format to a file instead of stdout
 --junit-report <path> Also write a JUnit XML report for CI test-report UIs
+--threshold <number>  Override the CRAP threshold (`8.0` by default)
 <file ...>            Analyze only these files
 <directory ...>       Analyze all Java files under each directory's nested src/main/java trees
 ```
@@ -125,6 +126,7 @@ java -jar cli/target/crap-java-cli-0.4.1.jar --format json
 java -jar cli/target/crap-java-cli-0.4.1.jar --format text
 java -jar cli/target/crap-java-cli-0.4.1.jar --format junit --output target/crap-java/TEST-crap-java.xml
 java -jar cli/target/crap-java-cli-0.4.1.jar --junit-report target/crap-java/TEST-crap-java.xml
+java -jar cli/target/crap-java-cli-0.4.1.jar --threshold 6
 java -jar cli/target/crap-java-cli-0.4.1.jar --build-tool maven module-a/src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.4.1.jar src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.4.1.jar module-a module-b
@@ -132,14 +134,22 @@ java -jar cli/target/crap-java-cli-0.4.1.jar module-a module-b
 
 The CLI writes only the requested report format to stdout, making the default
 TOON output suitable for agent workflows. Warnings and threshold errors are
-written to stderr. Machine-readable reports include a top-level `status`
-(`passed` or `failed`) and method-level `coverageKind` values identifying the
-coverage input used for each CRAP score (`instruction`, `branch`, or `N/A`).
+written to stderr. Machine-readable reports include top-level `status`
+(`passed` or `failed`) and `threshold` values, plus method-level
+`coverageKind` values identifying the coverage input used for each CRAP score
+(`instruction`, `branch`, or `N/A`).
+
+The default threshold is `8.0`. Values below `4.0` print a warning because they
+are likely too noisy; values above `8.0` print a warning because they are too
+lenient even for hard gates. The warning recommends `8.0` for hard gates,
+targeting `6.0` during implementation, and using the `8.0` default when in
+doubt.
 
 The JUnit XML format exposes each analyzed method as a testcase. Methods with
-CRAP scores over `8.0` fail, methods with unavailable coverage are skipped, and
-the testcase properties include the score, threshold, complexity, coverage
-percent, coverage kind, source path, and line range.
+CRAP scores over the configured threshold fail, methods with unavailable
+coverage are skipped, and the testsuite properties include the global
+threshold. Testcase properties include the score, complexity, coverage percent,
+coverage kind, source path, and line range.
 
 ## Distribution
 
@@ -170,6 +180,14 @@ Run:
 
 The Gradle task writes a JUnit XML report by default to
 `build/reports/crap-java/TEST-crap-java.xml`.
+
+Override the threshold in `build.gradle(.kts)`:
+
+```kotlin
+crapJava {
+    threshold.set(6.0)
+}
+```
 
 ### Maven Central Gradle Plugin
 
@@ -253,6 +271,12 @@ The Maven plugin writes a JUnit XML report by default to
 mvn verify -DcrapJava.junitReportPath=target/custom-crap-java.xml
 ```
 
+Override the threshold with:
+
+```bash
+mvn verify -DcrapJava.threshold=6.0
+```
+
 In GitLab CI, upload the generated XML with `artifacts:reports:junit`. In
 GitHub Actions, upload the file as an artifact or feed it into a JUnit
 test-report action.
@@ -261,7 +285,7 @@ test-report action.
 
 - `0` success, threshold respected
 - `1` invalid CLI usage
-- `2` CRAP threshold exceeded (`> 8.0`)
+- `2` CRAP threshold exceeded (`> configured threshold`)
 
 ## Contributing
 

--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -40,9 +40,10 @@ final class CliApplication {
         }
         CliArguments parsed = parse.arguments();
         try {
+            Main.writeThresholdWarning(err, parsed.threshold());
             List<Path> filesToAnalyze = filesForMode(parsed);
             if (filesToAnalyze.isEmpty()) {
-                CrapReport report = CrapReport.from(List.of(), ReportPublisher.THRESHOLD);
+                CrapReport report = CrapReport.from(List.of(), parsed.threshold());
                 ReportPublisher.publish(report, reportOptions(parsed), out);
                 return 0;
             }
@@ -50,12 +51,12 @@ final class CliApplication {
             List<MethodMetrics> metrics = analyzeByModule(filesToAnalyze, parsed.buildToolSelection());
             metrics.sort(Comparator.comparing(MethodMetrics::crapScore,
                     Comparator.nullsLast(Comparator.reverseOrder())));
-            CrapReport report = CrapReport.from(metrics, ReportPublisher.THRESHOLD);
+            CrapReport report = CrapReport.from(metrics, parsed.threshold());
             ReportPublisher.publish(report, reportOptions(parsed), out);
 
             double max = Main.maxCrap(metrics);
-            if (thresholdExceeded(max)) {
-                err.printf(Locale.ROOT, "CRAP threshold exceeded: %.1f > %.1f%n", max, ReportPublisher.THRESHOLD);
+            if (thresholdExceeded(max, parsed.threshold())) {
+                err.printf(Locale.ROOT, "CRAP threshold exceeded: %.1f > %.1f%n", max, parsed.threshold());
                 return 2;
             }
             return 0;
@@ -82,8 +83,8 @@ final class CliApplication {
         return metrics;
     }
 
-    static boolean thresholdExceeded(double max) {
-        return Double.compare(max, ReportPublisher.THRESHOLD) > 0;
+    static boolean thresholdExceeded(double max, double threshold) {
+        return Double.compare(max, threshold) > 0;
     }
 
     private ParseOutcome parseArguments(String[] args) {

--- a/core/src/main/java/media/barney/crap/core/CliArguments.java
+++ b/core/src/main/java/media/barney/crap/core/CliArguments.java
@@ -7,6 +7,7 @@ record CliArguments(
         CliMode mode,
         BuildToolSelection buildToolSelection,
         ReportFormat reportFormat,
+        double threshold,
         @Nullable String outputPath,
         @Nullable String junitReportPath,
         List<String> fileArgs

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -11,7 +11,15 @@ final class CliArgumentsParser {
 
     static CliArguments parse(String[] args) {
         if (args.length == 0) {
-            return new CliArguments(CliMode.ALL_SRC, BuildToolSelection.AUTO, ReportFormat.TOON, null, null, List.of());
+            return new CliArguments(
+                    CliMode.ALL_SRC,
+                    BuildToolSelection.AUTO,
+                    ReportFormat.TOON,
+                    Thresholds.DEFAULT,
+                    null,
+                    null,
+                    List.of()
+            );
         }
 
         ParseState state = parseState(args);
@@ -20,6 +28,7 @@ final class CliArgumentsParser {
                     CliMode.HELP,
                     state.buildToolSelection,
                     state.reportFormat,
+                    state.threshold,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -33,6 +42,7 @@ final class CliArgumentsParser {
                     CliMode.CHANGED_SRC,
                     state.buildToolSelection,
                     state.reportFormat,
+                    state.threshold,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -43,6 +53,7 @@ final class CliArgumentsParser {
                     CliMode.ALL_SRC,
                     state.buildToolSelection,
                     state.reportFormat,
+                    state.threshold,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -52,6 +63,7 @@ final class CliArgumentsParser {
                 CliMode.EXPLICIT_FILES,
                 state.buildToolSelection,
                 state.reportFormat,
+                state.threshold,
                 state.outputPath,
                 state.junitReportPath,
                 List.copyOf(values)
@@ -68,6 +80,14 @@ final class CliArgumentsParser {
 
     private static int parseArg(String[] args, int index, ParseStateBuilder state) {
         String arg = args[index];
+        if (!arg.startsWith("--")) {
+            state.values.add(arg);
+            return index;
+        }
+        return parseOption(args, index, state, arg);
+    }
+
+    private static int parseOption(String[] args, int index, ParseStateBuilder state, String arg) {
         if ("--help".equals(arg)) {
             state.help = true;
             return index;
@@ -96,11 +116,12 @@ final class CliArgumentsParser {
             state.junitReportPathSeen = true;
             return index + 1;
         }
-        if (arg.startsWith("--")) {
-            throw new IllegalArgumentException("Unknown option: " + arg);
+        if ("--threshold".equals(arg)) {
+            state.threshold = parseThreshold(args, index, state.thresholdSeen);
+            state.thresholdSeen = true;
+            return index + 1;
         }
-        state.values.add(arg);
-        return index;
+        throw new IllegalArgumentException("Unknown option: " + arg);
     }
 
     private static BuildToolSelection parseBuildTool(String[] args, int index, boolean buildToolSeen) {
@@ -133,6 +154,20 @@ final class CliArgumentsParser {
         return args[index + 1];
     }
 
+    private static double parseThreshold(String[] args, int index, boolean thresholdSeen) {
+        if (thresholdSeen) {
+            throw new IllegalArgumentException("--threshold can only be provided once");
+        }
+        if (index + 1 >= args.length) {
+            throw new IllegalArgumentException("--threshold requires a finite number greater than 0");
+        }
+        try {
+            return Thresholds.parse(args[index + 1]);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("--threshold requires a finite number greater than 0", ex);
+        }
+    }
+
     private static void ensureChangedIsNotCombined(boolean changed, List<String> values) {
         if (changed && !values.isEmpty()) {
             throw new IllegalArgumentException("--changed cannot be combined with file arguments");
@@ -143,6 +178,7 @@ final class CliArgumentsParser {
                               boolean changed,
                               BuildToolSelection buildToolSelection,
                               ReportFormat reportFormat,
+                              double threshold,
                               @Nullable String outputPath,
                               @Nullable String junitReportPath,
                               List<String> fileArgs) {
@@ -155,6 +191,8 @@ final class CliArgumentsParser {
         private boolean buildToolSeen;
         private ReportFormat reportFormat = ReportFormat.TOON;
         private boolean reportFormatSeen;
+        private double threshold = Thresholds.DEFAULT;
+        private boolean thresholdSeen;
         private @Nullable String outputPath;
         private boolean outputPathSeen;
         private @Nullable String junitReportPath;
@@ -162,7 +200,7 @@ final class CliArgumentsParser {
         private final List<String> values = new ArrayList<>();
 
         private ParseState build() {
-            return new ParseState(help, changed, buildToolSelection, reportFormat, outputPath, junitReportPath, values);
+            return new ParseState(help, changed, buildToolSelection, reportFormat, threshold, outputPath, junitReportPath, values);
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/CrapReport.java
+++ b/core/src/main/java/media/barney/crap/core/CrapReport.java
@@ -5,13 +5,15 @@ import org.jspecify.annotations.Nullable;
 
 record CrapReport(
         String status,
+        double threshold,
         List<MethodReport> methods
 ) {
     static CrapReport from(List<MethodMetrics> metrics, double threshold) {
+        double validatedThreshold = Thresholds.validate(threshold);
         List<MethodReport> methods = metrics.stream()
-                .map(metric -> MethodReport.from(metric, threshold))
+                .map(metric -> MethodReport.from(metric, validatedThreshold))
                 .toList();
-        return new CrapReport(status(methods), methods);
+        return new CrapReport(status(methods), validatedThreshold, methods);
     }
 
     private static String status(List<MethodReport> methods) {
@@ -30,7 +32,6 @@ record CrapReport(
             int complexity,
             @Nullable Double coveragePercent,
             String coverageKind,
-            double threshold,
             @Nullable Double crapScore
     ) {
         private static MethodReport from(MethodMetrics metric, double threshold) {
@@ -44,7 +45,6 @@ record CrapReport(
                     metric.complexity(),
                     metric.coveragePercent(),
                     metric.coverageKind(),
-                    threshold,
                     metric.crapScore()
             );
         }

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -9,6 +9,8 @@ import java.util.Locale;
 
 public final class Main {
 
+    public static final double DEFAULT_THRESHOLD = Thresholds.DEFAULT;
+
     private Main() {
     }
 
@@ -26,7 +28,14 @@ public final class Main {
     public static int runWithExistingCoverage(List<ResolvedCoverageModule> modules,
                                               PrintStream out,
                                               PrintStream err) throws Exception {
-        return runResolvedModules(modules, commonRoot(modules), out, err, ReportOptions.textWithOptionalJunit(null));
+        return runResolvedModules(
+                modules,
+                commonRoot(modules),
+                out,
+                err,
+                ReportOptions.textWithOptionalJunit(null),
+                DEFAULT_THRESHOLD
+        );
     }
 
     public static int runWithExistingCoverage(List<ResolvedCoverageModule> modules,
@@ -34,12 +43,22 @@ public final class Main {
                                               PrintStream out,
                                               PrintStream err,
                                               Path junitReportPath) throws Exception {
+        return runWithExistingCoverage(modules, reportRoot, out, err, junitReportPath, DEFAULT_THRESHOLD);
+    }
+
+    public static int runWithExistingCoverage(List<ResolvedCoverageModule> modules,
+                                              Path reportRoot,
+                                              PrintStream out,
+                                              PrintStream err,
+                                              Path junitReportPath,
+                                              double threshold) throws Exception {
         return runResolvedModules(
                 modules,
                 reportRoot.toAbsolutePath().normalize(),
                 out,
                 err,
-                ReportOptions.textWithOptionalJunit(junitReportPath.toAbsolutePath().normalize())
+                ReportOptions.textWithOptionalJunit(junitReportPath.toAbsolutePath().normalize()),
+                threshold
         );
     }
 
@@ -68,7 +87,10 @@ public final class Main {
                                           Path reportRoot,
                                           PrintStream out,
                                           PrintStream err,
-                                          ReportOptions reportOptions) throws Exception {
+                                          ReportOptions reportOptions,
+                                          double threshold) throws Exception {
+        Thresholds.validate(threshold);
+        writeThresholdWarning(err, threshold);
         List<MethodMetrics> metrics = new ArrayList<>();
         for (ResolvedCoverageModule module : modules) {
             if (module.sourceFiles().isEmpty()) {
@@ -80,12 +102,12 @@ public final class Main {
             metrics.addAll(CrapAnalyzer.analyze(reportRoot, module.sourceFiles(), module.coverageReport()));
         }
 
-        CrapReport report = CrapReport.from(metrics, ReportPublisher.THRESHOLD);
+        CrapReport report = CrapReport.from(metrics, threshold);
         ReportPublisher.publish(report, reportOptions, out);
 
         double max = Main.maxCrap(metrics);
-        if (CliApplication.thresholdExceeded(max)) {
-            err.printf(Locale.ROOT, "CRAP threshold exceeded: %.1f > %.1f%n", max, ReportPublisher.THRESHOLD);
+        if (CliApplication.thresholdExceeded(max, threshold)) {
+            err.printf(Locale.ROOT, "CRAP threshold exceeded: %.1f > %.1f%n", max, threshold);
             return 2;
         }
         return 0;
@@ -101,9 +123,17 @@ public final class Main {
                   crap-java --format json                 Write report as toon, json, text, or junit (default: toon)
                   crap-java --output report.toon          Write the selected report format to a file
                   crap-java --junit-report report.xml     Also write a JUnit XML report for CI
+                  crap-java --threshold 6                 Override the CRAP threshold (default: 8.0)
                   crap-java <path...>                     Analyze files, or for directory args analyze nested src/main/java trees under each path
                   crap-java --help                        Print this help message
                 """;
+    }
+
+    static void writeThresholdWarning(PrintStream err, double threshold) {
+        String warning = Thresholds.warning(threshold);
+        if (!warning.isEmpty()) {
+            err.println(warning);
+        }
     }
 
     private static Path commonRoot(List<ResolvedCoverageModule> modules) {

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -38,6 +38,7 @@ final class ReportFormatter {
         builder.append("CRAP Report\n");
         builder.append("===========\n");
         builder.append("Status: ").append(report.status()).append('\n');
+        builder.append("Threshold: ").append(formatDisplayNumber(report.threshold())).append('\n');
         builder.append(header).append('\n');
         builder.append(separator).append('\n');
 
@@ -60,6 +61,7 @@ final class ReportFormatter {
         StringBuilder builder = new StringBuilder();
         builder.append("{\n");
         field(builder, 1, "status", quote(report.status()), true);
+        field(builder, 1, "threshold", number(report.threshold()), true);
         builder.append("  \"methods\": [\n");
         List<CrapReport.MethodReport> methods = sortedMethods(report.methods());
         for (int index = 0; index < methods.size(); index++) {
@@ -81,7 +83,6 @@ final class ReportFormatter {
         field(builder, 3, "complexity", Integer.toString(method.complexity()), true);
         field(builder, 3, "coveragePercent", nullableNumber(method.coveragePercent()), true);
         field(builder, 3, "coverageKind", quote(method.coverageKind()), true);
-        field(builder, 3, "threshold", number(method.threshold()), true);
         field(builder, 3, "crapScore", nullableNumber(method.crapScore()), false);
         builder.append("    }");
         if (comma) {
@@ -114,8 +115,11 @@ final class ReportFormatter {
                 .append("\" failures=\"").append(failed)
                 .append("\" errors=\"0\" skipped=\"").append(skipped)
                 .append("\" time=\"0\">\n");
+        builder.append("    <properties>\n");
+        property(builder, 3, "threshold", number(report.threshold()));
+        builder.append("    </properties>\n");
         for (CrapReport.MethodReport method : sortedMethods(report.methods())) {
-            testcase(builder, method);
+            testcase(builder, method, report.threshold());
         }
         builder.append("  </testsuite>\n");
         builder.append("</testsuites>\n");
@@ -132,7 +136,7 @@ final class ReportFormatter {
         return count;
     }
 
-    private static void testcase(StringBuilder builder, CrapReport.MethodReport method) {
+    private static void testcase(StringBuilder builder, CrapReport.MethodReport method, double threshold) {
         builder.append("    <testcase classname=\"").append(xml(method.className()))
                 .append("\" name=\"").append(xml(testcaseName(method)))
                 .append("\" file=\"").append(xml(method.sourcePath()))
@@ -149,11 +153,10 @@ final class ReportFormatter {
         property(builder, 4, "coverageKind", method.coverageKind());
         property(builder, 4, "coveragePercent", nullableProperty(method.coveragePercent()));
         property(builder, 4, "crapScore", nullableProperty(method.crapScore()));
-        property(builder, 4, "threshold", number(method.threshold()));
         builder.append("      </properties>\n");
         if (method.status() == MethodStatus.FAILED) {
             String message = "CRAP threshold exceeded: "
-                    + formatDisplayNumber(method.crapScore()) + " > " + formatDisplayNumber(method.threshold());
+                    + formatDisplayNumber(method.crapScore()) + " > " + formatDisplayNumber(threshold);
             builder.append("      <failure message=\"").append(xml(message))
                     .append("\" type=\"crap-java.threshold\">")
                     .append(xml(message))

--- a/core/src/main/java/media/barney/crap/core/ReportPublisher.java
+++ b/core/src/main/java/media/barney/crap/core/ReportPublisher.java
@@ -8,8 +8,6 @@ import java.nio.file.Path;
 
 final class ReportPublisher {
 
-    static final double THRESHOLD = 8.0;
-
     private ReportPublisher() {
     }
 

--- a/core/src/main/java/media/barney/crap/core/Thresholds.java
+++ b/core/src/main/java/media/barney/crap/core/Thresholds.java
@@ -1,0 +1,49 @@
+package media.barney.crap.core;
+
+final class Thresholds {
+
+    static final double DEFAULT = 8.0;
+
+    private Thresholds() {
+    }
+
+    static double parse(String value) {
+        try {
+            return validate(Double.parseDouble(value));
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Threshold must be a finite number greater than 0", ex);
+        }
+    }
+
+    static double validate(double value) {
+        if (!Double.isFinite(value) || Double.compare(value, 0.0) <= 0) {
+            throw new IllegalArgumentException("Threshold must be a finite number greater than 0");
+        }
+        return value;
+    }
+
+    static boolean isLikelyTooNoisy(double value) {
+        return Double.compare(value, 4.0) < 0;
+    }
+
+    static boolean isTooLenient(double value) {
+        return Double.compare(value, DEFAULT) > 0;
+    }
+
+    static String warning(double value) {
+        if (isLikelyTooNoisy(value)) {
+            return "Warning: CRAP threshold below 4.0 is likely too noisy. "
+                    + recommendation();
+        }
+        if (isTooLenient(value)) {
+            return "Warning: CRAP threshold above 8.0 is too lenient even for hard gates. "
+                    + recommendation();
+        }
+        return "";
+    }
+
+    private static String recommendation() {
+        return "Use 8.0 for hard gates, target 6.0 during implementation, "
+                + "and use the 8.0 default when in doubt.";
+    }
+}

--- a/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
@@ -224,9 +224,87 @@ class CliApplicationTest {
     }
 
     @Test
-    void thresholdExceededUsesStrictlyGreaterThanEight() {
-        assertFalse(CliApplication.thresholdExceeded(8.0));
-        assertTrue(CliApplication.thresholdExceeded(8.1));
+    void thresholdExceededUsesStrictlyGreaterThanConfiguredValue() {
+        assertFalse(CliApplication.thresholdExceeded(6.0, 6.0));
+        assertTrue(CliApplication.thresholdExceeded(6.1, 6.0));
+    }
+
+    @Test
+    void customThresholdControlsExitCode() throws Exception {
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int alpha(boolean left, boolean right) {
+                        if (left) {
+                            return 1;
+                        }
+                        if (right) {
+                            return 2;
+                        }
+                        return 0;
+                    }
+                }
+                """);
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        CoverageRunner coverageRunner = new CoverageRunner((command, directory) -> {
+            Files.createDirectories(jacocoXml.getParent());
+            Files.writeString(jacocoXml, """
+                    <report name="demo">
+                      <package name="demo">
+                        <class name="demo/Sample" sourcefilename="Sample.java">
+                          <method name="alpha" desc="(ZZ)I" line="4">
+                            <counter type="INSTRUCTION" missed="1" covered="1"/>
+                          </method>
+                        </class>
+                      </package>
+                    </report>
+                    """);
+            return 0;
+        });
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), coverageRunner, CoverageMode.GENERATE)
+                .execute(new String[]{"--format", "text", "--threshold", "4.0", "src/main/java/demo/Sample.java"});
+
+        assertEquals(2, exit);
+        assertTrue(utf8(out).contains("Threshold: 4.0"));
+        assertTrue(utf8(err).contains("CRAP threshold exceeded: 4.1 > 4.0"));
+    }
+
+    @Test
+    void warnsForThresholdsLikelyTooNoisyOrTooLenient() throws Exception {
+        ByteArrayOutputStream noisyErr = new ByteArrayOutputStream();
+        ByteArrayOutputStream lenientErr = new ByteArrayOutputStream();
+
+        new CliApplication(tempDir, new PrintStream(new ByteArrayOutputStream()), new PrintStream(noisyErr), NOOP_COVERAGE, CoverageMode.GENERATE)
+                .execute(new String[]{"--threshold", "3.9"});
+        new CliApplication(tempDir, new PrintStream(new ByteArrayOutputStream()), new PrintStream(lenientErr), NOOP_COVERAGE, CoverageMode.GENERATE)
+                .execute(new String[]{"--threshold", "8.1"});
+
+        assertTrue(utf8(noisyErr).contains("threshold below 4.0 is likely too noisy"));
+        assertTrue(utf8(noisyErr).contains("Use 8.0 for hard gates, target 6.0 during implementation"));
+        assertTrue(utf8(lenientErr).contains("threshold above 8.0 is too lenient even for hard gates"));
+        assertTrue(utf8(lenientErr).contains("8.0 default when in doubt"));
+    }
+
+    @Test
+    void doesNotWarnForRecommendedThresholdBoundaries() throws Exception {
+        ByteArrayOutputStream fourErr = new ByteArrayOutputStream();
+        ByteArrayOutputStream eightErr = new ByteArrayOutputStream();
+
+        new CliApplication(tempDir, new PrintStream(new ByteArrayOutputStream()), new PrintStream(fourErr), NOOP_COVERAGE, CoverageMode.GENERATE)
+                .execute(new String[]{"--threshold", "4.0"});
+        new CliApplication(tempDir, new PrintStream(new ByteArrayOutputStream()), new PrintStream(eightErr), NOOP_COVERAGE, CoverageMode.GENERATE)
+                .execute(new String[]{"--threshold", "8.0"});
+
+        assertEquals("", utf8(fourErr));
+        assertEquals("", utf8(eightErr));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -15,6 +15,7 @@ class CliArgumentsParserTest {
         assertEquals(CliMode.ALL_SRC, args.mode());
         assertEquals(BuildToolSelection.AUTO, args.buildToolSelection());
         assertEquals(ReportFormat.TOON, args.reportFormat());
+        assertEquals(Main.DEFAULT_THRESHOLD, args.threshold());
     }
 
     @Test
@@ -57,6 +58,7 @@ class CliArgumentsParserTest {
         });
 
         assertEquals(ReportFormat.JSON, args.reportFormat());
+        assertEquals(Main.DEFAULT_THRESHOLD, args.threshold());
         assertEquals("target/crap-java/report.json", args.outputPath());
         assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
         assertEquals(List.of("src/main/java/demo/A.java"), args.fileArgs());
@@ -78,6 +80,40 @@ class CliArgumentsParserTest {
     void reportFormatCanOnlyBeProvidedOnce() {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--format", "json", "--format", "toon"}));
+    }
+
+    @Test
+    void thresholdIsParsed() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{"--threshold", "6.0", "--changed"});
+
+        assertEquals(CliMode.CHANGED_SRC, args.mode());
+        assertEquals(6.0, args.threshold());
+    }
+
+    @Test
+    void thresholdRequiresValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--threshold"}));
+    }
+
+    @Test
+    void thresholdCanOnlyBeProvidedOnce() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--threshold", "6", "--threshold", "8"}));
+    }
+
+    @Test
+    void thresholdRequiresFinitePositiveNumber() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--threshold", "0"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--threshold", "-1"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--threshold", "NaN"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--threshold", "Infinity"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--threshold", "low"}));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -32,6 +32,7 @@ class MainTest {
         assertTrue(utf8(out).contains("Usage:"));
         assertTrue(utf8(out).contains("--build-tool"));
         assertTrue(utf8(out).contains("--format"));
+        assertTrue(utf8(out).contains("--threshold"));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -18,6 +18,7 @@ class ReportFormatterTest {
         ), ReportFormat.TEXT);
 
         assertTrue(report.contains("Status: passed"));
+        assertTrue(report.contains("Threshold: 8.0"));
         assertTrue(report.contains("CovKind"));
         assertTrue(report.contains("passed"));
         assertTrue(report.contains("skipped"));
@@ -36,6 +37,7 @@ class ReportFormatterTest {
         String expected = """
                 {
                   "status": "failed",
+                  "threshold": 8.0,
                   "methods": [
                     {
                       "status": "failed",
@@ -47,7 +49,6 @@ class ReportFormatterTest {
                       "complexity": 5,
                       "coveragePercent": 10.0,
                       "coverageKind": "instruction",
-                      "threshold": 8.0,
                       "crapScore": 9.645
                     },
                     {
@@ -60,7 +61,6 @@ class ReportFormatterTest {
                       "complexity": 2,
                       "coveragePercent": null,
                       "coverageKind": "N/A",
-                      "threshold": 8.0,
                       "crapScore": null
                     }
                   ]
@@ -78,9 +78,10 @@ class ReportFormatterTest {
         ), ReportFormat.TOON);
 
         assertTrue(report.contains("status: passed"));
-        assertTrue(report.contains("methods[2]{status,methodName,className,sourcePath,startLine,endLine,complexity,coveragePercent,coverageKind,threshold,crapScore}:"));
-        assertTrue(report.contains("passed,foo,demo.Sample,src/main/java/demo/Sample.java,4,6,3,85,instruction,8,4.5"));
-        assertTrue(report.contains("skipped,bar,demo.Sample,src/main/java/demo/Sample.java,9,11,2,null,N/A,8,null"));
+        assertTrue(report.contains("threshold: 8"));
+        assertTrue(report.contains("methods[2]{status,methodName,className,sourcePath,startLine,endLine,complexity,coveragePercent,coverageKind,crapScore}:"));
+        assertTrue(report.contains("passed,foo,demo.Sample,src/main/java/demo/Sample.java,4,6,3,85,instruction,4.5"));
+        assertTrue(report.contains("skipped,bar,demo.Sample,src/main/java/demo/Sample.java,9,11,2,null,N/A,null"));
     }
 
     @Test
@@ -91,9 +92,9 @@ class ReportFormatterTest {
         ), ReportFormat.JUNIT);
 
         assertTrue(report.contains("<testsuites tests=\"2\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(report.contains("    <property name=\"threshold\" value=\"8.0\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"instruction\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"N/A\"/>"));
-        assertTrue(report.contains("<property name=\"threshold\" value=\"8.0\"/>"));
         assertTrue(report.contains("<testcase classname=\"demo.Sample\" name=\"FAILED danger:4 CRAP 9.6\""));
         assertTrue(report.contains("<failure message=\"CRAP threshold exceeded: 9.6 &gt; 8.0\""));
         assertTrue(report.contains("<testcase classname=\"demo.Sample\" name=\"SKIPPED unknown:20 CRAP N/A\""));
@@ -139,7 +140,7 @@ class ReportFormatterTest {
     }
 
     private static CrapReport report(MethodMetrics... metrics) {
-        return CrapReport.from(List.of(metrics), ReportPublisher.THRESHOLD);
+        return CrapReport.from(List.of(metrics), Main.DEFAULT_THRESHOLD);
     }
 
     private static MethodMetrics metric(String method,

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -7,6 +7,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -40,6 +41,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     @Input
     public abstract MapProperty<String, String> getModuleCoverageReports();
 
+    @Input
+    public abstract Property<Double> getThreshold();
+
     @OutputFile
     public abstract RegularFileProperty getJunitReport();
 
@@ -54,14 +58,14 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (sourceFiles.isEmpty()) {
             try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
                  var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
-                Main.runWithExistingCoverage(List.of(), analysisRoot, out, err, junitReport);
+                Main.runWithExistingCoverage(List.of(), analysisRoot, out, err, junitReport, getThreshold().get());
             }
             return;
         }
         List<Main.ResolvedCoverageModule> modules = resolvedModules(sourceFiles);
         try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
              var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
-            int exit = Main.runWithExistingCoverage(modules, analysisRoot, out, err, junitReport);
+            int exit = Main.runWithExistingCoverage(modules, analysisRoot, out, err, junitReport, getThreshold().get());
             if (exit != 0) {
                 throw new GradleException("crap-java-check failed with exit " + exit);
             }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaExtension.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaExtension.java
@@ -1,0 +1,8 @@
+package media.barney.crap.gradle;
+
+import org.gradle.api.provider.Property;
+
+public abstract class CrapJavaExtension {
+
+    public abstract Property<Double> getThreshold();
+}

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
@@ -1,5 +1,6 @@
 package media.barney.crap.gradle;
 
+import media.barney.crap.core.Main;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskProvider;
@@ -17,6 +18,9 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        CrapJavaExtension extension = project.getExtensions().create("crapJava", CrapJavaExtension.class);
+        extension.getThreshold().convention(Main.DEFAULT_THRESHOLD);
+
         TaskProvider<CrapJavaCheckTask> checkTask = project.getTasks().register(
                 "crap-java-check",
                 CrapJavaCheckTask.class,
@@ -24,6 +28,7 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
                     task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
                     task.setDescription("Runs the crap-java CRAP metric gate.");
                     task.getAnalysisRoot().set(project.getLayout().getProjectDirectory());
+                    task.getThreshold().convention(extension.getThreshold());
                     task.getJunitReport().convention(project.getLayout().getBuildDirectory()
                             .file("reports/crap-java/TEST-crap-java.xml"));
                 }

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -166,6 +166,22 @@ class CrapJavaGradlePluginFunctionalTest {
         assertTrue(outcome == TaskOutcome.SUCCESS || outcome == TaskOutcome.UP_TO_DATE);
     }
 
+    @Test
+    void configuredThresholdIsWrittenToJunitReport() throws Exception {
+        writeSingleModuleProject("""
+
+                crapJava {
+                    threshold.set(6.0)
+                }
+                """);
+
+        BuildResult result = runBuild("crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
+        assertTrue(Files.readString(tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml"))
+                .contains("<property name=\"threshold\" value=\"6.0\"/>"));
+    }
+
     private BuildResult runBuild(String... arguments) {
         List<String> gradleArguments = new ArrayList<>();
         gradleArguments.add("-Dgradle.user.home=" + tempDir.resolve("gradle-user-home"));
@@ -179,6 +195,10 @@ class CrapJavaGradlePluginFunctionalTest {
     }
 
     private void writeSingleModuleProject() throws IOException {
+        writeSingleModuleProject("");
+    }
+
+    private void writeSingleModuleProject(String extraBuildScript) throws IOException {
         writeFile("settings.gradle.kts", "rootProject.name = \"demo\"");
         writeFile("build.gradle.kts", """
                 plugins {
@@ -198,7 +218,7 @@ class CrapJavaGradlePluginFunctionalTest {
                 tasks.test {
                     useJUnitPlatform()
                 }
-                """);
+                """ + extraBuildScript);
         writeFile("src/main/java/demo/Sample.java", """
                 package demo;
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -30,9 +30,12 @@ class CrapJavaGradlePluginTest {
         project.getPluginManager().apply(CrapJavaGradlePlugin.class);
 
         CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
+        CrapJavaExtension extension = project.getExtensions().getByType(CrapJavaExtension.class);
 
         assertEquals("verification", checkTask.getGroup());
         assertEquals("Runs the crap-java CRAP metric gate.", checkTask.getDescription());
+        assertEquals(8.0, extension.getThreshold().get());
+        assertEquals(8.0, checkTask.getThreshold().get());
         Set<String> dependencyNames = checkTask.getTaskDependencies().getDependencies(checkTask).stream()
                 .map(Task::getName)
                 .collect(Collectors.toSet());
@@ -42,6 +45,19 @@ class CrapJavaGradlePluginTest {
                 .replace('\\', '/')
                 .endsWith("build/reports/crap-java/TEST-crap-java.xml"));
         assertNotNull(project.getTasks().findByName("jacocoTestReport"));
+    }
+
+    @Test
+    void configuredExtensionThresholdFlowsToCheckTask() {
+        Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+
+        project.getPluginManager().apply("java");
+        project.getPluginManager().apply(CrapJavaGradlePlugin.class);
+        project.getExtensions().getByType(CrapJavaExtension.class).getThreshold().set(6.0);
+
+        CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
+
+        assertEquals(6.0, checkTask.getThreshold().get());
     }
 
     @Test
@@ -79,6 +95,7 @@ class CrapJavaGradlePluginTest {
         task.getAnalysisSources().from(source);
         task.getCoverageReports().from(jacocoXml);
         task.getModuleCoverageReports().put(".", "build/reports/jacoco/test/jacocoTestReport.xml");
+        task.getThreshold().set(8.0);
         Path junitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
         task.getJunitReport().fileValue(junitReport.toFile());
 

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -34,6 +34,9 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     @Parameter(property = "crapJava.junitReportPath")
     private @Nullable File junitReportPath;
 
+    @Parameter(property = "crapJava.threshold", defaultValue = "8.0")
+    private double threshold = Main.DEFAULT_THRESHOLD;
+
     public CrapJavaCheckMojo() {
         this((useExistingCoverage, args, projectRoot, out, err) -> useExistingCoverage
                 ? Main.runWithExistingCoverage(args, projectRoot, out, err)
@@ -77,6 +80,8 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         return new String[]{
                 "--format",
                 "text",
+                "--threshold",
+                Double.toString(threshold),
                 "--junit-report",
                 junitReportPath(executionRoot).toString()
         };

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -64,6 +64,8 @@ class CrapJavaCheckMojoTest {
         assertEquals(List.of(
                 "--format",
                 "text",
+                "--threshold",
+                "8.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));
@@ -83,7 +85,30 @@ class CrapJavaCheckMojoTest {
 
         mojo.execute();
 
-        assertEquals(List.of("--format", "text", "--junit-report", report.toString()), List.of(runner.args));
+        assertEquals(List.of("--format", "text", "--threshold", "8.0", "--junit-report", report.toString()), List.of(runner.args));
+    }
+
+    @Test
+    void usesConfiguredThreshold() throws Exception {
+        Path root = tempDir.resolve("root");
+        writeCoverageReport(root);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        setField(mojo, "session", session(List.of(project(root, "root")), root));
+        setField(mojo, "project", project(root, "root"));
+        setField(mojo, "threshold", 6.0);
+
+        mojo.execute();
+
+        assertEquals(List.of(
+                "--format",
+                "text",
+                "--threshold",
+                "6.0",
+                "--junit-report",
+                root.resolve("target/crap-java/TEST-crap-java.xml").toString()
+        ), List.of(runner.args));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add configurable CRAP threshold support for CLI, Maven, and Gradle
- move threshold to the global report level for text, JSON, TOON, and JUnit
- add validation and warning behavior for invalid, noisy, and lenient thresholds

## Verification
- `mvn -B -pl cli -am package`
- `mvn -B -pl maven-plugin -am verify`
- `mvn -B verify`
- `cd gradle-plugin && ./gradlew test`
- `java -jar cli/target/crap-java-cli-0.4.1.jar --format text --junit-report target/crap-java/TEST-crap-java-maven-sources.xml --build-tool maven core/src/main/java cli/src/main/java maven-plugin/src/main/java`
- `java -jar cli/target/crap-java-cli-0.4.1.jar --format text --junit-report target/crap-java/TEST-crap-java-gradle-plugin.xml --build-tool gradle gradle-plugin/src/main/java`

Closes #69