### PR TITLE
Add compact agent output mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - CRAP scoring now uses the worse method coverage out of JaCoCo instruction and branch counters, reporting the selected coverage kind per method.
 - Simplified machine-readable reports to a top-level status plus method-level entries.
 - CRAP threshold is now configurable through the CLI, Maven plugin, and Gradle plugin, and reports expose the threshold as a global value.
+- Added CLI agent mode for compact failures-only primary output while keeping sidecar JUnit reports complete.
 
 ## 0.4.1 - 2026-04-08
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ java -jar cli/target/crap-java-cli-0.4.1.jar
 --changed             Analyze changed Java files under any nested src/main/java tree
 --build-tool <tool>   Force `auto`, `maven`, or `gradle`
 --format <format>     Write `toon`, `json`, `text`, or `junit` output (`toon` by default)
+--agent               Write compact primary output for agents (failures only)
 --output <path>       Write the selected output format to a file instead of stdout
 --junit-report <path> Also write a JUnit XML report for CI test-report UIs
 --threshold <number>  Override the CRAP threshold (`8.0` by default)
@@ -124,6 +125,7 @@ java -jar cli/target/crap-java-cli-0.4.1.jar --changed
 java -jar cli/target/crap-java-cli-0.4.1.jar --build-tool gradle
 java -jar cli/target/crap-java-cli-0.4.1.jar --format json
 java -jar cli/target/crap-java-cli-0.4.1.jar --format text
+java -jar cli/target/crap-java-cli-0.4.1.jar --agent --format json
 java -jar cli/target/crap-java-cli-0.4.1.jar --format junit --output target/crap-java/TEST-crap-java.xml
 java -jar cli/target/crap-java-cli-0.4.1.jar --junit-report target/crap-java/TEST-crap-java.xml
 java -jar cli/target/crap-java-cli-0.4.1.jar --threshold 6
@@ -132,12 +134,19 @@ java -jar cli/target/crap-java-cli-0.4.1.jar src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.4.1.jar module-a module-b
 ```
 
-The CLI writes only the requested report format to stdout, making the default
-TOON output suitable for agent workflows. Warnings and threshold errors are
-written to stderr. Machine-readable reports include top-level `status`
+The CLI writes only the requested report format to stdout. Warnings and
+threshold errors are written to stderr. Machine-readable reports include
+top-level `status`
 (`passed` or `failed`) and `threshold` values, plus method-level
 `coverageKind` values identifying the coverage input used for each CRAP score
 (`instruction`, `branch`, or `N/A`).
+
+Use `--agent` for compact primary output that always keeps the top-level
+`status` and `threshold` and omits passing and skipped methods. Agent mode
+defaults to TOON and supports `--format toon`, `--format json`, and
+`--format text`; `--agent --format junit` is rejected because JUnit XML is not
+token-optimized. `--junit-report <path>` can still be combined with `--agent`
+to write the complete unfiltered JUnit report as a sidecar.
 
 The default threshold is `8.0`. Values below `4.0` print a warning because they
 are likely too noisy; values above `8.0` print a warning because they are too

--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -114,6 +114,7 @@ final class CliApplication {
     private ReportOptions reportOptions(CliArguments parsed) {
         return new ReportOptions(
                 parsed.reportFormat(),
+                parsed.agent(),
                 outputPath(parsed.outputPath()),
                 outputPath(parsed.junitReportPath())
         );

--- a/core/src/main/java/media/barney/crap/core/CliArguments.java
+++ b/core/src/main/java/media/barney/crap/core/CliArguments.java
@@ -8,6 +8,7 @@ record CliArguments(
         BuildToolSelection buildToolSelection,
         ReportFormat reportFormat,
         double threshold,
+        boolean agent,
         @Nullable String outputPath,
         @Nullable String junitReportPath,
         List<String> fileArgs

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -16,6 +16,7 @@ final class CliArgumentsParser {
                     BuildToolSelection.AUTO,
                     ReportFormat.TOON,
                     Thresholds.DEFAULT,
+                    false,
                     null,
                     null,
                     List.of()
@@ -29,6 +30,7 @@ final class CliArgumentsParser {
                     state.buildToolSelection,
                     state.reportFormat,
                     state.threshold,
+                    state.agent,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -43,6 +45,7 @@ final class CliArgumentsParser {
                     state.buildToolSelection,
                     state.reportFormat,
                     state.threshold,
+                    state.agent,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -54,6 +57,7 @@ final class CliArgumentsParser {
                     state.buildToolSelection,
                     state.reportFormat,
                     state.threshold,
+                    state.agent,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -64,6 +68,7 @@ final class CliArgumentsParser {
                 state.buildToolSelection,
                 state.reportFormat,
                 state.threshold,
+                state.agent,
                 state.outputPath,
                 state.junitReportPath,
                 List.copyOf(values)
@@ -96,6 +101,15 @@ final class CliArgumentsParser {
             state.changed = true;
             return index;
         }
+        if ("--agent".equals(arg)) {
+            state.agent = parseAgent(state.agentSeen);
+            state.agentSeen = true;
+            return index;
+        }
+        return parseValuedOption(args, index, state, arg);
+    }
+
+    private static int parseValuedOption(String[] args, int index, ParseStateBuilder state, String arg) {
         if ("--build-tool".equals(arg)) {
             state.buildToolSelection = parseBuildTool(args, index, state.buildToolSeen);
             state.buildToolSeen = true;
@@ -122,6 +136,13 @@ final class CliArgumentsParser {
             return index + 1;
         }
         throw new IllegalArgumentException("Unknown option: " + arg);
+    }
+
+    private static boolean parseAgent(boolean agentSeen) {
+        if (agentSeen) {
+            throw new IllegalArgumentException("--agent can only be provided once");
+        }
+        return true;
     }
 
     private static BuildToolSelection parseBuildTool(String[] args, int index, boolean buildToolSeen) {
@@ -174,11 +195,18 @@ final class CliArgumentsParser {
         }
     }
 
+    private static void ensureAgentFormatIsSupported(boolean agent, ReportFormat reportFormat) {
+        if (agent && reportFormat == ReportFormat.JUNIT) {
+            throw new IllegalArgumentException("--agent cannot be combined with --format junit");
+        }
+    }
+
     private record ParseState(boolean help,
                               boolean changed,
                               BuildToolSelection buildToolSelection,
                               ReportFormat reportFormat,
                               double threshold,
+                              boolean agent,
                               @Nullable String outputPath,
                               @Nullable String junitReportPath,
                               List<String> fileArgs) {
@@ -193,6 +221,8 @@ final class CliArgumentsParser {
         private boolean reportFormatSeen;
         private double threshold = Thresholds.DEFAULT;
         private boolean thresholdSeen;
+        private boolean agent;
+        private boolean agentSeen;
         private @Nullable String outputPath;
         private boolean outputPathSeen;
         private @Nullable String junitReportPath;
@@ -200,7 +230,8 @@ final class CliArgumentsParser {
         private final List<String> values = new ArrayList<>();
 
         private ParseState build() {
-            return new ParseState(help, changed, buildToolSelection, reportFormat, threshold, outputPath, junitReportPath, values);
+            ensureAgentFormatIsSupported(agent, reportFormat);
+            return new ParseState(help, changed, buildToolSelection, reportFormat, threshold, agent, outputPath, junitReportPath, values);
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -121,6 +121,7 @@ public final class Main {
                   crap-java --build-tool gradle           Force Gradle for all resolved modules
                   crap-java --build-tool maven --changed  Force Maven for changed files
                   crap-java --format json                 Write report as toon, json, text, or junit (default: toon)
+                  crap-java --agent                       Write compact agent output (failures only; default format: toon)
                   crap-java --output report.toon          Write the selected report format to a file
                   crap-java --junit-report report.xml     Also write a JUnit XML report for CI
                   crap-java --threshold 6                 Override the CRAP threshold (default: 8.0)

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -13,11 +13,29 @@ final class ReportFormatter {
     }
 
     static String format(CrapReport report, ReportFormat format) {
+        return format(report, format, false);
+    }
+
+    static String format(CrapReport report, ReportFormat format, boolean agent) {
+        return agent ? formatAgent(report, format) : formatFull(report, format);
+    }
+
+    private static String formatFull(CrapReport report, ReportFormat format) {
         return switch (format) {
             case TOON -> JToon.encodeJson(formatJson(report));
             case JSON -> formatJson(report);
             case TEXT -> formatText(report);
             case JUNIT -> formatJunit(report);
+        };
+    }
+
+    private static String formatAgent(CrapReport report, ReportFormat format) {
+        CrapReport failures = failuresOnly(report);
+        return switch (format) {
+            case TOON -> JToon.encodeJson(formatJson(failures));
+            case JSON -> formatJson(failures);
+            case TEXT -> formatAgentText(report);
+            case JUNIT -> throw new IllegalArgumentException("--agent cannot be combined with --format junit");
         };
     }
 
@@ -54,6 +72,38 @@ final class ReportFormatter {
             builder.append('\n');
         }
 
+        return builder.toString();
+    }
+
+    private static String formatAgentText(CrapReport report) {
+        List<CrapReport.MethodReport> failedMethods = sortedMethods(failuresOnly(report).methods());
+        StringBuilder builder = new StringBuilder();
+        builder.append("Status: ").append(report.status()).append('\n');
+        builder.append("Threshold: ").append(formatDisplayNumber(report.threshold())).append('\n');
+        if (failedMethods.isEmpty()) {
+            return builder.toString();
+        }
+        String header = String.format(
+                "%-30s %-35s %4s %7s %-11s %8s",
+                "Method",
+                "Class",
+                "CC",
+                "Cov%",
+                "CovKind",
+                "CRAP"
+        );
+        builder.append(header).append('\n');
+        builder.append("-".repeat(header.length())).append('\n');
+        for (CrapReport.MethodReport entry : failedMethods) {
+            builder.append(String.format(Locale.ROOT, "%-30s %-35s %4d %7s %-11s %8s",
+                    entry.methodName(),
+                    entry.className(),
+                    entry.complexity(),
+                    formatCoverage(entry.coveragePercent()),
+                    entry.coverageKind(),
+                    formatDisplayNumber(entry.crapScore())));
+            builder.append('\n');
+        }
         return builder.toString();
     }
 
@@ -197,6 +247,13 @@ final class ReportFormatter {
                 .thenComparing(CrapReport.MethodReport::methodName)
                 .thenComparingInt(CrapReport.MethodReport::startLine));
         return sorted;
+    }
+
+    private static CrapReport failuresOnly(CrapReport report) {
+        List<CrapReport.MethodReport> failedMethods = report.methods().stream()
+                .filter(method -> method.status() == MethodStatus.FAILED)
+                .toList();
+        return new CrapReport(report.status(), report.threshold(), failedMethods);
     }
 
     private static String formatCoverage(@Nullable Double coverage) {

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -5,10 +5,11 @@ import org.jspecify.annotations.Nullable;
 
 record ReportOptions(
         ReportFormat format,
+        boolean agent,
         @Nullable Path outputPath,
         @Nullable Path junitReportPath
 ) {
     static ReportOptions textWithOptionalJunit(@Nullable Path junitReportPath) {
-        return new ReportOptions(ReportFormat.TEXT, null, junitReportPath);
+        return new ReportOptions(ReportFormat.TEXT, false, null, junitReportPath);
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportPublisher.java
+++ b/core/src/main/java/media/barney/crap/core/ReportPublisher.java
@@ -19,7 +19,7 @@ final class ReportPublisher {
     }
 
     private static void publishPrimary(CrapReport report, ReportOptions options, PrintStream out) throws IOException {
-        String content = ReportFormatter.format(report, options.format());
+        String content = ReportFormatter.format(report, options.format(), options.agent());
         if (options.outputPath() == null) {
             out.print(content);
             return;

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CliArgumentsParserTest {
 
@@ -16,6 +18,7 @@ class CliArgumentsParserTest {
         assertEquals(BuildToolSelection.AUTO, args.buildToolSelection());
         assertEquals(ReportFormat.TOON, args.reportFormat());
         assertEquals(Main.DEFAULT_THRESHOLD, args.threshold());
+        assertFalse(args.agent());
     }
 
     @Test
@@ -59,9 +62,49 @@ class CliArgumentsParserTest {
 
         assertEquals(ReportFormat.JSON, args.reportFormat());
         assertEquals(Main.DEFAULT_THRESHOLD, args.threshold());
+        assertFalse(args.agent());
         assertEquals("target/crap-java/report.json", args.outputPath());
         assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
         assertEquals(List.of("src/main/java/demo/A.java"), args.fileArgs());
+    }
+
+    @Test
+    void agentModeDefaultsToToon() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{"--agent", "--changed"});
+
+        assertEquals(CliMode.CHANGED_SRC, args.mode());
+        assertEquals(ReportFormat.TOON, args.reportFormat());
+        assertTrue(args.agent());
+    }
+
+    @Test
+    void agentModeAllowsNonJunitPrimaryFormatsJunitSidecarAndThreshold() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{
+                "--agent",
+                "--format", "text",
+                "--junit-report", "target/crap-java/TEST-crap-java.xml",
+                "--threshold", "6.0",
+                "--changed"
+        });
+
+        assertEquals(ReportFormat.TEXT, args.reportFormat());
+        assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
+        assertEquals(6.0, args.threshold());
+        assertTrue(args.agent());
+    }
+
+    @Test
+    void agentModeRejectsJunitPrimaryFormat() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--agent", "--format", "junit"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--format", "junit", "--agent"}));
+    }
+
+    @Test
+    void agentModeCanOnlyBeProvidedOnce() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--agent", "--agent"}));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MainTest {
@@ -32,6 +33,7 @@ class MainTest {
         assertTrue(utf8(out).contains("Usage:"));
         assertTrue(utf8(out).contains("--build-tool"));
         assertTrue(utf8(out).contains("--format"));
+        assertTrue(utf8(out).contains("--agent"));
         assertTrue(utf8(out).contains("--threshold"));
     }
 
@@ -222,6 +224,84 @@ class MainTest {
         assertEquals("", utf8(err));
         assertTrue(Files.readString(jsonReport).contains("\"coverageKind\": \"instruction\""));
         assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
+    }
+
+    @Test
+    void agentModeFiltersPrimaryOutputButKeepsJunitSidecarComplete() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int danger(boolean left, boolean right) {
+                        if (left) {
+                            return 1;
+                        }
+                        if (right) {
+                            return 2;
+                        }
+                        return 0;
+                    }
+
+                    int safe() {
+                        return 1;
+                    }
+
+                    int unknown() {
+                        return 2;
+                    }
+                }
+                """);
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Files.createDirectories(jacocoXml.getParent());
+        Files.writeString(jacocoXml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="danger" desc="(ZZ)I" line="4">
+                        <counter type="INSTRUCTION" missed="10" covered="0"/>
+                      </method>
+                      <method name="safe" desc="()I" line="14">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+        Path jsonReport = tempDir.resolve("target/crap-java/agent.json");
+        Path junitReport = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                new String[]{
+                        "--agent",
+                        "--format", "json",
+                        "--output", "target/crap-java/agent.json",
+                        "--junit-report", "target/crap-java/TEST-crap-java.xml",
+                        "src/main/java/demo/Sample.java"
+                },
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        String primary = Files.readString(jsonReport);
+        String junit = Files.readString(junitReport);
+        assertEquals(2, exit);
+        assertEquals("", utf8(out));
+        assertTrue(primary.contains("\"status\": \"failed\""));
+        assertTrue(primary.contains("\"threshold\": 8.0"));
+        assertTrue(primary.contains("\"methodName\": \"danger\""));
+        assertFalse(primary.contains("\"methodName\": \"safe\""));
+        assertFalse(primary.contains("\"methodName\": \"unknown\""));
+        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(junit.contains("FAILED danger"));
+        assertTrue(junit.contains("PASSED safe"));
+        assertTrue(junit.contains("SKIPPED unknown"));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -6,6 +6,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReportFormatterTest {
@@ -82,6 +83,81 @@ class ReportFormatterTest {
         assertTrue(report.contains("methods[2]{status,methodName,className,sourcePath,startLine,endLine,complexity,coveragePercent,coverageKind,crapScore}:"));
         assertTrue(report.contains("passed,foo,demo.Sample,src/main/java/demo/Sample.java,4,6,3,85,instruction,4.5"));
         assertTrue(report.contains("skipped,bar,demo.Sample,src/main/java/demo/Sample.java,9,11,2,null,N/A,null"));
+    }
+
+    @Test
+    void formatsAgentJsonWithOnlyFailuresAndGlobalStatusThreshold() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.JSON, true);
+
+        String expected = """
+                {
+                  "status": "failed",
+                  "threshold": 8.0,
+                  "methods": [
+                    {
+                      "status": "failed",
+                      "methodName": "danger",
+                      "className": "demo.Sample",
+                      "sourcePath": "src/main/java/demo/Sample.java",
+                      "startLine": 4,
+                      "endLine": 6,
+                      "complexity": 5,
+                      "coveragePercent": 10.0,
+                      "coverageKind": "instruction",
+                      "crapScore": 9.645
+                    }
+                  ]
+                }
+                """;
+
+        assertEquals(expected, report);
+    }
+
+    @Test
+    void formatsAgentToonWithOnlyFailures() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("safe", "demo.Sample", 9, 1, 100.0, 1.0)
+        ), ReportFormat.TOON, true);
+
+        assertTrue(report.contains("status: failed"));
+        assertTrue(report.contains("threshold: 8"));
+        assertTrue(report.contains("methods[1]{status,methodName,className,sourcePath,startLine,endLine,complexity,coveragePercent,coverageKind,crapScore}:"));
+        assertTrue(report.contains("failed,danger,demo.Sample,src/main/java/demo/Sample.java,4,6,5,10,instruction,9.645"));
+    }
+
+    @Test
+    void formatsAgentTextWithOnlyFailures() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.TEXT, true);
+
+        assertTrue(report.startsWith("Status: failed\nThreshold: 8.0\n"));
+        assertTrue(report.contains("Method"));
+        assertTrue(report.contains("danger"));
+        assertTrue(report.contains("9.6"));
+        assertFalse(report.contains("safe"));
+        assertFalse(report.contains("unknown"));
+        assertFalse(report.contains("CRAP Report"));
+    }
+
+    @Test
+    void formatsAgentTextWithoutMethodRowsWhenPassed() {
+        String report = ReportFormatter.format(report(
+                metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.TEXT, true);
+
+        assertEquals("""
+                Status: passed
+                Threshold: 8.0
+                """, report);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add `--agent` compact primary output mode for TOON, JSON, and text
- reject `--agent --format junit` while keeping `--junit-report` sidecars complete
- filter agent primary method entries to failures only while preserving top-level status and threshold

## Verification
- `mvn -B -pl core test`
- `mvn -B -pl cli -am package`
- `mvn -B -pl maven-plugin -am verify`
- `mvn -B verify`
- `cd gradle-plugin && ./gradlew test`
- `java -jar cli/target/crap-java-cli-0.4.1.jar --format text --junit-report target/crap-java/TEST-crap-java-maven-sources.xml --build-tool maven core/src/main/java cli/src/main/java maven-plugin/src/main/java`
- `java -jar cli/target/crap-java-cli-0.4.1.jar --format text --junit-report target/crap-java/TEST-crap-java-gradle-plugin.xml --build-tool gradle gradle-plugin/src/main/java`

Closes #67