### PR TITLE
Prettify text report table

### DIFF
--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -41,37 +41,12 @@ final class ReportFormatter {
 
     private static String formatText(CrapReport report) {
         List<CrapReport.MethodReport> sorted = sortedMethods(report.methods());
-        String header = String.format(
-                "%-8s %-30s %-35s %4s %7s %-11s %8s",
-                "Status",
-                "Method",
-                "Class",
-                "CC",
-                "Cov%",
-                "CovKind",
-                "CRAP"
-        );
-        String separator = "-".repeat(header.length());
         StringBuilder builder = new StringBuilder();
         builder.append("CRAP Report\n");
         builder.append("===========\n");
         builder.append("Status: ").append(report.status()).append('\n');
         builder.append("Threshold: ").append(formatDisplayNumber(report.threshold())).append('\n');
-        builder.append(header).append('\n');
-        builder.append(separator).append('\n');
-
-        for (CrapReport.MethodReport entry : sorted) {
-            builder.append(String.format(Locale.ROOT, "%-8s %-30s %-35s %4d %7s %-11s %8s",
-                    entry.status().value(),
-                    entry.methodName(),
-                    entry.className(),
-                    entry.complexity(),
-                    formatCoverage(entry.coveragePercent()),
-                    entry.coverageKind(),
-                    formatDisplayNumber(entry.crapScore())));
-            builder.append('\n');
-        }
-
+        appendMethodTable(builder, fullTextColumns(), sorted);
         return builder.toString();
     }
 
@@ -83,28 +58,94 @@ final class ReportFormatter {
         if (failedMethods.isEmpty()) {
             return builder.toString();
         }
-        String header = String.format(
-                "%-30s %-35s %4s %7s %-11s %8s",
-                "Method",
-                "Class",
-                "CC",
-                "Cov%",
-                "CovKind",
-                "CRAP"
-        );
-        builder.append(header).append('\n');
-        builder.append("-".repeat(header.length())).append('\n');
-        for (CrapReport.MethodReport entry : failedMethods) {
-            builder.append(String.format(Locale.ROOT, "%-30s %-35s %4d %7s %-11s %8s",
-                    entry.methodName(),
-                    entry.className(),
-                    entry.complexity(),
-                    formatCoverage(entry.coveragePercent()),
-                    entry.coverageKind(),
-                    formatDisplayNumber(entry.crapScore())));
-            builder.append('\n');
-        }
+        appendMethodTable(builder, agentTextColumns(), failedMethods);
         return builder.toString();
+    }
+
+    private static List<TableColumn> fullTextColumns() {
+        return List.of(
+                new TableColumn("Status", Alignment.LEFT, method -> method.status().value()),
+                new TableColumn("Method", Alignment.LEFT, CrapReport.MethodReport::methodName),
+                new TableColumn("Class", Alignment.LEFT, CrapReport.MethodReport::className),
+                new TableColumn("CC", Alignment.RIGHT, method -> Integer.toString(method.complexity())),
+                new TableColumn("Cov%", Alignment.RIGHT, method -> formatCoverage(method.coveragePercent())),
+                new TableColumn("CovKind", Alignment.LEFT, CrapReport.MethodReport::coverageKind),
+                new TableColumn("CRAP", Alignment.RIGHT, method -> formatDisplayNumber(method.crapScore()))
+        );
+    }
+
+    private static List<TableColumn> agentTextColumns() {
+        return List.of(
+                new TableColumn("Method", Alignment.LEFT, CrapReport.MethodReport::methodName),
+                new TableColumn("Class", Alignment.LEFT, CrapReport.MethodReport::className),
+                new TableColumn("CC", Alignment.RIGHT, method -> Integer.toString(method.complexity())),
+                new TableColumn("Cov%", Alignment.RIGHT, method -> formatCoverage(method.coveragePercent())),
+                new TableColumn("CovKind", Alignment.LEFT, CrapReport.MethodReport::coverageKind),
+                new TableColumn("CRAP", Alignment.RIGHT, method -> formatDisplayNumber(method.crapScore()))
+        );
+    }
+
+    private static void appendMethodTable(StringBuilder builder,
+                                          List<TableColumn> columns,
+                                          List<CrapReport.MethodReport> methods) {
+        List<List<String>> rows = methods.stream()
+                .map(method -> row(columns, method))
+                .toList();
+        List<Integer> widths = columnWidths(columns, rows);
+        appendTableRow(builder, columns, columnHeaders(columns), widths);
+        appendSeparator(builder, widths);
+        for (List<String> row : rows) {
+            appendTableRow(builder, columns, row, widths);
+        }
+    }
+
+    private static List<String> row(List<TableColumn> columns, CrapReport.MethodReport method) {
+        List<String> values = new ArrayList<>();
+        for (TableColumn column : columns) {
+            values.add(column.value(method));
+        }
+        return values;
+    }
+
+    private static List<String> columnHeaders(List<TableColumn> columns) {
+        return columns.stream()
+                .map(TableColumn::header)
+                .toList();
+    }
+
+    private static List<Integer> columnWidths(List<TableColumn> columns, List<List<String>> rows) {
+        List<Integer> widths = columns.stream()
+                .map(column -> column.header().length())
+                .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+        for (List<String> row : rows) {
+            for (int index = 0; index < row.size(); index++) {
+                widths.set(index, Math.max(widths.get(index), row.get(index).length()));
+            }
+        }
+        return widths;
+    }
+
+    private static void appendSeparator(StringBuilder builder, List<Integer> widths) {
+        for (int index = 0; index < widths.size(); index++) {
+            if (index > 0) {
+                builder.append("  ");
+            }
+            builder.append("-".repeat(widths.get(index)));
+        }
+        builder.append('\n');
+    }
+
+    private static void appendTableRow(StringBuilder builder,
+                                       List<TableColumn> columns,
+                                       List<String> row,
+                                       List<Integer> widths) {
+        for (int index = 0; index < row.size(); index++) {
+            if (index > 0) {
+                builder.append("  ");
+            }
+            builder.append(columns.get(index).align(row.get(index), widths.get(index)));
+        }
+        builder.append('\n');
     }
 
     private static String formatJson(CrapReport report) {
@@ -317,5 +358,36 @@ final class ReportFormatter {
             }
         }
         return builder.toString();
+    }
+
+    private record TableColumn(String header, Alignment alignment, CellValue cellValue) {
+        private String align(String value, int width) {
+            return alignment.align(value, width);
+        }
+
+        private String value(CrapReport.MethodReport method) {
+            return cellValue.value(method);
+        }
+    }
+
+    private interface CellValue {
+        String value(CrapReport.MethodReport method);
+    }
+
+    private enum Alignment {
+        LEFT {
+            @Override
+            String align(String value, int width) {
+                return value + " ".repeat(width - value.length());
+            }
+        },
+        RIGHT {
+            @Override
+            String align(String value, int width) {
+                return " ".repeat(width - value.length()) + value;
+            }
+        };
+
+        abstract String align(String value, int width);
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -63,18 +63,17 @@ final class ReportFormatter {
     }
 
     private static List<TableColumn> fullTextColumns() {
-        return List.of(
-                new TableColumn("Status", Alignment.LEFT, method -> method.status().value()),
-                new TableColumn("Method", Alignment.LEFT, CrapReport.MethodReport::methodName),
-                new TableColumn("Class", Alignment.LEFT, CrapReport.MethodReport::className),
-                new TableColumn("CC", Alignment.RIGHT, method -> Integer.toString(method.complexity())),
-                new TableColumn("Cov%", Alignment.RIGHT, method -> formatCoverage(method.coveragePercent())),
-                new TableColumn("CovKind", Alignment.LEFT, CrapReport.MethodReport::coverageKind),
-                new TableColumn("CRAP", Alignment.RIGHT, method -> formatDisplayNumber(method.crapScore()))
-        );
+        List<TableColumn> columns = new ArrayList<>();
+        columns.add(new TableColumn("Status", Alignment.LEFT, method -> method.status().value()));
+        columns.addAll(methodTextColumns());
+        return columns;
     }
 
     private static List<TableColumn> agentTextColumns() {
+        return methodTextColumns();
+    }
+
+    private static List<TableColumn> methodTextColumns() {
         return List.of(
                 new TableColumn("Method", Alignment.LEFT, CrapReport.MethodReport::methodName),
                 new TableColumn("Class", Alignment.LEFT, CrapReport.MethodReport::className),

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -29,6 +29,30 @@ class ReportFormatterTest {
     }
 
     @Test
+    void formatsTextReportWithDynamicColumnWidths() {
+        String report = ReportFormatter.format(report(
+                metric("veryLongMethodNameForWideColumn", "demo.really.LongClassNameForWideColumn", 4, 12, 5.0, 45.25),
+                metric("ok", "demo.S", 9, 2, 100.0, 2.0)
+        ), ReportFormat.TEXT);
+
+        List<String> lines = report.lines().toList();
+        String header = lines.get(4);
+        String separator = lines.get(5);
+        String failed = lines.get(6);
+        String passed = lines.get(7);
+
+        assertTrue(failed.contains("veryLongMethodNameForWideColumn"));
+        assertTrue(failed.contains("demo.really.LongClassNameForWideColumn"));
+        assertEquals(header.length(), separator.length());
+        assertEquals(header.length(), failed.length());
+        assertEquals(header.length(), passed.length());
+
+        int complexityColumn = header.indexOf("CC");
+        assertEquals("12", failed.substring(complexityColumn, complexityColumn + 2));
+        assertEquals(" 2", passed.substring(complexityColumn, complexityColumn + 2));
+    }
+
+    @Test
     void formatsJsonReportWithSchemaSummaryAndMethods() {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
@@ -145,6 +169,10 @@ class ReportFormatterTest {
         assertFalse(report.contains("safe"));
         assertFalse(report.contains("unknown"));
         assertFalse(report.contains("CRAP Report"));
+
+        List<String> lines = report.lines().toList();
+        assertEquals(lines.get(2).length(), lines.get(3).length());
+        assertEquals(lines.get(2).length(), lines.get(4).length());
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -36,10 +36,11 @@ class ReportFormatterTest {
         ), ReportFormat.TEXT);
 
         List<String> lines = report.lines().toList();
-        String header = lines.get(4);
-        String separator = lines.get(5);
-        String failed = lines.get(6);
-        String passed = lines.get(7);
+        int headerIndex = tableHeaderIndex(lines, "Status");
+        String header = lines.get(headerIndex);
+        String separator = lines.get(headerIndex + 1);
+        String failed = lines.get(headerIndex + 2);
+        String passed = lines.get(headerIndex + 3);
 
         assertTrue(failed.contains("veryLongMethodNameForWideColumn"));
         assertTrue(failed.contains("demo.really.LongClassNameForWideColumn"));
@@ -171,8 +172,9 @@ class ReportFormatterTest {
         assertFalse(report.contains("CRAP Report"));
 
         List<String> lines = report.lines().toList();
-        assertEquals(lines.get(2).length(), lines.get(3).length());
-        assertEquals(lines.get(2).length(), lines.get(4).length());
+        int headerIndex = tableHeaderIndex(lines, "Method");
+        assertEquals(lines.get(headerIndex).length(), lines.get(headerIndex + 1).length());
+        assertEquals(lines.get(headerIndex).length(), lines.get(headerIndex + 2).length());
     }
 
     @Test
@@ -245,6 +247,16 @@ class ReportFormatterTest {
 
     private static CrapReport report(MethodMetrics... metrics) {
         return CrapReport.from(List.of(metrics), Main.DEFAULT_THRESHOLD);
+    }
+
+    private static int tableHeaderIndex(List<String> lines, String firstColumn) {
+        for (int index = 0; index < lines.size(); index++) {
+            String line = lines.get(index);
+            if (line.startsWith(firstColumn) && line.contains("Class") && line.contains("CovKind")) {
+                return index;
+            }
+        }
+        throw new AssertionError("Missing text table header");
     }
 
     private static MethodMetrics metric(String method,


### PR DESCRIPTION
## Summary
- render text reports with dynamic column widths instead of fixed padding
- share table rendering between full text output and compact agent text output
- right-align numeric columns while preserving existing report fields and sorting

## Verification
- `mvn -B -pl core test -Dtest=ReportFormatterTest`
- `mvn -B -pl cli -am package`
- `mvn -B cognitive-java:check`

Closes #70