### PR TITLE
Align compact Java report schema

### DIFF
--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -199,15 +199,14 @@ final class ReportFormatter {
     private static JsonMethod jsonMethod(CrapReport.MethodReport method) {
         return new JsonMethod(
                 method.status().value(),
-                method.methodName(),
-                method.className(),
-                method.sourcePath(),
-                method.startLine(),
-                method.endLine(),
+                method.crapScore(),
                 method.complexity(),
                 method.coveragePercent(),
                 method.coverageKind(),
-                method.crapScore()
+                method.methodName(),
+                method.className(),
+                method.startLine(),
+                method.endLine()
         );
     }
 
@@ -353,15 +352,14 @@ final class ReportFormatter {
 
     private record JsonMethod(
             String status,
-            String methodName,
-            String className,
-            String sourcePath,
-            int startLine,
-            int endLine,
-            int complexity,
-            @Nullable Double coveragePercent,
-            String coverageKind,
-            @Nullable Double crapScore
+            @Nullable Double crap,
+            int cc,
+            @Nullable Double cov,
+            String covKind,
+            String method,
+            String src,
+            int lineStart,
+            int lineEnd
     ) {
     }
 

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -95,7 +95,7 @@ class MainTest {
 
         assertEquals(0, exit);
         assertTrue(utf8(out).contains("status: passed"));
-        assertTrue(utf8(out).contains("coverageKind"));
+        assertTrue(utf8(out).contains("covKind"));
         assertTrue(utf8(out).contains("Sample"));
         assertTrue(utf8(out).contains("alpha"));
     }
@@ -222,7 +222,7 @@ class MainTest {
         assertEquals(0, exit);
         assertEquals("", utf8(out));
         assertEquals("", utf8(err));
-        assertTrue(Files.readString(jsonReport).contains("\"coverageKind\": \"instruction\""));
+        assertTrue(Files.readString(jsonReport).contains("\"covKind\": \"instruction\""));
         assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
     }
 
@@ -295,9 +295,9 @@ class MainTest {
         assertEquals("", utf8(out));
         assertTrue(primary.contains("\"status\": \"failed\""));
         assertTrue(primary.contains("\"threshold\": 8.0"));
-        assertTrue(primary.contains("\"methodName\": \"danger\""));
-        assertFalse(primary.contains("\"methodName\": \"safe\""));
-        assertFalse(primary.contains("\"methodName\": \"unknown\""));
+        assertTrue(primary.contains("\"method\": \"danger\""));
+        assertFalse(primary.contains("\"method\": \"safe\""));
+        assertFalse(primary.contains("\"method\": \"unknown\""));
         assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
         assertTrue(junit.contains("FAILED danger"));
         assertTrue(junit.contains("PASSED safe"));

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -74,27 +74,25 @@ class ReportFormatterTest {
                   "methods": [
                     {
                       "status": "failed",
-                      "methodName": "danger",
-                      "className": "demo.Sample",
-                      "sourcePath": "src/main/java/demo/Sample.java",
-                      "startLine": 4,
-                      "endLine": 6,
-                      "complexity": 5,
-                      "coveragePercent": 10.0,
-                      "coverageKind": "instruction",
-                      "crapScore": 9.645
+                      "crap": 9.645,
+                      "cc": 5,
+                      "cov": 10.0,
+                      "covKind": "instruction",
+                      "method": "danger",
+                      "src": "demo.Sample",
+                      "lineStart": 4,
+                      "lineEnd": 6
                     },
                     {
                       "status": "skipped",
-                      "methodName": "unknown",
-                      "className": "demo.Sample",
-                      "sourcePath": "src/main/java/demo/Sample.java",
-                      "startLine": 20,
-                      "endLine": 22,
-                      "complexity": 2,
-                      "coveragePercent": null,
-                      "coverageKind": "N/A",
-                      "crapScore": null
+                      "crap": null,
+                      "cc": 2,
+                      "cov": null,
+                      "covKind": "N/A",
+                      "method": "unknown",
+                      "src": "demo.Sample",
+                      "lineStart": 20,
+                      "lineEnd": 22
                     }
                   ]
                 }
@@ -112,9 +110,9 @@ class ReportFormatterTest {
 
         assertTrue(report.contains("status: passed"));
         assertTrue(report.contains("threshold: 8"));
-        assertTrue(report.contains("methods[2]{status,methodName,className,sourcePath,startLine,endLine,complexity,coveragePercent,coverageKind,crapScore}:"));
-        assertTrue(report.contains("passed,foo,demo.Sample,src/main/java/demo/Sample.java,4,6,3,85,instruction,4.5"));
-        assertTrue(report.contains("skipped,bar,demo.Sample,src/main/java/demo/Sample.java,9,11,2,null,N/A,null"));
+        assertTrue(report.contains("methods[2]{status,crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
+        assertTrue(report.contains("passed,4.5,3,85,instruction,foo,demo.Sample,4,6"));
+        assertTrue(report.contains("skipped,null,2,null,N/A,bar,demo.Sample,9,11"));
     }
 
     @Test
@@ -132,15 +130,14 @@ class ReportFormatterTest {
                   "methods": [
                     {
                       "status": "failed",
-                      "methodName": "danger",
-                      "className": "demo.Sample",
-                      "sourcePath": "src/main/java/demo/Sample.java",
-                      "startLine": 4,
-                      "endLine": 6,
-                      "complexity": 5,
-                      "coveragePercent": 10.0,
-                      "coverageKind": "instruction",
-                      "crapScore": 9.645
+                      "crap": 9.645,
+                      "cc": 5,
+                      "cov": 10.0,
+                      "covKind": "instruction",
+                      "method": "danger",
+                      "src": "demo.Sample",
+                      "lineStart": 4,
+                      "lineEnd": 6
                     }
                   ]
                 }
@@ -158,8 +155,8 @@ class ReportFormatterTest {
 
         assertTrue(report.contains("status: failed"));
         assertTrue(report.contains("threshold: 8"));
-        assertTrue(report.contains("methods[1]{status,methodName,className,sourcePath,startLine,endLine,complexity,coveragePercent,coverageKind,crapScore}:"));
-        assertTrue(report.contains("failed,danger,demo.Sample,src/main/java/demo/Sample.java,4,6,5,10,instruction,9.645"));
+        assertTrue(report.contains("methods[1]{status,crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
+        assertTrue(report.contains("failed,9.645,5,10,instruction,danger,demo.Sample,4,6"));
     }
 
     @Test
@@ -243,7 +240,7 @@ class ReportFormatterTest {
 
         String json = ReportFormatter.format(report(metric), ReportFormat.JSON);
 
-        assertTrue(json.contains("\"methodName\": \"quote\\\"slash\\\\line\\nreturn\\rtab\\tcontrol\\u0001\""));
+        assertTrue(json.contains("\"method\": \"quote\\\"slash\\\\line\\nreturn\\rtab\\tcontrol\\u0001\""));
     }
 
     @Test


### PR DESCRIPTION
Closes #77.

## Summary
- rename compact JSON/TOON method fields to `status`, `crap`, `cc`, `cov`, `covKind`, `method`, `src`, `lineStart`, and `lineEnd`
- map `method` to the Java method name and `src` to the fully qualified Java class name
- update formatter and CLI-output tests for the new field names and order

## Validation
- `mvn -B -pl core -Dtest=ReportFormatterTest test`
- `mvn -B -pl core "-Dtest=ReportFormatterTest,MainTest" test`
- `mvn -B verify`