### PR TITLE
Add failuresOnly primary report control

### DIFF
--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -115,6 +115,7 @@ final class CliApplication {
         return new ReportOptions(
                 parsed.reportFormat(),
                 parsed.agent(),
+                parsed.failuresOnly(),
                 outputPath(parsed.outputPath()),
                 outputPath(parsed.junitReportPath())
         );

--- a/core/src/main/java/media/barney/crap/core/CliArguments.java
+++ b/core/src/main/java/media/barney/crap/core/CliArguments.java
@@ -9,6 +9,7 @@ record CliArguments(
         ReportFormat reportFormat,
         double threshold,
         boolean agent,
+        boolean failuresOnly,
         @Nullable String outputPath,
         @Nullable String junitReportPath,
         List<String> fileArgs

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -17,6 +17,7 @@ final class CliArgumentsParser {
                     ReportFormat.TOON,
                     Thresholds.DEFAULT,
                     false,
+                    false,
                     null,
                     null,
                     List.of()
@@ -31,6 +32,7 @@ final class CliArgumentsParser {
                     state.reportFormat,
                     state.threshold,
                     state.agent,
+                    state.failuresOnly,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -46,6 +48,7 @@ final class CliArgumentsParser {
                     state.reportFormat,
                     state.threshold,
                     state.agent,
+                    state.failuresOnly,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -58,6 +61,7 @@ final class CliArgumentsParser {
                     state.reportFormat,
                     state.threshold,
                     state.agent,
+                    state.failuresOnly,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -69,6 +73,7 @@ final class CliArgumentsParser {
                 state.reportFormat,
                 state.threshold,
                 state.agent,
+                state.failuresOnly,
                 state.outputPath,
                 state.junitReportPath,
                 List.copyOf(values)
@@ -104,6 +109,11 @@ final class CliArgumentsParser {
         if ("--agent".equals(arg)) {
             state.agent = parseAgent(state.agentSeen);
             state.agentSeen = true;
+            return index;
+        }
+        if (isBooleanOption(arg, "--failures-only")) {
+            state.failuresOnly = parseBooleanOption(arg, "--failures-only", state.failuresOnlySeen);
+            state.failuresOnlySeen = true;
             return index;
         }
         return parseValuedOption(args, index, state, arg);
@@ -143,6 +153,27 @@ final class CliArgumentsParser {
             throw new IllegalArgumentException("--agent can only be provided once");
         }
         return true;
+    }
+
+    private static boolean isBooleanOption(String arg, String option) {
+        return arg.equals(option) || arg.startsWith(option + "=");
+    }
+
+    private static boolean parseBooleanOption(String arg, String option, boolean seen) {
+        if (seen) {
+            throw new IllegalArgumentException(option + " can only be provided once");
+        }
+        if (arg.equals(option)) {
+            return true;
+        }
+        String value = arg.substring(option.length() + 1);
+        if ("true".equals(value)) {
+            return true;
+        }
+        if ("false".equals(value)) {
+            return false;
+        }
+        throw new IllegalArgumentException(option + " requires true or false when assigned");
     }
 
     private static BuildToolSelection parseBuildTool(String[] args, int index, boolean buildToolSeen) {
@@ -207,6 +238,7 @@ final class CliArgumentsParser {
                               ReportFormat reportFormat,
                               double threshold,
                               boolean agent,
+                              boolean failuresOnly,
                               @Nullable String outputPath,
                               @Nullable String junitReportPath,
                               List<String> fileArgs) {
@@ -223,6 +255,8 @@ final class CliArgumentsParser {
         private boolean thresholdSeen;
         private boolean agent;
         private boolean agentSeen;
+        private boolean failuresOnly;
+        private boolean failuresOnlySeen;
         private @Nullable String outputPath;
         private boolean outputPathSeen;
         private @Nullable String junitReportPath;
@@ -231,7 +265,7 @@ final class CliArgumentsParser {
 
         private ParseState build() {
             ensureAgentFormatIsSupported(agent, reportFormat);
-            return new ParseState(help, changed, buildToolSelection, reportFormat, threshold, agent, outputPath, junitReportPath, values);
+            return new ParseState(help, changed, buildToolSelection, reportFormat, threshold, agent, failuresOnly, outputPath, junitReportPath, values);
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -2,6 +2,7 @@ package media.barney.crap.core;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import org.jspecify.annotations.Nullable;
 
 final class CliArgumentsParser {
@@ -166,7 +167,7 @@ final class CliArgumentsParser {
         if (arg.equals(option)) {
             return true;
         }
-        String value = arg.substring(option.length() + 1);
+        String value = arg.substring(option.length() + 1).toLowerCase(Locale.ROOT);
         if ("true".equals(value)) {
             return true;
         }

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -233,6 +233,14 @@ final class CliArgumentsParser {
         }
     }
 
+    private static void ensureFailuresOnlyDoesNotConflictWithAgent(boolean agent,
+                                                                   boolean failuresOnly,
+                                                                   boolean failuresOnlySeen) {
+        if (agent && failuresOnlySeen && !failuresOnly) {
+            throw new IllegalArgumentException("--agent cannot be combined with --failures-only=false");
+        }
+    }
+
     private record ParseState(boolean help,
                               boolean changed,
                               BuildToolSelection buildToolSelection,
@@ -266,6 +274,7 @@ final class CliArgumentsParser {
 
         private ParseState build() {
             ensureAgentFormatIsSupported(agent, reportFormat);
+            ensureFailuresOnlyDoesNotConflictWithAgent(agent, failuresOnly, failuresOnlySeen);
             return new ParseState(help, changed, buildToolSelection, reportFormat, threshold, agent, failuresOnly, outputPath, junitReportPath, values);
         }
     }

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -122,6 +122,7 @@ public final class Main {
                   crap-java --build-tool maven --changed  Force Maven for changed files
                   crap-java --format json                 Write report as toon, json, text, or junit (default: toon)
                   crap-java --agent                       Write compact agent output (failures only; default format: toon)
+                  crap-java --failures-only[=true|false]  Only include failing methods in the primary report
                   crap-java --output report.toon          Write the selected report format to a file
                   crap-java --junit-report report.xml     Also write a JUnit XML report for CI
                   crap-java --threshold 6                 Override the CRAP threshold (default: 8.0)

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -38,7 +38,14 @@ final class ReportFormatter {
     }
 
     static String format(CrapReport report, ReportFormat format, boolean agent) {
-        return agent ? formatAgent(report, format) : formatFull(report, format);
+        return format(report, format, agent, false);
+    }
+
+    static String format(CrapReport report, ReportFormat format, boolean agent, boolean failuresOnly) {
+        if (agent) {
+            return formatAgent(report, format);
+        }
+        return formatFull(failuresOnly ? failuresOnly(report) : report, format);
     }
 
     private static String formatFull(CrapReport report, ReportFormat format) {

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -6,10 +6,11 @@ import org.jspecify.annotations.Nullable;
 record ReportOptions(
         ReportFormat format,
         boolean agent,
+        boolean failuresOnly,
         @Nullable Path outputPath,
         @Nullable Path junitReportPath
 ) {
     static ReportOptions textWithOptionalJunit(@Nullable Path junitReportPath) {
-        return new ReportOptions(ReportFormat.TEXT, false, null, junitReportPath);
+        return new ReportOptions(ReportFormat.TEXT, false, false, null, junitReportPath);
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportPublisher.java
+++ b/core/src/main/java/media/barney/crap/core/ReportPublisher.java
@@ -19,7 +19,7 @@ final class ReportPublisher {
     }
 
     private static void publishPrimary(CrapReport report, ReportOptions options, PrintStream out) throws IOException {
-        String content = ReportFormatter.format(report, options.format(), options.agent());
+        String content = ReportFormatter.format(report, options.format(), options.agent(), options.failuresOnly());
         if (options.outputPath() == null) {
             out.print(content);
             return;

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -121,9 +121,13 @@ class CliArgumentsParserTest {
     void failuresOnlyFlagAcceptsExplicitBooleanAssignments() {
         CliArguments enabled = CliArgumentsParser.parse(new String[]{"--failures-only=true", "--changed"});
         CliArguments disabled = CliArgumentsParser.parse(new String[]{"--failures-only=false", "--changed"});
+        CliArguments enabledUppercase = CliArgumentsParser.parse(new String[]{"--failures-only=TRUE", "--changed"});
+        CliArguments disabledUppercase = CliArgumentsParser.parse(new String[]{"--failures-only=FALSE", "--changed"});
 
         assertTrue(enabled.failuresOnly());
         assertFalse(disabled.failuresOnly());
+        assertTrue(enabledUppercase.failuresOnly());
+        assertFalse(disabledUppercase.failuresOnly());
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -19,6 +19,7 @@ class CliArgumentsParserTest {
         assertEquals(ReportFormat.TOON, args.reportFormat());
         assertEquals(Main.DEFAULT_THRESHOLD, args.threshold());
         assertFalse(args.agent());
+        assertFalse(args.failuresOnly());
     }
 
     @Test
@@ -63,6 +64,7 @@ class CliArgumentsParserTest {
         assertEquals(ReportFormat.JSON, args.reportFormat());
         assertEquals(Main.DEFAULT_THRESHOLD, args.threshold());
         assertFalse(args.agent());
+        assertFalse(args.failuresOnly());
         assertEquals("target/crap-java/report.json", args.outputPath());
         assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
         assertEquals(List.of("src/main/java/demo/A.java"), args.fileArgs());
@@ -105,6 +107,37 @@ class CliArgumentsParserTest {
     void agentModeCanOnlyBeProvidedOnce() {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--agent", "--agent"}));
+    }
+
+    @Test
+    void failuresOnlyFlagDefaultsToTrueWhenUnassigned() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{"--failures-only", "--changed"});
+
+        assertEquals(CliMode.CHANGED_SRC, args.mode());
+        assertTrue(args.failuresOnly());
+    }
+
+    @Test
+    void failuresOnlyFlagAcceptsExplicitBooleanAssignments() {
+        CliArguments enabled = CliArgumentsParser.parse(new String[]{"--failures-only=true", "--changed"});
+        CliArguments disabled = CliArgumentsParser.parse(new String[]{"--failures-only=false", "--changed"});
+
+        assertTrue(enabled.failuresOnly());
+        assertFalse(disabled.failuresOnly());
+    }
+
+    @Test
+    void failuresOnlyFlagRejectsInvalidAssignments() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--failures-only=yes", "--changed"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--failures-only=", "--changed"}));
+    }
+
+    @Test
+    void failuresOnlyFlagCanOnlyBeProvidedOnce() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--failures-only", "--failures-only=false"}));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -110,6 +110,14 @@ class CliArgumentsParserTest {
     }
 
     @Test
+    void agentModeRejectsExplicitFailuresOnlyFalse() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--agent", "--failures-only=false"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--failures-only=false", "--agent"}));
+    }
+
+    @Test
     void failuresOnlyFlagDefaultsToTrueWhenUnassigned() {
         CliArguments args = CliArgumentsParser.parse(new String[]{"--failures-only", "--changed"});
 

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -34,6 +34,7 @@ class MainTest {
         assertTrue(utf8(out).contains("--build-tool"));
         assertTrue(utf8(out).contains("--format"));
         assertTrue(utf8(out).contains("--agent"));
+        assertTrue(utf8(out).contains("--failures-only"));
         assertTrue(utf8(out).contains("--threshold"));
     }
 
@@ -228,49 +229,7 @@ class MainTest {
 
     @Test
     void agentModeFiltersPrimaryOutputButKeepsJunitSidecarComplete() throws Exception {
-        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
-        Path sourceRoot = tempDir.resolve("src/main/java/demo");
-        Files.createDirectories(sourceRoot);
-        Path source = sourceRoot.resolve("Sample.java");
-        Files.writeString(source, """
-                package demo;
-
-                class Sample {
-                    int danger(boolean left, boolean right) {
-                        if (left) {
-                            return 1;
-                        }
-                        if (right) {
-                            return 2;
-                        }
-                        return 0;
-                    }
-
-                    int safe() {
-                        return 1;
-                    }
-
-                    int unknown() {
-                        return 2;
-                    }
-                }
-                """);
-        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
-        Files.createDirectories(jacocoXml.getParent());
-        Files.writeString(jacocoXml, """
-                <report name="demo">
-                  <package name="demo">
-                    <class name="demo/Sample" sourcefilename="Sample.java">
-                      <method name="danger" desc="(ZZ)I" line="4">
-                        <counter type="INSTRUCTION" missed="10" covered="0"/>
-                      </method>
-                      <method name="safe" desc="()I" line="14">
-                        <counter type="INSTRUCTION" missed="0" covered="1"/>
-                      </method>
-                    </class>
-                  </package>
-                </report>
-                """);
+        writeMixedCoverageSample();
         Path jsonReport = tempDir.resolve("target/crap-java/agent.json");
         Path junitReport = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -281,6 +240,42 @@ class MainTest {
                         "--agent",
                         "--format", "json",
                         "--output", "target/crap-java/agent.json",
+                        "--junit-report", "target/crap-java/TEST-crap-java.xml",
+                        "src/main/java/demo/Sample.java"
+                },
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        String primary = Files.readString(jsonReport);
+        String junit = Files.readString(junitReport);
+        assertEquals(2, exit);
+        assertEquals("", utf8(out));
+        assertTrue(primary.contains("\"status\": \"failed\""));
+        assertTrue(primary.contains("\"threshold\": 8.0"));
+        assertTrue(primary.contains("\"method\": \"danger\""));
+        assertFalse(primary.contains("\"method\": \"safe\""));
+        assertFalse(primary.contains("\"method\": \"unknown\""));
+        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(junit.contains("FAILED danger"));
+        assertTrue(junit.contains("PASSED safe"));
+        assertTrue(junit.contains("SKIPPED unknown"));
+    }
+
+    @Test
+    void failuresOnlyFiltersPrimaryOutputButKeepsJunitSidecarComplete() throws Exception {
+        writeMixedCoverageSample();
+        Path jsonReport = tempDir.resolve("target/crap-java/failures.json");
+        Path junitReport = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                new String[]{
+                        "--failures-only",
+                        "--format", "json",
+                        "--output", "target/crap-java/failures.json",
                         "--junit-report", "target/crap-java/TEST-crap-java.xml",
                         "src/main/java/demo/Sample.java"
                 },
@@ -408,6 +403,52 @@ class MainTest {
 
     private static String utf8(ByteArrayOutputStream output) {
         return output.toString(StandardCharsets.UTF_8);
+    }
+
+    private void writeMixedCoverageSample() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int danger(boolean left, boolean right) {
+                        if (left) {
+                            return 1;
+                        }
+                        if (right) {
+                            return 2;
+                        }
+                        return 0;
+                    }
+
+                    int safe() {
+                        return 1;
+                    }
+
+                    int unknown() {
+                        return 2;
+                    }
+                }
+                """);
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Files.createDirectories(jacocoXml.getParent());
+        Files.writeString(jacocoXml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="danger" desc="(ZZ)I" line="4">
+                        <counter type="INSTRUCTION" missed="10" covered="0"/>
+                      </method>
+                      <method name="safe" desc="()I" line="14">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
     }
 
     private static void writeCoverageXml(Path path, String className, String methodName, int line) throws Exception {

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -147,6 +147,37 @@ class ReportFormatterTest {
     }
 
     @Test
+    void formatsFailuresOnlyJsonWithOnlyFailedMethods() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.JSON, false, true);
+
+        String expected = """
+                {
+                  "status": "failed",
+                  "threshold": 8.0,
+                  "methods": [
+                    {
+                      "status": "failed",
+                      "crap": 9.645,
+                      "cc": 5,
+                      "cov": 10.0,
+                      "covKind": "instruction",
+                      "method": "danger",
+                      "src": "demo.Sample",
+                      "lineStart": 4,
+                      "lineEnd": 6
+                    }
+                  ]
+                }
+                """;
+
+        assertEquals(expected, report);
+    }
+
+    @Test
     void formatsAgentToonWithOnlyFailures() {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -178,6 +178,41 @@ class ReportFormatterTest {
     }
 
     @Test
+    void formatsFailuresOnlyTextWithOnlyFailedMethods() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.TEXT, false, true);
+
+        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 8.0\n"));
+        assertTrue(report.contains("Status"));
+        assertTrue(report.contains("failed"));
+        assertTrue(report.contains("danger"));
+        assertFalse(report.contains("safe"));
+        assertFalse(report.contains("unknown"));
+    }
+
+    @Test
+    void formatsFailuresOnlyJunitWithOnlyFailedMethods() throws Exception {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.JUNIT, false, true);
+
+        Element root = parseXml(report).getDocumentElement();
+
+        assertEquals("1", root.getAttribute("tests"));
+        assertEquals("1", root.getAttribute("failures"));
+        assertEquals("0", root.getAttribute("skipped"));
+        assertTrue(report.contains("FAILED danger"));
+        assertTrue(report.contains("<property name=\"threshold\" value=\"8.0\"/>"));
+        assertFalse(report.contains("PASSED safe"));
+        assertFalse(report.contains("SKIPPED unknown"));
+    }
+
+    @Test
     void formatsAgentToonWithOnlyFailures() {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),


### PR DESCRIPTION
Closes #79.

## Summary
- add `--failures-only[=true|false]` parsing and carry the option into primary report publishing
- filter primary report methods to failures when enabled while preserving run-level `status` and `threshold`
- keep JUnit sidecar generation on the full report

## Validation
- `mvn -B -pl core "-Dtest=CliArgumentsParserTest,ReportFormatterTest,MainTest" test`
- `mvn -B verify`