### PR TITLE
Add omitRedundancy primary report control

### DIFF
--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -116,6 +116,7 @@ final class CliApplication {
                 parsed.reportFormat(),
                 parsed.agent(),
                 parsed.failuresOnly(),
+                parsed.omitRedundancy(),
                 outputPath(parsed.outputPath()),
                 outputPath(parsed.junitReportPath())
         );

--- a/core/src/main/java/media/barney/crap/core/CliArguments.java
+++ b/core/src/main/java/media/barney/crap/core/CliArguments.java
@@ -10,6 +10,7 @@ record CliArguments(
         double threshold,
         boolean agent,
         boolean failuresOnly,
+        boolean omitRedundancy,
         @Nullable String outputPath,
         @Nullable String junitReportPath,
         List<String> fileArgs

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -19,6 +19,7 @@ final class CliArgumentsParser {
                     Thresholds.DEFAULT,
                     false,
                     false,
+                    false,
                     null,
                     null,
                     List.of()
@@ -34,6 +35,7 @@ final class CliArgumentsParser {
                     state.threshold,
                     state.agent,
                     state.failuresOnly,
+                    state.omitRedundancy,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -50,6 +52,7 @@ final class CliArgumentsParser {
                     state.threshold,
                     state.agent,
                     state.failuresOnly,
+                    state.omitRedundancy,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -63,6 +66,7 @@ final class CliArgumentsParser {
                     state.threshold,
                     state.agent,
                     state.failuresOnly,
+                    state.omitRedundancy,
                     state.outputPath,
                     state.junitReportPath,
                     List.of()
@@ -75,6 +79,7 @@ final class CliArgumentsParser {
                 state.threshold,
                 state.agent,
                 state.failuresOnly,
+                state.omitRedundancy,
                 state.outputPath,
                 state.junitReportPath,
                 List.copyOf(values)
@@ -115,6 +120,11 @@ final class CliArgumentsParser {
         if (isBooleanOption(arg, "--failures-only")) {
             state.failuresOnly = parseBooleanOption(arg, "--failures-only", state.failuresOnlySeen);
             state.failuresOnlySeen = true;
+            return index;
+        }
+        if (isBooleanOption(arg, "--omit-redundancy")) {
+            state.omitRedundancy = parseBooleanOption(arg, "--omit-redundancy", state.omitRedundancySeen);
+            state.omitRedundancySeen = true;
             return index;
         }
         return parseValuedOption(args, index, state, arg);
@@ -248,6 +258,7 @@ final class CliArgumentsParser {
                               double threshold,
                               boolean agent,
                               boolean failuresOnly,
+                              boolean omitRedundancy,
                               @Nullable String outputPath,
                               @Nullable String junitReportPath,
                               List<String> fileArgs) {
@@ -266,6 +277,8 @@ final class CliArgumentsParser {
         private boolean agentSeen;
         private boolean failuresOnly;
         private boolean failuresOnlySeen;
+        private boolean omitRedundancy;
+        private boolean omitRedundancySeen;
         private @Nullable String outputPath;
         private boolean outputPathSeen;
         private @Nullable String junitReportPath;
@@ -275,7 +288,7 @@ final class CliArgumentsParser {
         private ParseState build() {
             ensureAgentFormatIsSupported(agent, reportFormat);
             ensureFailuresOnlyDoesNotConflictWithAgent(agent, failuresOnly, failuresOnlySeen);
-            return new ParseState(help, changed, buildToolSelection, reportFormat, threshold, agent, failuresOnly, outputPath, junitReportPath, values);
+            return new ParseState(help, changed, buildToolSelection, reportFormat, threshold, agent, failuresOnly, omitRedundancy, outputPath, junitReportPath, values);
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -123,6 +123,7 @@ public final class Main {
                   crap-java --format json                 Write report as toon, json, text, or junit (default: toon)
                   crap-java --agent                       Write compact agent output (failures only; default format: toon)
                   crap-java --failures-only[=true|false]  Only include failing methods in the primary report
+                  crap-java --omit-redundancy[=true|false]  Omit redundant method fields from the primary report
                   crap-java --output report.toon          Write the selected report format to a file
                   crap-java --junit-report report.xml     Also write a JUnit XML report for CI
                   crap-java --threshold 6                 Override the CRAP threshold (default: 8.0)

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -42,39 +42,47 @@ final class ReportFormatter {
     }
 
     static String format(CrapReport report, ReportFormat format, boolean agent, boolean failuresOnly) {
-        if (agent) {
-            return formatAgent(report, format);
-        }
-        return formatFull(failuresOnly ? failuresOnly(report) : report, format);
+        return format(report, format, agent, failuresOnly, false);
     }
 
-    private static String formatFull(CrapReport report, ReportFormat format) {
+    static String format(CrapReport report,
+                         ReportFormat format,
+                         boolean agent,
+                         boolean failuresOnly,
+                         boolean omitRedundancy) {
+        if (agent) {
+            return formatAgent(report, format, omitRedundancy);
+        }
+        return formatFull(failuresOnly ? failuresOnly(report) : report, format, omitRedundancy);
+    }
+
+    private static String formatFull(CrapReport report, ReportFormat format, boolean omitRedundancy) {
         return switch (format) {
-            case TOON -> JToon.encodeJson(formatJson(report));
-            case JSON -> formatJson(report);
-            case TEXT -> formatText(report);
-            case JUNIT -> formatJunit(report);
+            case TOON -> JToon.encodeJson(formatJson(report, omitRedundancy));
+            case JSON -> formatJson(report, omitRedundancy);
+            case TEXT -> formatText(report, omitRedundancy);
+            case JUNIT -> formatJunit(report, omitRedundancy);
         };
     }
 
-    private static String formatAgent(CrapReport report, ReportFormat format) {
+    private static String formatAgent(CrapReport report, ReportFormat format, boolean omitRedundancy) {
         CrapReport failures = failuresOnly(report);
         return switch (format) {
-            case TOON -> JToon.encodeJson(formatJson(failures));
-            case JSON -> formatJson(failures);
+            case TOON -> JToon.encodeJson(formatJson(failures, omitRedundancy));
+            case JSON -> formatJson(failures, omitRedundancy);
             case TEXT -> formatAgentText(report);
             case JUNIT -> throw new IllegalArgumentException("--agent cannot be combined with --format junit");
         };
     }
 
-    private static String formatText(CrapReport report) {
+    private static String formatText(CrapReport report, boolean omitRedundancy) {
         List<CrapReport.MethodReport> sorted = sortedMethods(report.methods());
         StringBuilder builder = new StringBuilder();
         builder.append("CRAP Report\n");
         builder.append("===========\n");
         builder.append("Status: ").append(report.status()).append('\n');
         builder.append("Threshold: ").append(formatDisplayNumber(report.threshold())).append('\n');
-        appendMethodTable(builder, fullTextColumns(), sorted);
+        appendMethodTable(builder, omitRedundancy ? methodTextColumns() : fullTextColumns(), sorted);
         return builder.toString();
     }
 
@@ -175,12 +183,12 @@ final class ReportFormatter {
         builder.append('\n');
     }
 
-    private static String formatJson(CrapReport report) {
-        return writeJson(jsonReport(report));
+    private static String formatJson(CrapReport report, boolean omitRedundancy) {
+        return writeJson(jsonReport(report, omitRedundancy));
     }
 
-    private static String formatJunit(CrapReport report) {
-        return writeXml(junitTestSuites(report));
+    private static String formatJunit(CrapReport report, boolean omitRedundancy) {
+        return writeXml(junitTestSuites(report, omitRedundancy));
     }
 
     private static int countStatus(List<CrapReport.MethodReport> methods, MethodStatus status) {
@@ -193,19 +201,19 @@ final class ReportFormatter {
         return count;
     }
 
-    private static JsonReport jsonReport(CrapReport report) {
+    private static JsonReport jsonReport(CrapReport report, boolean omitRedundancy) {
         return new JsonReport(
                 report.status(),
                 report.threshold(),
                 sortedMethods(report.methods()).stream()
-                        .map(ReportFormatter::jsonMethod)
+                        .map(method -> jsonMethod(method, omitRedundancy))
                         .toList()
         );
     }
 
-    private static JsonMethod jsonMethod(CrapReport.MethodReport method) {
+    private static JsonMethod jsonMethod(CrapReport.MethodReport method, boolean omitRedundancy) {
         return new JsonMethod(
-                method.status().value(),
+                omitRedundancy ? null : method.status().value(),
                 method.crapScore(),
                 method.complexity(),
                 method.coveragePercent(),
@@ -225,7 +233,7 @@ final class ReportFormatter {
         }
     }
 
-    private static JunitTestSuites junitTestSuites(CrapReport report) {
+    private static JunitTestSuites junitTestSuites(CrapReport report, boolean omitRedundancy) {
         List<CrapReport.MethodReport> methods = sortedMethods(report.methods());
         int failed = countStatus(methods, MethodStatus.FAILED);
         int skipped = countStatus(methods, MethodStatus.SKIPPED);
@@ -238,34 +246,44 @@ final class ReportFormatter {
                 "0",
                 new JunitProperties(List.of(new JunitProperty("threshold", number(report.threshold())))),
                 methods.stream()
-                        .map(method -> junitTestCase(method, report.threshold()))
+                        .map(method -> junitTestCase(method, report.threshold(), omitRedundancy))
                         .toList()
         );
         return new JunitTestSuites(methods.size(), failed, 0, skipped, "0", List.of(testSuite));
     }
 
-    private static JunitTestCase junitTestCase(CrapReport.MethodReport method, double threshold) {
+    private static JunitTestCase junitTestCase(CrapReport.MethodReport method,
+                                               double threshold,
+                                               boolean omitRedundancy) {
         return new JunitTestCase(
                 method.className(),
                 testcaseName(method),
                 method.sourcePath(),
                 method.startLine(),
                 "0",
-                new JunitProperties(List.of(
-                        new JunitProperty("status", method.status().value()),
-                        new JunitProperty("methodName", method.methodName()),
-                        new JunitProperty("className", method.className()),
-                        new JunitProperty("sourcePath", method.sourcePath()),
-                        new JunitProperty("startLine", Integer.toString(method.startLine())),
-                        new JunitProperty("endLine", Integer.toString(method.endLine())),
-                        new JunitProperty("complexity", Integer.toString(method.complexity())),
-                        new JunitProperty("coverageKind", method.coverageKind()),
-                        new JunitProperty("coveragePercent", nullableProperty(method.coveragePercent())),
-                        new JunitProperty("crapScore", nullableProperty(method.crapScore()))
-                )),
+                junitProperties(method, omitRedundancy),
                 junitFailure(method, threshold),
                 junitSkipped(method)
         );
+    }
+
+    private static JunitProperties junitProperties(CrapReport.MethodReport method, boolean omitRedundancy) {
+        List<JunitProperty> properties = new ArrayList<>();
+        if (!omitRedundancy) {
+            properties.add(new JunitProperty("status", method.status().value()));
+        }
+        properties.addAll(List.of(
+                new JunitProperty("methodName", method.methodName()),
+                new JunitProperty("className", method.className()),
+                new JunitProperty("sourcePath", method.sourcePath()),
+                new JunitProperty("startLine", Integer.toString(method.startLine())),
+                new JunitProperty("endLine", Integer.toString(method.endLine())),
+                new JunitProperty("complexity", Integer.toString(method.complexity())),
+                new JunitProperty("coverageKind", method.coverageKind()),
+                new JunitProperty("coveragePercent", nullableProperty(method.coveragePercent())),
+                new JunitProperty("crapScore", nullableProperty(method.crapScore()))
+        ));
+        return new JunitProperties(properties);
     }
 
     private static @Nullable JunitFailure junitFailure(CrapReport.MethodReport method, double threshold) {
@@ -358,7 +376,8 @@ final class ReportFormatter {
     }
 
     private record JsonMethod(
-            String status,
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            @Nullable String status,
             @Nullable Double crap,
             int cc,
             @Nullable Double cov,

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -7,10 +7,11 @@ record ReportOptions(
         ReportFormat format,
         boolean agent,
         boolean failuresOnly,
+        boolean omitRedundancy,
         @Nullable Path outputPath,
         @Nullable Path junitReportPath
 ) {
     static ReportOptions textWithOptionalJunit(@Nullable Path junitReportPath) {
-        return new ReportOptions(ReportFormat.TEXT, false, false, null, junitReportPath);
+        return new ReportOptions(ReportFormat.TEXT, false, false, false, null, junitReportPath);
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportPublisher.java
+++ b/core/src/main/java/media/barney/crap/core/ReportPublisher.java
@@ -19,7 +19,13 @@ final class ReportPublisher {
     }
 
     private static void publishPrimary(CrapReport report, ReportOptions options, PrintStream out) throws IOException {
-        String content = ReportFormatter.format(report, options.format(), options.agent(), options.failuresOnly());
+        String content = ReportFormatter.format(
+                report,
+                options.format(),
+                options.agent(),
+                options.failuresOnly(),
+                options.omitRedundancy()
+        );
         if (options.outputPath() == null) {
             out.print(content);
             return;

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -20,6 +20,7 @@ class CliArgumentsParserTest {
         assertEquals(Main.DEFAULT_THRESHOLD, args.threshold());
         assertFalse(args.agent());
         assertFalse(args.failuresOnly());
+        assertFalse(args.omitRedundancy());
     }
 
     @Test
@@ -65,6 +66,7 @@ class CliArgumentsParserTest {
         assertEquals(Main.DEFAULT_THRESHOLD, args.threshold());
         assertFalse(args.agent());
         assertFalse(args.failuresOnly());
+        assertFalse(args.omitRedundancy());
         assertEquals("target/crap-java/report.json", args.outputPath());
         assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
         assertEquals(List.of("src/main/java/demo/A.java"), args.fileArgs());
@@ -150,6 +152,41 @@ class CliArgumentsParserTest {
     void failuresOnlyFlagCanOnlyBeProvidedOnce() {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--failures-only", "--failures-only=false"}));
+    }
+
+    @Test
+    void omitRedundancyFlagDefaultsToTrueWhenUnassigned() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{"--omit-redundancy", "--changed"});
+
+        assertEquals(CliMode.CHANGED_SRC, args.mode());
+        assertTrue(args.omitRedundancy());
+    }
+
+    @Test
+    void omitRedundancyFlagAcceptsExplicitBooleanAssignments() {
+        CliArguments enabled = CliArgumentsParser.parse(new String[]{"--omit-redundancy=true", "--changed"});
+        CliArguments disabled = CliArgumentsParser.parse(new String[]{"--omit-redundancy=false", "--changed"});
+        CliArguments enabledUppercase = CliArgumentsParser.parse(new String[]{"--omit-redundancy=TRUE", "--changed"});
+        CliArguments disabledUppercase = CliArgumentsParser.parse(new String[]{"--omit-redundancy=FALSE", "--changed"});
+
+        assertTrue(enabled.omitRedundancy());
+        assertFalse(disabled.omitRedundancy());
+        assertTrue(enabledUppercase.omitRedundancy());
+        assertFalse(disabledUppercase.omitRedundancy());
+    }
+
+    @Test
+    void omitRedundancyFlagRejectsInvalidAssignments() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--omit-redundancy=yes", "--changed"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--omit-redundancy=", "--changed"}));
+    }
+
+    @Test
+    void omitRedundancyFlagCanOnlyBeProvidedOnce() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--omit-redundancy", "--omit-redundancy=false"}));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -35,6 +35,7 @@ class MainTest {
         assertTrue(utf8(out).contains("--format"));
         assertTrue(utf8(out).contains("--agent"));
         assertTrue(utf8(out).contains("--failures-only"));
+        assertTrue(utf8(out).contains("--omit-redundancy"));
         assertTrue(utf8(out).contains("--threshold"));
     }
 
@@ -297,6 +298,42 @@ class MainTest {
         assertTrue(junit.contains("FAILED danger"));
         assertTrue(junit.contains("PASSED safe"));
         assertTrue(junit.contains("SKIPPED unknown"));
+    }
+
+    @Test
+    void omitRedundancyOmitsPrimaryStatusFieldsButKeepsJunitSidecarComplete() throws Exception {
+        writeMixedCoverageSample();
+        Path jsonReport = tempDir.resolve("target/crap-java/compact.json");
+        Path junitReport = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                new String[]{
+                        "--omit-redundancy",
+                        "--format", "json",
+                        "--output", "target/crap-java/compact.json",
+                        "--junit-report", "target/crap-java/TEST-crap-java.xml",
+                        "src/main/java/demo/Sample.java"
+                },
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        String primary = Files.readString(jsonReport);
+        String junit = Files.readString(junitReport);
+        assertEquals(2, exit);
+        assertEquals("", utf8(out));
+        assertTrue(primary.contains("\"status\": \"failed\""));
+        assertTrue(primary.contains("\"threshold\": 8.0"));
+        assertFalse(primary.contains("      \"status\":"));
+        assertTrue(primary.contains("\"method\": \"danger\""));
+        assertTrue(primary.contains("\"method\": \"safe\""));
+        assertTrue(primary.contains("\"method\": \"unknown\""));
+        assertTrue(junit.contains("<property name=\"status\" value=\"failed\"/>"));
+        assertTrue(junit.contains("<property name=\"status\" value=\"passed\"/>"));
+        assertTrue(junit.contains("<property name=\"status\" value=\"skipped\"/>"));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -213,6 +213,92 @@ class ReportFormatterTest {
     }
 
     @Test
+    void formatsOmitRedundancyJsonWithoutMethodStatus() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.JSON, false, false, true);
+
+        String expected = """
+                {
+                  "status": "failed",
+                  "threshold": 8.0,
+                  "methods": [
+                    {
+                      "crap": 9.645,
+                      "cc": 5,
+                      "cov": 10.0,
+                      "covKind": "instruction",
+                      "method": "danger",
+                      "src": "demo.Sample",
+                      "lineStart": 4,
+                      "lineEnd": 6
+                    },
+                    {
+                      "crap": null,
+                      "cc": 2,
+                      "cov": null,
+                      "covKind": "N/A",
+                      "method": "unknown",
+                      "src": "demo.Sample",
+                      "lineStart": 20,
+                      "lineEnd": 22
+                    }
+                  ]
+                }
+                """;
+
+        assertEquals(expected, report);
+    }
+
+    @Test
+    void formatsOmitRedundancyToonWithoutMethodStatus() {
+        String report = ReportFormatter.format(report(
+                metric("foo", "demo.Sample", 4, 3, 85.0, 4.5),
+                metric("bar", "demo.Sample", 9, 2, null, null)
+        ), ReportFormat.TOON, false, false, true);
+
+        assertTrue(report.contains("status: passed"));
+        assertTrue(report.contains("threshold: 8"));
+        assertTrue(report.contains("methods[2]{crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
+        assertTrue(report.contains("4.5,3,85,instruction,foo,demo.Sample,4,6"));
+        assertTrue(report.contains("null,2,null,N/A,bar,demo.Sample,9,11"));
+        assertFalse(report.contains("methods[2]{status,"));
+    }
+
+    @Test
+    void formatsOmitRedundancyTextWithoutMethodStatusColumn() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("safe", "demo.Sample", 9, 1, 100.0, 1.0)
+        ), ReportFormat.TEXT, false, false, true);
+
+        List<String> lines = report.lines().toList();
+        int headerIndex = tableHeaderIndex(lines, "Method");
+
+        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 8.0\n"));
+        assertTrue(lines.get(headerIndex).startsWith("Method"));
+        assertFalse(lines.get(headerIndex).startsWith("Status"));
+        assertTrue(report.contains("danger"));
+        assertTrue(report.contains("safe"));
+    }
+
+    @Test
+    void formatsOmitRedundancyJunitWithoutStatusProperty() throws Exception {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
+                metric("unknown", "demo.Sample", 20, 2, null, null)
+        ), ReportFormat.JUNIT, false, false, true);
+
+        Element root = parseXml(report).getDocumentElement();
+
+        assertEquals("2", root.getAttribute("tests"));
+        assertTrue(report.contains("<property name=\"threshold\" value=\"8.0\"/>"));
+        assertTrue(report.contains("<property name=\"methodName\" value=\"danger\"/>"));
+        assertFalse(report.contains("<property name=\"status\""));
+    }
+
+    @Test
     void formatsAgentToonWithOnlyFailures() {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),


### PR DESCRIPTION
Closes #81.

## Summary
- add `--omit-redundancy[=true|false]` parsing and carry the option into primary report publishing
- omit per-method `status` from primary JSON/TOON/TEXT/JUnit reports while preserving report-level `status` and `threshold`
- keep JUnit sidecar reports full and unaffected by the primary report control

## Validation
- `mvn -B -pl core "-Dtest=CliArgumentsParserTest,ReportFormatterTest,MainTest" test`
- `mvn -B verify`