### PR TITLE
Redefine agent as composite primary report shortcut

### DIFF
--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -114,7 +114,6 @@ final class CliApplication {
     private ReportOptions reportOptions(CliArguments parsed) {
         return new ReportOptions(
                 parsed.reportFormat(),
-                parsed.agent(),
                 parsed.failuresOnly(),
                 parsed.omitRedundancy(),
                 outputPath(parsed.outputPath()),

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -237,20 +237,6 @@ final class CliArgumentsParser {
         }
     }
 
-    private static void ensureAgentFormatIsSupported(boolean agent, ReportFormat reportFormat) {
-        if (agent && reportFormat == ReportFormat.JUNIT) {
-            throw new IllegalArgumentException("--agent cannot be combined with --format junit");
-        }
-    }
-
-    private static void ensureFailuresOnlyDoesNotConflictWithAgent(boolean agent,
-                                                                   boolean failuresOnly,
-                                                                   boolean failuresOnlySeen) {
-        if (agent && failuresOnlySeen && !failuresOnly) {
-            throw new IllegalArgumentException("--agent cannot be combined with --failures-only=false");
-        }
-    }
-
     private record ParseState(boolean help,
                               boolean changed,
                               BuildToolSelection buildToolSelection,
@@ -286,9 +272,21 @@ final class CliArgumentsParser {
         private final List<String> values = new ArrayList<>();
 
         private ParseState build() {
-            ensureAgentFormatIsSupported(agent, reportFormat);
-            ensureFailuresOnlyDoesNotConflictWithAgent(agent, failuresOnly, failuresOnlySeen);
-            return new ParseState(help, changed, buildToolSelection, reportFormat, threshold, agent, failuresOnly, omitRedundancy, outputPath, junitReportPath, values);
+            boolean effectiveFailuresOnly = (agent && !failuresOnlySeen) || failuresOnly;
+            boolean effectiveOmitRedundancy = (agent && !omitRedundancySeen) || omitRedundancy;
+            return new ParseState(
+                    help,
+                    changed,
+                    buildToolSelection,
+                    reportFormat,
+                    threshold,
+                    agent,
+                    effectiveFailuresOnly,
+                    effectiveOmitRedundancy,
+                    outputPath,
+                    junitReportPath,
+                    values
+            );
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -121,7 +121,7 @@ public final class Main {
                   crap-java --build-tool gradle           Force Gradle for all resolved modules
                   crap-java --build-tool maven --changed  Force Maven for changed files
                   crap-java --format json                 Write report as toon, json, text, or junit (default: toon)
-                  crap-java --agent                       Write compact agent output (failures only; default format: toon)
+                  crap-java --agent                       Apply AI-agent defaults: toon, failures only, omit redundancy
                   crap-java --failures-only[=true|false]  Only include failing methods in the primary report
                   crap-java --omit-redundancy[=true|false]  Omit redundant method fields from the primary report
                   crap-java --output report.toon          Write the selected report format to a file

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -34,25 +34,10 @@ final class ReportFormatter {
     }
 
     static String format(CrapReport report, ReportFormat format) {
-        return format(report, format, false);
+        return format(report, format, false, false);
     }
 
-    static String format(CrapReport report, ReportFormat format, boolean agent) {
-        return format(report, format, agent, false);
-    }
-
-    static String format(CrapReport report, ReportFormat format, boolean agent, boolean failuresOnly) {
-        return format(report, format, agent, failuresOnly, false);
-    }
-
-    static String format(CrapReport report,
-                         ReportFormat format,
-                         boolean agent,
-                         boolean failuresOnly,
-                         boolean omitRedundancy) {
-        if (agent) {
-            return formatAgent(report, format, omitRedundancy);
-        }
+    static String format(CrapReport report, ReportFormat format, boolean failuresOnly, boolean omitRedundancy) {
         return formatFull(failuresOnly ? failuresOnly(report) : report, format, omitRedundancy);
     }
 
@@ -62,16 +47,6 @@ final class ReportFormatter {
             case JSON -> formatJson(report, omitRedundancy);
             case TEXT -> formatText(report, omitRedundancy);
             case JUNIT -> formatJunit(report, omitRedundancy);
-        };
-    }
-
-    private static String formatAgent(CrapReport report, ReportFormat format, boolean omitRedundancy) {
-        CrapReport failures = failuresOnly(report);
-        return switch (format) {
-            case TOON -> JToon.encodeJson(formatJson(failures, omitRedundancy));
-            case JSON -> formatJson(failures, omitRedundancy);
-            case TEXT -> formatAgentText(report);
-            case JUNIT -> throw new IllegalArgumentException("--agent cannot be combined with --format junit");
         };
     }
 
@@ -86,27 +61,11 @@ final class ReportFormatter {
         return builder.toString();
     }
 
-    private static String formatAgentText(CrapReport report) {
-        List<CrapReport.MethodReport> failedMethods = sortedMethods(failuresOnly(report).methods());
-        StringBuilder builder = new StringBuilder();
-        builder.append("Status: ").append(report.status()).append('\n');
-        builder.append("Threshold: ").append(formatDisplayNumber(report.threshold())).append('\n');
-        if (failedMethods.isEmpty()) {
-            return builder.toString();
-        }
-        appendMethodTable(builder, agentTextColumns(), failedMethods);
-        return builder.toString();
-    }
-
     private static List<TableColumn> fullTextColumns() {
         List<TableColumn> columns = new ArrayList<>();
         columns.add(new TableColumn("Status", Alignment.LEFT, method -> method.status().value()));
         columns.addAll(methodTextColumns());
         return columns;
-    }
-
-    private static List<TableColumn> agentTextColumns() {
-        return methodTextColumns();
     }
 
     private static List<TableColumn> methodTextColumns() {

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -5,13 +5,12 @@ import org.jspecify.annotations.Nullable;
 
 record ReportOptions(
         ReportFormat format,
-        boolean agent,
         boolean failuresOnly,
         boolean omitRedundancy,
         @Nullable Path outputPath,
         @Nullable Path junitReportPath
 ) {
     static ReportOptions textWithOptionalJunit(@Nullable Path junitReportPath) {
-        return new ReportOptions(ReportFormat.TEXT, false, false, false, null, junitReportPath);
+        return new ReportOptions(ReportFormat.TEXT, false, false, null, junitReportPath);
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportPublisher.java
+++ b/core/src/main/java/media/barney/crap/core/ReportPublisher.java
@@ -22,7 +22,6 @@ final class ReportPublisher {
         String content = ReportFormatter.format(
                 report,
                 options.format(),
-                options.agent(),
                 options.failuresOnly(),
                 options.omitRedundancy()
         );

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -79,30 +79,40 @@ class CliArgumentsParserTest {
         assertEquals(CliMode.CHANGED_SRC, args.mode());
         assertEquals(ReportFormat.TOON, args.reportFormat());
         assertTrue(args.agent());
+        assertTrue(args.failuresOnly());
+        assertTrue(args.omitRedundancy());
     }
 
     @Test
-    void agentModeAllowsNonJunitPrimaryFormatsJunitSidecarAndThreshold() {
+    void agentModeAllowsPrimaryFormatJunitSidecarAndThresholdOverrides() {
         CliArguments args = CliArgumentsParser.parse(new String[]{
                 "--agent",
-                "--format", "text",
+                "--format", "junit",
                 "--junit-report", "target/crap-java/TEST-crap-java.xml",
                 "--threshold", "6.0",
                 "--changed"
         });
 
-        assertEquals(ReportFormat.TEXT, args.reportFormat());
+        assertEquals(ReportFormat.JUNIT, args.reportFormat());
         assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
         assertEquals(6.0, args.threshold());
         assertTrue(args.agent());
+        assertTrue(args.failuresOnly());
+        assertTrue(args.omitRedundancy());
     }
 
     @Test
-    void agentModeRejectsJunitPrimaryFormat() {
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--agent", "--format", "junit"}));
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--format", "junit", "--agent"}));
+    void agentModeAllowsExplicitBooleanOverrides() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{
+                "--agent",
+                "--failures-only=false",
+                "--omit-redundancy=false",
+                "--changed"
+        });
+
+        assertTrue(args.agent());
+        assertFalse(args.failuresOnly());
+        assertFalse(args.omitRedundancy());
     }
 
     @Test
@@ -112,11 +122,12 @@ class CliArgumentsParserTest {
     }
 
     @Test
-    void agentModeRejectsExplicitFailuresOnlyFalse() {
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--agent", "--failures-only=false"}));
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--failures-only=false", "--agent"}));
+    void agentModeAllowsExplicitFailuresOnlyFalseBeforeAgent() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{"--failures-only=false", "--agent", "--changed"});
+
+        assertTrue(args.agent());
+        assertFalse(args.failuresOnly());
+        assertTrue(args.omitRedundancy());
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -229,7 +229,7 @@ class MainTest {
     }
 
     @Test
-    void agentModeFiltersPrimaryOutputButKeepsJunitSidecarComplete() throws Exception {
+    void agentModeComposesPrimaryDefaultsButKeepsJunitSidecarComplete() throws Exception {
         writeMixedCoverageSample();
         Path jsonReport = tempDir.resolve("target/crap-java/agent.json");
         Path junitReport = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
@@ -255,6 +255,7 @@ class MainTest {
         assertEquals("", utf8(out));
         assertTrue(primary.contains("\"status\": \"failed\""));
         assertTrue(primary.contains("\"threshold\": 8.0"));
+        assertFalse(primary.contains("      \"status\":"));
         assertTrue(primary.contains("\"method\": \"danger\""));
         assertFalse(primary.contains("\"method\": \"safe\""));
         assertFalse(primary.contains("\"method\": \"unknown\""));
@@ -262,6 +263,39 @@ class MainTest {
         assertTrue(junit.contains("FAILED danger"));
         assertTrue(junit.contains("PASSED safe"));
         assertTrue(junit.contains("SKIPPED unknown"));
+    }
+
+    @Test
+    void agentModeAllowsExplicitPrimaryControlOverrides() throws Exception {
+        writeMixedCoverageSample();
+        Path jsonReport = tempDir.resolve("target/crap-java/agent-full.json");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                new String[]{
+                        "--agent",
+                        "--format", "json",
+                        "--failures-only=false",
+                        "--omit-redundancy=false",
+                        "--output", "target/crap-java/agent-full.json",
+                        "src/main/java/demo/Sample.java"
+                },
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        String primary = Files.readString(jsonReport);
+        assertEquals(2, exit);
+        assertEquals("", utf8(out));
+        assertTrue(primary.contains("\"status\": \"failed\""));
+        assertTrue(primary.contains("      \"status\": \"failed\""));
+        assertTrue(primary.contains("      \"status\": \"passed\""));
+        assertTrue(primary.contains("      \"status\": \"skipped\""));
+        assertTrue(primary.contains("\"method\": \"danger\""));
+        assertTrue(primary.contains("\"method\": \"safe\""));
+        assertTrue(primary.contains("\"method\": \"unknown\""));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -116,12 +116,12 @@ class ReportFormatterTest {
     }
 
     @Test
-    void formatsAgentJsonWithOnlyFailuresAndGlobalStatusThreshold() {
+    void formatsFailuresOnlyOmitRedundancyJsonWithOnlyFailuresAndGlobalStatusThreshold() {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
                 metric("unknown", "demo.Sample", 20, 2, null, null)
-        ), ReportFormat.JSON, true);
+        ), ReportFormat.JSON, true, true);
 
         String expected = """
                 {
@@ -129,7 +129,6 @@ class ReportFormatterTest {
                   "threshold": 8.0,
                   "methods": [
                     {
-                      "status": "failed",
                       "crap": 9.645,
                       "cc": 5,
                       "cov": 10.0,
@@ -152,7 +151,7 @@ class ReportFormatterTest {
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
                 metric("unknown", "demo.Sample", 20, 2, null, null)
-        ), ReportFormat.JSON, false, true);
+        ), ReportFormat.JSON, true, false);
 
         String expected = """
                 {
@@ -183,7 +182,7 @@ class ReportFormatterTest {
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
                 metric("unknown", "demo.Sample", 20, 2, null, null)
-        ), ReportFormat.TEXT, false, true);
+        ), ReportFormat.TEXT, true, false);
 
         assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 8.0\n"));
         assertTrue(report.contains("Status"));
@@ -199,7 +198,7 @@ class ReportFormatterTest {
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
                 metric("unknown", "demo.Sample", 20, 2, null, null)
-        ), ReportFormat.JUNIT, false, true);
+        ), ReportFormat.JUNIT, true, false);
 
         Element root = parseXml(report).getDocumentElement();
 
@@ -217,7 +216,7 @@ class ReportFormatterTest {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("unknown", "demo.Sample", 20, 2, null, null)
-        ), ReportFormat.JSON, false, false, true);
+        ), ReportFormat.JSON, false, true);
 
         String expected = """
                 {
@@ -256,7 +255,7 @@ class ReportFormatterTest {
         String report = ReportFormatter.format(report(
                 metric("foo", "demo.Sample", 4, 3, 85.0, 4.5),
                 metric("bar", "demo.Sample", 9, 2, null, null)
-        ), ReportFormat.TOON, false, false, true);
+        ), ReportFormat.TOON, false, true);
 
         assertTrue(report.contains("status: passed"));
         assertTrue(report.contains("threshold: 8"));
@@ -271,7 +270,7 @@ class ReportFormatterTest {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("safe", "demo.Sample", 9, 1, 100.0, 1.0)
-        ), ReportFormat.TEXT, false, false, true);
+        ), ReportFormat.TEXT, false, true);
 
         List<String> lines = report.lines().toList();
         int headerIndex = tableHeaderIndex(lines, "Method");
@@ -288,7 +287,7 @@ class ReportFormatterTest {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("unknown", "demo.Sample", 20, 2, null, null)
-        ), ReportFormat.JUNIT, false, false, true);
+        ), ReportFormat.JUNIT, false, true);
 
         Element root = parseXml(report).getDocumentElement();
 
@@ -299,51 +298,51 @@ class ReportFormatterTest {
     }
 
     @Test
-    void formatsAgentToonWithOnlyFailures() {
+    void formatsFailuresOnlyOmitRedundancyToonWithOnlyFailures() {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("safe", "demo.Sample", 9, 1, 100.0, 1.0)
-        ), ReportFormat.TOON, true);
+        ), ReportFormat.TOON, true, true);
 
         assertTrue(report.contains("status: failed"));
         assertTrue(report.contains("threshold: 8"));
-        assertTrue(report.contains("methods[1]{status,crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
-        assertTrue(report.contains("failed,9.645,5,10,instruction,danger,demo.Sample,4,6"));
+        assertTrue(report.contains("methods[1]{crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
+        assertTrue(report.contains("9.645,5,10,instruction,danger,demo.Sample,4,6"));
     }
 
     @Test
-    void formatsAgentTextWithOnlyFailures() {
+    void formatsFailuresOnlyOmitRedundancyTextWithOnlyFailures() {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
                 metric("unknown", "demo.Sample", 20, 2, null, null)
-        ), ReportFormat.TEXT, true);
+        ), ReportFormat.TEXT, true, true);
 
-        assertTrue(report.startsWith("Status: failed\nThreshold: 8.0\n"));
+        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 8.0\n"));
         assertTrue(report.contains("Method"));
         assertTrue(report.contains("danger"));
         assertTrue(report.contains("9.6"));
         assertFalse(report.contains("safe"));
         assertFalse(report.contains("unknown"));
-        assertFalse(report.contains("CRAP Report"));
 
         List<String> lines = report.lines().toList();
         int headerIndex = tableHeaderIndex(lines, "Method");
+        assertTrue(lines.get(headerIndex).startsWith("Method"));
         assertEquals(lines.get(headerIndex).length(), lines.get(headerIndex + 1).length());
         assertEquals(lines.get(headerIndex).length(), lines.get(headerIndex + 2).length());
     }
 
     @Test
-    void formatsAgentTextWithoutMethodRowsWhenPassed() {
+    void formatsFailuresOnlyOmitRedundancyTextWithoutMethodRowsWhenPassed() {
         String report = ReportFormatter.format(report(
                 metric("safe", "demo.Sample", 9, 1, 100.0, 1.0),
                 metric("unknown", "demo.Sample", 20, 2, null, null)
-        ), ReportFormat.TEXT, true);
+        ), ReportFormat.TEXT, true, true);
 
-        assertEquals("""
-                Status: passed
-                Threshold: 8.0
-                """, report);
+        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: passed\nThreshold: 8.0\n"));
+        assertTrue(report.contains("Method"));
+        assertFalse(report.contains("safe"));
+        assertFalse(report.contains("unknown"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make `--agent` apply composite defaults for toon, failures-only, and omit-redundancy primary output
- allow explicit `--format`, `--failures-only=false`, and `--omit-redundancy=false` to override agent defaults
- keep JUnit sidecar generation independent of agent primary-output filtering

Closes #83

## Validation
- `mvn -B -pl core "-Dtest=CliArgumentsParserTest,ReportFormatterTest,MainTest" test`
- `mvn -B verify`