### PR TITLE
Add none primary report format

### DIFF
--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -202,7 +202,7 @@ final class CliArgumentsParser {
             throw new IllegalArgumentException("--format can only be provided once");
         }
         if (index + 1 >= args.length) {
-            throw new IllegalArgumentException("--format requires one of: toon, json, text, junit");
+            throw new IllegalArgumentException("--format requires one of: toon, json, text, junit, none");
         }
         return ReportFormat.parse(args[index + 1]);
     }

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -120,7 +120,7 @@ public final class Main {
                   crap-java --changed                      Analyze changed Java files under any nested src/main/java tree
                   crap-java --build-tool gradle           Force Gradle for all resolved modules
                   crap-java --build-tool maven --changed  Force Maven for changed files
-                  crap-java --format json                 Write report as toon, json, text, or junit (default: toon)
+                  crap-java --format json                 Write report as toon, json, text, junit, or none (default: toon)
                   crap-java --agent                       Apply AI-agent defaults: toon, failures only, omit redundancy
                   crap-java --failures-only[=true|false]  Only include failing methods in the primary report
                   crap-java --omit-redundancy[=true|false]  Omit redundant method fields from the primary report

--- a/core/src/main/java/media/barney/crap/core/ReportFormat.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormat.java
@@ -6,7 +6,8 @@ enum ReportFormat {
     TOON,
     JSON,
     TEXT,
-    JUNIT;
+    JUNIT,
+    NONE;
 
     static ReportFormat parse(String value) {
         return switch (value.toLowerCase(Locale.ROOT)) {
@@ -14,6 +15,7 @@ enum ReportFormat {
             case "json" -> JSON;
             case "text" -> TEXT;
             case "junit" -> JUNIT;
+            case "none" -> NONE;
             default -> throw new IllegalArgumentException("Unknown report format: " + value);
         };
     }

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -38,6 +38,9 @@ final class ReportFormatter {
     }
 
     static String format(CrapReport report, ReportFormat format, boolean failuresOnly, boolean omitRedundancy) {
+        if (format == ReportFormat.NONE) {
+            return "";
+        }
         return formatFull(failuresOnly ? failuresOnly(report) : report, format, omitRedundancy);
     }
 

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -47,6 +47,7 @@ final class ReportFormatter {
             case JSON -> formatJson(report, omitRedundancy);
             case TEXT -> formatText(report, omitRedundancy);
             case JUNIT -> formatJunit(report, omitRedundancy);
+            case NONE -> "";
         };
     }
 

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -215,8 +215,9 @@ class CliArgumentsParserTest {
 
     @Test
     void reportFormatRequiresValue() {
-        assertThrows(IllegalArgumentException.class,
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--format"}));
+        assertEquals("--format requires one of: toon, json, text, junit, none", error.getMessage());
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -207,6 +207,13 @@ class CliArgumentsParserTest {
     }
 
     @Test
+    void noneReportFormatIsParsed() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{"--format", "none", "--changed"});
+
+        assertEquals(ReportFormat.NONE, args.reportFormat());
+    }
+
+    @Test
     void reportFormatRequiresValue() {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--format"}));

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -229,6 +229,61 @@ class MainTest {
     }
 
     @Test
+    void noneFormatSuppressesStdoutButKeepsJunitSidecarComplete() throws Exception {
+        writeMixedCoverageSample();
+        Path junitReport = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                new String[]{
+                        "--format", "none",
+                        "--junit-report", "target/crap-java/TEST-crap-java.xml",
+                        "src/main/java/demo/Sample.java"
+                },
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        String junit = Files.readString(junitReport);
+        assertEquals(2, exit);
+        assertEquals("", utf8(out));
+        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(junit.contains("FAILED danger"));
+        assertTrue(junit.contains("PASSED safe"));
+        assertTrue(junit.contains("SKIPPED unknown"));
+    }
+
+    @Test
+    void noneFormatWritesEmptyPrimaryFileWhenOutputConfigured() throws Exception {
+        writeMixedCoverageSample();
+        Path primaryReport = tempDir.resolve("target/crap-java/empty.report");
+        Path junitReport = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                new String[]{
+                        "--format", "none",
+                        "--output", "target/crap-java/empty.report",
+                        "--junit-report", "target/crap-java/TEST-crap-java.xml",
+                        "src/main/java/demo/Sample.java"
+                },
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err)
+        );
+
+        String junit = Files.readString(junitReport);
+        assertEquals(2, exit);
+        assertEquals("", utf8(out));
+        assertTrue(Files.exists(primaryReport));
+        assertEquals("", Files.readString(primaryReport));
+        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+    }
+
+    @Test
     void agentModeComposesPrimaryDefaultsButKeepsJunitSidecarComplete() throws Exception {
         writeMixedCoverageSample();
         Path jsonReport = tempDir.resolve("target/crap-java/agent.json");

--- a/core/src/test/java/media/barney/crap/core/ReportFormatTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatTest.java
@@ -13,6 +13,7 @@ class ReportFormatTest {
         assertEquals(ReportFormat.JSON, ReportFormat.parse("json"));
         assertEquals(ReportFormat.TEXT, ReportFormat.parse("text"));
         assertEquals(ReportFormat.JUNIT, ReportFormat.parse("junit"));
+        assertEquals(ReportFormat.NONE, ReportFormat.parse("none"));
         assertEquals(ReportFormat.JSON, ReportFormat.parse("JSON"));
     }
 

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -116,6 +116,15 @@ class ReportFormatterTest {
     }
 
     @Test
+    void formatsNoneReportAsEmptyContent() {
+        String report = ReportFormatter.format(report(
+                metric("danger", "demo.Sample", 4, 5, 10.0, 9.645)
+        ), ReportFormat.NONE, true, true);
+
+        assertEquals("", report);
+    }
+
+    @Test
     void formatsFailuresOnlyOmitRedundancyJsonWithOnlyFailuresAndGlobalStatusThreshold() {
         String report = ReportFormatter.format(report(
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),


### PR DESCRIPTION
## Summary
- add `none` to the Java report format parser and formatter
- suppress primary stdout for `--format none`, while keeping empty output file creation through the existing publisher path
- cover parser, formatter, and integration behavior including full JUnit sidecar output

Closes #85

## Validation
- `mvn -B -pl core "-Dtest=ReportFormatTest,CliArgumentsParserTest,ReportFormatterTest,MainTest" test`
- `mvn -B verify`