### PR TITLE
Add Maven plugin report controls

### DIFF
--- a/maven-plugin/src/it/configured-report-controls/pom.xml
+++ b/maven-plugin/src/it/configured-report-controls/pom.xml
@@ -1,0 +1,72 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>it.demo</groupId>
+  <artifactId>configured-report-controls</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.13</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>media.barney</groupId>
+        <artifactId>crap-java-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <format>json</format>
+          <agent>true</agent>
+          <failuresOnly>false</failuresOnly>
+          <omitRedundancy>true</omitRedundancy>
+          <output>target/crap-java/report.json</output>
+          <junit>true</junit>
+          <junitReport>target/crap-java/custom-junit.xml</junitReport>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin/src/it/configured-report-controls/src/main/java/demo/Sample.java
+++ b/maven-plugin/src/it/configured-report-controls/src/main/java/demo/Sample.java
@@ -1,0 +1,10 @@
+package demo;
+
+public class Sample {
+    public int alpha(boolean value) {
+        if (value) {
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/maven-plugin/src/it/configured-report-controls/src/test/java/demo/SampleTest.java
+++ b/maven-plugin/src/it/configured-report-controls/src/test/java/demo/SampleTest.java
@@ -1,0 +1,13 @@
+package demo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SampleTest {
+
+    @Test
+    void alphaReturnsOneForTrue() {
+        assertEquals(1, new Sample().alpha(true));
+    }
+}

--- a/maven-plugin/src/it/configured-report-controls/verify.bsh
+++ b/maven-plugin/src/it/configured-report-controls/verify.bsh
@@ -1,0 +1,35 @@
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+Path root = basedir.toPath();
+Path primaryReport = root.resolve("target/crap-java/report.json");
+Path junitReport = root.resolve("target/crap-java/custom-junit.xml");
+if (!Files.exists(primaryReport)) {
+    throw new RuntimeException("Missing configured primary report");
+}
+if (!Files.exists(junitReport)) {
+    throw new RuntimeException("Missing configured JUnit sidecar");
+}
+if (Files.exists(root.resolve("target/crap-java/TEST-crap-java.xml"))) {
+    throw new RuntimeException("Configured junitReport should replace the default sidecar path");
+}
+
+String primary = Files.readString(primaryReport);
+if (!primary.contains("\"status\": \"passed\"")) {
+    throw new RuntimeException("Configured primary report is missing top-level status");
+}
+if (!primary.contains("\"method\": \"alpha\"")) {
+    throw new RuntimeException("Configured primary report should include passing methods when failuresOnly is false");
+}
+if (primary.contains("      \"status\":")) {
+    throw new RuntimeException("Configured primary report should omit redundant method statuses");
+}
+
+String junit = Files.readString(junitReport);
+if (!junit.contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">")) {
+    throw new RuntimeException("Configured JUnit sidecar should contain the full report");
+}
+if (!junit.contains("<property name=\"status\" value=\"passed\"/>")) {
+    throw new RuntimeException("Configured JUnit sidecar should not omit method status");
+}
+return true;

--- a/maven-plugin/src/it/multi-module/verify.bsh
+++ b/maven-plugin/src/it/multi-module/verify.bsh
@@ -1,4 +1,5 @@
 import java.nio.file.Files;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
 
 Path root = basedir.toPath();
@@ -11,8 +12,22 @@ if (!Files.exists(root.resolve("module-b/target/site/jacoco/jacoco.xml"))) {
 if (!Files.exists(root.resolve("target/crap-java/TEST-crap-java.xml"))) {
     throw new RuntimeException("Missing default crap-java JUnit sidecar for multi-module IT");
 }
+Path reportDir = root.resolve("target/crap-java");
+DirectoryStream reportArtifacts = Files.newDirectoryStream(reportDir);
+for (Path reportArtifact : reportArtifacts) {
+    if (!reportArtifact.getFileName().toString().equals("TEST-crap-java.xml")) {
+        throw new RuntimeException("Default Maven plugin run wrote unexpected primary report artifact: " + reportArtifact);
+    }
+}
+reportArtifacts.close();
 Path buildLog = root.resolve("build.log");
-if (Files.exists(buildLog) && Files.readString(buildLog).contains("CRAP Report")) {
-    throw new RuntimeException("Default Maven plugin run should not emit a primary report");
+if (Files.exists(buildLog)) {
+    String log = Files.readString(buildLog);
+    if (log.contains("CRAP Report")
+            || log.contains("status:")
+            || log.contains("\"status\"")
+            || log.contains("<testsuites")) {
+        throw new RuntimeException("Default Maven plugin run should not emit a primary report");
+    }
 }
 return true;

--- a/maven-plugin/src/it/multi-module/verify.bsh
+++ b/maven-plugin/src/it/multi-module/verify.bsh
@@ -1,9 +1,18 @@
 import java.nio.file.Files;
+import java.nio.file.Path;
 
-if (!Files.exists(basedir.toPath().resolve("module-a/target/site/jacoco/jacoco.xml"))) {
+Path root = basedir.toPath();
+if (!Files.exists(root.resolve("module-a/target/site/jacoco/jacoco.xml"))) {
     throw new RuntimeException("Missing JaCoCo XML report for module-a");
 }
-if (!Files.exists(basedir.toPath().resolve("module-b/target/site/jacoco/jacoco.xml"))) {
+if (!Files.exists(root.resolve("module-b/target/site/jacoco/jacoco.xml"))) {
     throw new RuntimeException("Missing JaCoCo XML report for module-b");
+}
+if (!Files.exists(root.resolve("target/crap-java/TEST-crap-java.xml"))) {
+    throw new RuntimeException("Missing default crap-java JUnit sidecar for multi-module IT");
+}
+Path buildLog = root.resolve("build.log");
+if (Files.exists(buildLog) && Files.readString(buildLog).contains("CRAP Report")) {
+    throw new RuntimeException("Default Maven plugin run should not emit a primary report");
 }
 return true;

--- a/maven-plugin/src/it/single-module/verify.bsh
+++ b/maven-plugin/src/it/single-module/verify.bsh
@@ -1,4 +1,5 @@
 import java.nio.file.Files;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
 
 Path root = basedir.toPath();
@@ -8,8 +9,22 @@ if (!Files.exists(root.resolve("target/site/jacoco/jacoco.xml"))) {
 if (!Files.exists(root.resolve("target/crap-java/TEST-crap-java.xml"))) {
     throw new RuntimeException("Missing default crap-java JUnit sidecar for single-module IT");
 }
+Path reportDir = root.resolve("target/crap-java");
+DirectoryStream reportArtifacts = Files.newDirectoryStream(reportDir);
+for (Path reportArtifact : reportArtifacts) {
+    if (!reportArtifact.getFileName().toString().equals("TEST-crap-java.xml")) {
+        throw new RuntimeException("Default Maven plugin run wrote unexpected primary report artifact: " + reportArtifact);
+    }
+}
+reportArtifacts.close();
 Path buildLog = root.resolve("build.log");
-if (Files.exists(buildLog) && Files.readString(buildLog).contains("CRAP Report")) {
-    throw new RuntimeException("Default Maven plugin run should not emit a primary report");
+if (Files.exists(buildLog)) {
+    String log = Files.readString(buildLog);
+    if (log.contains("CRAP Report")
+            || log.contains("status:")
+            || log.contains("\"status\"")
+            || log.contains("<testsuites")) {
+        throw new RuntimeException("Default Maven plugin run should not emit a primary report");
+    }
 }
 return true;

--- a/maven-plugin/src/it/single-module/verify.bsh
+++ b/maven-plugin/src/it/single-module/verify.bsh
@@ -1,6 +1,15 @@
 import java.nio.file.Files;
+import java.nio.file.Path;
 
-if (!Files.exists(basedir.toPath().resolve("target/site/jacoco/jacoco.xml"))) {
+Path root = basedir.toPath();
+if (!Files.exists(root.resolve("target/site/jacoco/jacoco.xml"))) {
     throw new RuntimeException("Missing JaCoCo XML report for single-module IT");
+}
+if (!Files.exists(root.resolve("target/crap-java/TEST-crap-java.xml"))) {
+    throw new RuntimeException("Missing default crap-java JUnit sidecar for single-module IT");
+}
+Path buildLog = root.resolve("build.log");
+if (Files.exists(buildLog) && Files.readString(buildLog).contains("CRAP Report")) {
+    throw new RuntimeException("Default Maven plugin run should not emit a primary report");
 }
 return true;

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -31,8 +31,26 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private @Nullable MavenProject project;
 
-    @Parameter(property = "crapJava.junitReportPath")
-    private @Nullable File junitReportPath;
+    @Parameter(property = "crapJava.format", defaultValue = "none")
+    private String format = "none";
+
+    @Parameter(property = "crapJava.agent", defaultValue = "false")
+    private boolean agent;
+
+    @Parameter(property = "crapJava.failuresOnly")
+    private @Nullable Boolean failuresOnly;
+
+    @Parameter(property = "crapJava.omitRedundancy")
+    private @Nullable Boolean omitRedundancy;
+
+    @Parameter(property = "crapJava.output")
+    private @Nullable File output;
+
+    @Parameter(property = "crapJava.junit", defaultValue = "true")
+    private boolean junit = true;
+
+    @Parameter(property = "crapJava.junitReport")
+    private @Nullable File junitReport;
 
     @Parameter(property = "crapJava.threshold", defaultValue = "8.0")
     private double threshold = Main.DEFAULT_THRESHOLD;
@@ -77,18 +95,33 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     }
 
     private String[] reportArgs(Path executionRoot) {
-        return new String[]{
-                "--format",
-                "text",
-                "--threshold",
-                Double.toString(threshold),
-                "--junit-report",
-                junitReportPath(executionRoot).toString()
-        };
+        List<String> args = new ArrayList<>();
+        args.add("--format");
+        args.add(format);
+        if (agent) {
+            args.add("--agent");
+        }
+        if (failuresOnly != null) {
+            args.add("--failures-only=" + failuresOnly);
+        }
+        if (omitRedundancy != null) {
+            args.add("--omit-redundancy=" + omitRedundancy);
+        }
+        if (output != null) {
+            args.add("--output");
+            args.add(output.toPath().normalize().toString());
+        }
+        args.add("--threshold");
+        args.add(Double.toString(threshold));
+        if (junit) {
+            args.add("--junit-report");
+            args.add(junitReportPath(executionRoot).toString());
+        }
+        return args.toArray(String[]::new);
     }
 
     private Path junitReportPath(Path executionRoot) {
-        File configured = junitReportPath;
+        File configured = junitReport;
         if (configured != null) {
             return configured.toPath().normalize();
         }

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -109,7 +109,7 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         }
         if (output != null) {
             args.add("--output");
-            args.add(output.toPath().normalize().toString());
+            args.add(configuredPath(executionRoot, output).toString());
         }
         args.add("--threshold");
         args.add(Double.toString(threshold));
@@ -123,9 +123,14 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     private Path junitReportPath(Path executionRoot) {
         File configured = junitReport;
         if (configured != null) {
-            return configured.toPath().normalize();
+            return configuredPath(executionRoot, configured);
         }
         return executionRoot.resolve("target/crap-java/TEST-crap-java.xml").normalize();
+    }
+
+    private static Path configuredPath(Path executionRoot, File configured) {
+        Path path = configured.toPath().normalize();
+        return path.isAbsolute() ? path : executionRoot.resolve(path).normalize();
     }
 
     private void ensureCoverageReportsExist() throws MojoFailureException {

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -63,7 +63,7 @@ class CrapJavaCheckMojoTest {
         assertEquals(root, runner.projectRoot);
         assertEquals(List.of(
                 "--format",
-                "text",
+                "none",
                 "--threshold",
                 "8.0",
                 "--junit-report",
@@ -72,7 +72,7 @@ class CrapJavaCheckMojoTest {
     }
 
     @Test
-    void usesConfiguredJunitReportPath() throws Exception {
+    void usesConfiguredJunitReport() throws Exception {
         Path root = tempDir.resolve("root");
         writeCoverageReport(root);
         Path report = root.resolve("custom/crap.xml");
@@ -81,11 +81,60 @@ class CrapJavaCheckMojoTest {
         CrapJavaCheckMojo mojo = mojo(runner);
         setField(mojo, "session", session(List.of(project(root, "root")), root));
         setField(mojo, "project", project(root, "root"));
-        setField(mojo, "junitReportPath", report.toFile());
+        setField(mojo, "junitReport", report.toFile());
 
         mojo.execute();
 
-        assertEquals(List.of("--format", "text", "--threshold", "8.0", "--junit-report", report.toString()), List.of(runner.args));
+        assertEquals(List.of("--format", "none", "--threshold", "8.0", "--junit-report", report.toString()), List.of(runner.args));
+    }
+
+    @Test
+    void usesConfiguredReportControls() throws Exception {
+        Path root = tempDir.resolve("root");
+        writeCoverageReport(root);
+        Path output = root.resolve("target/crap-java/report.json");
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        setField(mojo, "session", session(List.of(project(root, "root")), root));
+        setField(mojo, "project", project(root, "root"));
+        setField(mojo, "format", "json");
+        setField(mojo, "agent", true);
+        setField(mojo, "failuresOnly", false);
+        setField(mojo, "omitRedundancy", true);
+        setField(mojo, "output", output.toFile());
+
+        mojo.execute();
+
+        assertEquals(List.of(
+                "--format",
+                "json",
+                "--agent",
+                "--failures-only=false",
+                "--omit-redundancy=true",
+                "--output",
+                output.toString(),
+                "--threshold",
+                "8.0",
+                "--junit-report",
+                root.resolve("target/crap-java/TEST-crap-java.xml").toString()
+        ), List.of(runner.args));
+    }
+
+    @Test
+    void disablesJunitReport() throws Exception {
+        Path root = tempDir.resolve("root");
+        writeCoverageReport(root);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        setField(mojo, "session", session(List.of(project(root, "root")), root));
+        setField(mojo, "project", project(root, "root"));
+        setField(mojo, "junit", false);
+
+        mojo.execute();
+
+        assertEquals(List.of("--format", "none", "--threshold", "8.0"), List.of(runner.args));
     }
 
     @Test
@@ -103,7 +152,7 @@ class CrapJavaCheckMojoTest {
 
         assertEquals(List.of(
                 "--format",
-                "text",
+                "none",
                 "--threshold",
                 "6.0",
                 "--junit-report",

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -138,6 +138,32 @@ class CrapJavaCheckMojoTest {
     }
 
     @Test
+    void resolvesConfiguredRelativeReportPathsAgainstExecutionRoot() throws Exception {
+        Path root = tempDir.resolve("root");
+        writeCoverageReport(root);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        setField(mojo, "session", session(List.of(project(root, "root")), root));
+        setField(mojo, "project", project(root, "root"));
+        setField(mojo, "output", Path.of("target/crap-java/report.json").toFile());
+        setField(mojo, "junitReport", Path.of("target/crap-java/custom-junit.xml").toFile());
+
+        mojo.execute();
+
+        assertEquals(List.of(
+                "--format",
+                "none",
+                "--output",
+                root.resolve("target/crap-java/report.json").toString(),
+                "--threshold",
+                "8.0",
+                "--junit-report",
+                root.resolve("target/crap-java/custom-junit.xml").toString()
+        ), List.of(runner.args));
+    }
+
+    @Test
     void usesConfiguredThreshold() throws Exception {
         Path root = tempDir.resolve("root");
         writeCoverageReport(root);


### PR DESCRIPTION
## Summary
- add aligned Maven plugin parameters for format, agent, failures-only, omit-redundancy, output, junit, and junitReport
- default Maven primary output to `none` while keeping the JUnit sidecar enabled at the existing default path
- replace `crapJava.junitReportPath` with `crapJava.junitReport`
- extend unit and invoker coverage for default sidecar/no-primary-output behavior and configured controls

Closes #87

## Validation
- `mvn -B -pl maven-plugin "-Dtest=CrapJavaCheckMojoTest" test`
- `mvn -B verify`