### PR TITLE
Add Gradle plugin report controls

### DIFF
--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -77,17 +77,18 @@ public final class Main {
                                               @Nullable Path outputPath,
                                               @Nullable Path junitReportPath,
                                               double threshold) throws Exception {
+        Path normalizedReportRoot = reportRoot.toAbsolutePath().normalize();
         return runResolvedModules(
                 modules,
-                reportRoot.toAbsolutePath().normalize(),
+                normalizedReportRoot,
                 out,
                 err,
                 new ReportOptions(
                         ReportFormat.parse(reportFormat),
                         failuresOnly,
                         omitRedundancy,
-                        normalize(outputPath),
-                        normalize(junitReportPath)
+                        normalize(normalizedReportRoot, outputPath),
+                        normalize(normalizedReportRoot, junitReportPath)
                 ),
                 threshold
         );
@@ -170,8 +171,12 @@ public final class Main {
         }
     }
 
-    private static @Nullable Path normalize(@Nullable Path path) {
-        return path == null ? null : path.toAbsolutePath().normalize();
+    private static @Nullable Path normalize(Path root, @Nullable Path path) {
+        if (path == null) {
+            return null;
+        }
+        Path normalized = path.normalize();
+        return normalized.isAbsolute() ? normalized : root.resolve(normalized).normalize();
     }
 
     private static Path commonRoot(List<ResolvedCoverageModule> modules) {

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import org.jspecify.annotations.Nullable;
 
 public final class Main {
 
@@ -52,12 +53,42 @@ public final class Main {
                                               PrintStream err,
                                               Path junitReportPath,
                                               double threshold) throws Exception {
+        return runWithExistingCoverage(
+                modules,
+                reportRoot,
+                out,
+                err,
+                ReportFormat.TEXT.name(),
+                false,
+                false,
+                null,
+                junitReportPath,
+                threshold
+        );
+    }
+
+    public static int runWithExistingCoverage(List<ResolvedCoverageModule> modules,
+                                              Path reportRoot,
+                                              PrintStream out,
+                                              PrintStream err,
+                                              String reportFormat,
+                                              boolean failuresOnly,
+                                              boolean omitRedundancy,
+                                              @Nullable Path outputPath,
+                                              @Nullable Path junitReportPath,
+                                              double threshold) throws Exception {
         return runResolvedModules(
                 modules,
                 reportRoot.toAbsolutePath().normalize(),
                 out,
                 err,
-                ReportOptions.textWithOptionalJunit(junitReportPath.toAbsolutePath().normalize()),
+                new ReportOptions(
+                        ReportFormat.parse(reportFormat),
+                        failuresOnly,
+                        omitRedundancy,
+                        normalize(outputPath),
+                        normalize(junitReportPath)
+                ),
                 threshold
         );
     }
@@ -137,6 +168,10 @@ public final class Main {
         if (!warning.isEmpty()) {
             err.println(warning);
         }
+    }
+
+    private static @Nullable Path normalize(@Nullable Path path) {
+        return path == null ? null : path.toAbsolutePath().normalize();
     }
 
     private static Path commonRoot(List<ResolvedCoverageModule> modules) {

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -53,16 +53,12 @@ public final class Main {
                                               PrintStream err,
                                               Path junitReportPath,
                                               double threshold) throws Exception {
-        return runWithExistingCoverage(
+        return runResolvedModules(
                 modules,
-                reportRoot,
+                reportRoot.toAbsolutePath().normalize(),
                 out,
                 err,
-                ReportFormat.TEXT.name(),
-                false,
-                false,
-                null,
-                junitReportPath,
+                ReportOptions.textWithOptionalJunit(junitReportPath),
                 threshold
         );
     }
@@ -83,13 +79,13 @@ public final class Main {
                 normalizedReportRoot,
                 out,
                 err,
-                new ReportOptions(
-                        ReportFormat.parse(reportFormat),
+                reportOptionsRelativeToRoot(
+                        normalizedReportRoot,
+                        reportFormat,
                         failuresOnly,
                         omitRedundancy,
-                        normalize(normalizedReportRoot, outputPath),
-                        normalize(normalizedReportRoot, junitReportPath)
-                ),
+                        outputPath,
+                        junitReportPath),
                 threshold
         );
     }
@@ -177,6 +173,21 @@ public final class Main {
         }
         Path normalized = path.normalize();
         return normalized.isAbsolute() ? normalized : root.resolve(normalized).normalize();
+    }
+
+    private static ReportOptions reportOptionsRelativeToRoot(Path root,
+                                                             String reportFormat,
+                                                             boolean failuresOnly,
+                                                             boolean omitRedundancy,
+                                                             @Nullable Path outputPath,
+                                                             @Nullable Path junitReportPath) {
+        return new ReportOptions(
+                ReportFormat.parse(reportFormat),
+                failuresOnly,
+                omitRedundancy,
+                normalize(root, outputPath),
+                normalize(root, junitReportPath)
+        );
     }
 
     private static Path commonRoot(List<ResolvedCoverageModule> modules) {

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -53,7 +53,9 @@ record ReportOptions(
             return true;
         }
         try {
-            return sameExistingFile(first, second) || sameParentAndFileName(first, second);
+            return sameExistingFile(first, second)
+                    || sameRealPath(first, second)
+                    || sameParentAndFileName(first, second);
         } catch (IOException exception) {
             return false;
         }

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -68,7 +68,34 @@ record ReportOptions(
 
     private static boolean sameAliasedParent(Path firstParent, Path secondParent) throws IOException {
         return sameExistingFile(firstParent, secondParent)
+                || sameRealPath(firstParent, secondParent)
                 || sameCaseInsensitivePath(firstParent, secondParent);
+    }
+
+    private static boolean sameRealPath(Path first, Path second) {
+        Path firstRealPath = realPathForComparison(first);
+        Path secondRealPath = realPathForComparison(second);
+        return firstRealPath != null && firstRealPath.equals(secondRealPath);
+    }
+
+    private static @Nullable Path realPathForComparison(Path path) {
+        Path normalized = path.toAbsolutePath().normalize();
+        try {
+            if (Files.exists(normalized)) {
+                return normalized.toRealPath();
+            }
+            Path existing = nearestExistingPath(normalized);
+            if (existing != null) {
+                return existing.toRealPath().resolve(existing.relativize(normalized)).normalize();
+            }
+        } catch (IOException | SecurityException exception) {
+            return null;
+        }
+        return null;
+    }
+
+    private static @Nullable Path nearestExistingPath(Path path) {
+        return ancestors(path).filter(Files::exists).findFirst().orElse(null);
     }
 
     private static boolean sameFileName(Path first, Path second, @Nullable Path parent) {

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -18,6 +18,8 @@ record ReportOptions(
     ReportOptions {
         outputPath = normalize(outputPath);
         junitReportPath = normalize(junitReportPath);
+        validateReportPath("output", outputPath);
+        validateReportPath("junitReport", junitReportPath);
         if (outputPath != null && junitReportPath != null && sameReportTarget(outputPath, junitReportPath)) {
             throw new IllegalArgumentException("output and junitReport must not point to the same file");
         }
@@ -32,6 +34,12 @@ record ReportOptions(
             return null;
         }
         return path.toAbsolutePath().normalize();
+    }
+
+    private static void validateReportPath(String name, @Nullable Path path) {
+        if (path != null && path.getFileName() == null) {
+            throw new IllegalArgumentException(name + " must not point to a filesystem root");
+        }
     }
 
     private static boolean sameReportTarget(Path first, Path second) {

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -49,11 +49,15 @@ record ReportOptions(
     private static boolean sameParentAndFileName(Path first, Path second) throws IOException {
         Path firstParent = first.getParent();
         Path secondParent = second.getParent();
-        return first.getFileName().equals(second.getFileName())
+        return sameFileName(first, second)
                 && firstParent != null
                 && secondParent != null
                 && Files.exists(firstParent)
                 && Files.exists(secondParent)
                 && Files.isSameFile(firstParent, secondParent);
+    }
+
+    private static boolean sameFileName(Path first, Path second) {
+        return first.getFileName().toString().equalsIgnoreCase(second.getFileName().toString());
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -93,8 +93,18 @@ record ReportOptions(
     }
 
     private static @Nullable Path realPathForComparison(Path path) {
+        return realPathForComparison(path, 0);
+    }
+
+    private static @Nullable Path realPathForComparison(Path path, int symlinkDepth) {
+        if (symlinkDepth > 8) {
+            return null;
+        }
         Path normalized = path.toAbsolutePath().normalize();
         try {
+            if (Files.isSymbolicLink(normalized)) {
+                return symbolicLinkTargetForComparison(normalized, symlinkDepth);
+            }
             if (Files.exists(normalized)) {
                 return normalized.toRealPath();
             }
@@ -106,6 +116,12 @@ record ReportOptions(
             return null;
         }
         return null;
+    }
+
+    private static @Nullable Path symbolicLinkTargetForComparison(Path link, int symlinkDepth) throws IOException {
+        Path target = Files.readSymbolicLink(link);
+        Path resolved = link.resolveSibling(target);
+        return realPathForComparison(resolved, symlinkDepth + 1);
     }
 
     private static @Nullable Path nearestExistingPath(Path path) {

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -3,6 +3,7 @@ package media.barney.crap.core;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 import org.jspecify.annotations.Nullable;
 
 record ReportOptions(
@@ -49,15 +50,55 @@ record ReportOptions(
     private static boolean sameParentAndFileName(Path first, Path second) throws IOException {
         Path firstParent = first.getParent();
         Path secondParent = second.getParent();
-        return sameFileName(first, second)
-                && firstParent != null
-                && secondParent != null
-                && Files.exists(firstParent)
-                && Files.exists(secondParent)
-                && Files.isSameFile(firstParent, secondParent);
+        return sameParent(firstParent, secondParent) && sameFileName(first, second, firstParent);
     }
 
-    private static boolean sameFileName(Path first, Path second) {
-        return first.getFileName().toString().equalsIgnoreCase(second.getFileName().toString());
+    private static boolean sameParent(@Nullable Path firstParent, @Nullable Path secondParent) throws IOException {
+        if (firstParent == null || secondParent == null) {
+            return firstParent == secondParent;
+        }
+        return firstParent.equals(secondParent)
+                || (Files.exists(firstParent) && Files.exists(secondParent) && Files.isSameFile(firstParent, secondParent));
+    }
+
+    private static boolean sameFileName(Path first, Path second, @Nullable Path parent) {
+        String firstName = first.getFileName().toString();
+        String secondName = second.getFileName().toString();
+        return firstName.equals(secondName)
+                || (firstName.equalsIgnoreCase(secondName) && isCaseInsensitive(parent));
+    }
+
+    private static boolean isCaseInsensitive(@Nullable Path path) {
+        Path directory = nearestExistingDirectory(path);
+        if (directory == null) {
+            return isLikelyCaseInsensitiveOs();
+        }
+        try {
+            Path probe = Files.createTempFile(directory, ".crap-java-case-", ".tmp");
+            try {
+                Path variant = probe.resolveSibling(probe.getFileName().toString().toUpperCase(Locale.ROOT));
+                return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
+            } finally {
+                Files.deleteIfExists(probe);
+            }
+        } catch (IOException | SecurityException exception) {
+            return isLikelyCaseInsensitiveOs();
+        }
+    }
+
+    private static @Nullable Path nearestExistingDirectory(@Nullable Path path) {
+        Path current = path == null ? Path.of(".").toAbsolutePath().normalize() : path.toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isDirectory(current)) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        return null;
+    }
+
+    private static boolean isLikelyCaseInsensitiveOs() {
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        return os.contains("win") || os.contains("mac");
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -10,7 +10,22 @@ record ReportOptions(
         @Nullable Path outputPath,
         @Nullable Path junitReportPath
 ) {
+    ReportOptions {
+        outputPath = normalize(outputPath);
+        junitReportPath = normalize(junitReportPath);
+        if (outputPath != null && outputPath.equals(junitReportPath)) {
+            throw new IllegalArgumentException("output and junitReport must not point to the same file");
+        }
+    }
+
     static ReportOptions textWithOptionalJunit(@Nullable Path junitReportPath) {
         return new ReportOptions(ReportFormat.TEXT, false, false, null, junitReportPath);
+    }
+
+    private static @Nullable Path normalize(@Nullable Path path) {
+        if (path == null) {
+            return null;
+        }
+        return path.toAbsolutePath().normalize();
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -37,8 +37,14 @@ record ReportOptions(
     }
 
     private static void validateReportPath(String name, @Nullable Path path) {
-        if (path != null && path.getFileName() == null) {
+        if (path == null) {
+            return;
+        }
+        if (path.getFileName() == null) {
             throw new IllegalArgumentException(name + " must not point to a filesystem root");
+        }
+        if (Files.isDirectory(path)) {
+            throw new IllegalArgumentException(name + " must not point to a directory");
         }
     }
 

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 
 record ReportOptions(
@@ -54,11 +56,19 @@ record ReportOptions(
     }
 
     private static boolean sameParent(@Nullable Path firstParent, @Nullable Path secondParent) throws IOException {
-        if (firstParent == null || secondParent == null) {
-            return firstParent == secondParent;
-        }
+        return (firstParent == null || secondParent == null)
+                ? firstParent == secondParent
+                : sameNonNullParent(firstParent, secondParent);
+    }
+
+    private static boolean sameNonNullParent(Path firstParent, Path secondParent) throws IOException {
         return firstParent.equals(secondParent)
-                || (Files.exists(firstParent) && Files.exists(secondParent) && Files.isSameFile(firstParent, secondParent));
+                || sameAliasedParent(firstParent, secondParent);
+    }
+
+    private static boolean sameAliasedParent(Path firstParent, Path secondParent) throws IOException {
+        return sameExistingFile(firstParent, secondParent)
+                || sameCaseInsensitivePath(firstParent, secondParent);
     }
 
     private static boolean sameFileName(Path first, Path second, @Nullable Path parent) {
@@ -70,14 +80,14 @@ record ReportOptions(
 
     private static boolean isCaseInsensitive(@Nullable Path path) {
         Path directory = nearestExistingDirectory(path);
-        if (directory == null) {
-            return isLikelyCaseInsensitiveOs();
-        }
+        return directory == null ? isLikelyCaseInsensitiveOs() : directoryIsCaseInsensitive(directory);
+    }
+
+    private static boolean directoryIsCaseInsensitive(Path directory) {
         try {
             Path probe = Files.createTempFile(directory, ".crap-java-case-", ".tmp");
             try {
-                Path variant = probe.resolveSibling(probe.getFileName().toString().toUpperCase(Locale.ROOT));
-                return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
+                return caseVariantExists(probe);
             } finally {
                 Files.deleteIfExists(probe);
             }
@@ -87,18 +97,25 @@ record ReportOptions(
     }
 
     private static @Nullable Path nearestExistingDirectory(@Nullable Path path) {
-        Path current = path == null ? Path.of(".").toAbsolutePath().normalize() : path.toAbsolutePath().normalize();
-        while (current != null) {
-            if (Files.isDirectory(current)) {
-                return current;
-            }
-            current = current.getParent();
-        }
-        return null;
+        Path start = path == null ? Path.of(".").toAbsolutePath().normalize() : path.toAbsolutePath().normalize();
+        return ancestors(start).filter(Files::isDirectory).findFirst().orElse(null);
+    }
+
+    private static Stream<Path> ancestors(Path path) {
+        return Stream.iterate(path, Objects::nonNull, Path::getParent);
+    }
+
+    private static boolean caseVariantExists(Path probe) {
+        Path variant = probe.resolveSibling(probe.getFileName().toString().toUpperCase(Locale.ROOT));
+        return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
     }
 
     private static boolean isLikelyCaseInsensitiveOs() {
         String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         return os.contains("win") || os.contains("mac");
+    }
+
+    private static boolean sameCaseInsensitivePath(Path first, Path second) {
+        return first.toString().equalsIgnoreCase(second.toString()) && isCaseInsensitive(first);
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -1,5 +1,7 @@
 package media.barney.crap.core;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.jspecify.annotations.Nullable;
 
@@ -13,7 +15,7 @@ record ReportOptions(
     ReportOptions {
         outputPath = normalize(outputPath);
         junitReportPath = normalize(junitReportPath);
-        if (outputPath != null && outputPath.equals(junitReportPath)) {
+        if (outputPath != null && junitReportPath != null && sameReportTarget(outputPath, junitReportPath)) {
             throw new IllegalArgumentException("output and junitReport must not point to the same file");
         }
     }
@@ -27,5 +29,31 @@ record ReportOptions(
             return null;
         }
         return path.toAbsolutePath().normalize();
+    }
+
+    private static boolean sameReportTarget(Path first, Path second) {
+        if (first.equals(second)) {
+            return true;
+        }
+        try {
+            return sameExistingFile(first, second) || sameParentAndFileName(first, second);
+        } catch (IOException exception) {
+            return false;
+        }
+    }
+
+    private static boolean sameExistingFile(Path first, Path second) throws IOException {
+        return Files.exists(first) && Files.exists(second) && Files.isSameFile(first, second);
+    }
+
+    private static boolean sameParentAndFileName(Path first, Path second) throws IOException {
+        Path firstParent = first.getParent();
+        Path secondParent = second.getParent();
+        return first.getFileName().equals(second.getFileName())
+                && firstParent != null
+                && secondParent != null
+                && Files.exists(firstParent)
+                && Files.exists(secondParent)
+                && Files.isSameFile(firstParent, secondParent);
     }
 }

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -426,6 +426,43 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoveragePreResolvedModulesHonorsPrimaryReportControls() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path jsonReport = tempDir.resolve("target/crap-java/gradle.json");
+        Path junitReport = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err),
+                "json",
+                true,
+                true,
+                jsonReport,
+                junitReport,
+                8.0
+        );
+
+        String primary = Files.readString(jsonReport);
+        String junit = Files.readString(junitReport);
+        assertEquals(2, exit);
+        assertEquals("", utf8(out));
+        assertTrue(primary.contains("\"status\": \"failed\""));
+        assertFalse(primary.contains("      \"status\":"));
+        assertTrue(primary.contains("\"method\": \"danger\""));
+        assertFalse(primary.contains("\"method\": \"safe\""));
+        assertFalse(primary.contains("\"method\": \"unknown\""));
+        assertTrue(junit.contains("FAILED danger"));
+        assertTrue(junit.contains("PASSED safe"));
+        assertTrue(junit.contains("SKIPPED unknown"));
+    }
+
+    @Test
     void runWithExistingCoverageAnalyzesPreResolvedModules() throws Exception {
         Path moduleRoot = tempDir.resolve("app");
         Path source = moduleRoot.resolve("src/main/java/demo/Sample.java");

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -1,6 +1,7 @@
 package media.barney.crap.core;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
@@ -9,7 +10,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -542,15 +545,14 @@ class MainTest {
     }
 
     @Test
-    void runWithExistingCoverageRejectsCaseOnlyPrimaryAndJunitReportPathCollision() throws Exception {
+    void runWithExistingCoverageHandlesCaseOnlyPrimaryAndJunitReportPathCollision() throws Exception {
         writeMixedCoverageSample();
         Path source = tempDir.resolve("src/main/java/demo/Sample.java");
         Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
         Path report = tempDir.resolve("target/crap-java/report.xml");
         Path caseVariant = tempDir.resolve("target/crap-java/REPORT.XML");
-        Files.createDirectories(report.getParent());
 
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
+        Executable run = () -> Main.runWithExistingCoverage(
                 List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
                 tempDir,
                 new PrintStream(new ByteArrayOutputStream()),
@@ -561,9 +563,14 @@ class MainTest {
                 report,
                 caseVariant,
                 8.0
-        ));
+        );
 
-        assertEquals("output and junitReport must not point to the same file", thrown.getMessage());
+        if (isCaseInsensitiveFileSystem(tempDir)) {
+            IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, run);
+            assertEquals("output and junitReport must not point to the same file", thrown.getMessage());
+        } else {
+            assertDoesNotThrow(run);
+        }
     }
 
     @Test
@@ -731,6 +738,16 @@ class MainTest {
                   </package>
                 </report>
                 """.formatted(className, methodName, line));
+    }
+
+    private boolean isCaseInsensitiveFileSystem(Path directory) throws Exception {
+        Path probe = Files.createTempFile(directory, ".crap-java-case-", ".tmp");
+        try {
+            Path variant = probe.resolveSibling(probe.getFileName().toString().toUpperCase(Locale.ROOT));
+            return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
+        } finally {
+            Files.deleteIfExists(probe);
+        }
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -495,6 +495,30 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageLegacyJunitOverloadKeepsRelativePathAgainstWorkingDirectory() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path junitReport = tempDir.resolve("legacy-relative-junit.xml").toAbsolutePath().normalize();
+        Path relativeJunitReport = Path.of("").toAbsolutePath().normalize().relativize(junitReport);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err),
+                relativeJunitReport,
+                8.0
+        );
+
+        assertEquals(2, exit);
+        assertTrue(Files.exists(junitReport));
+        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+    }
+
+    @Test
     void runWithExistingCoverageRejectsSharedPrimaryAndJunitReportPath() throws Exception {
         writeMixedCoverageSample();
         Path source = tempDir.resolve("src/main/java/demo/Sample.java");
@@ -549,8 +573,8 @@ class MainTest {
         writeMixedCoverageSample();
         Path source = tempDir.resolve("src/main/java/demo/Sample.java");
         Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
-        Path report = tempDir.resolve("target/crap-java/report.xml");
-        Path caseVariant = tempDir.resolve("target/crap-java/REPORT.XML");
+        Path report = tempDir.resolve("fresh/reports/report.xml");
+        Path caseVariant = tempDir.resolve("FRESH/REPORTS/REPORT.XML");
 
         Executable run = () -> Main.runWithExistingCoverage(
                 List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -544,6 +544,30 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageRejectsRootPrimaryReportPath() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path root = tempDir.toAbsolutePath().getRoot();
+        assumeTrue(root != null, "Filesystem root is unavailable");
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()),
+                "json",
+                false,
+                false,
+                root,
+                tempDir.resolve("target/crap-java/TEST-crap-java.xml"),
+                8.0
+        ));
+
+        assertEquals("output must not point to a filesystem root", thrown.getMessage());
+    }
+
+    @Test
     void runWithExistingCoverageRejectsAliasedPrimaryAndJunitReportPath() throws Exception {
         writeMixedCoverageSample();
         Path source = tempDir.resolve("src/main/java/demo/Sample.java");

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -643,6 +643,32 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageRejectsDanglingSymlinkedPrimaryAndJunitReportPath() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path report = tempDir.resolve("target/crap-java/report.xml");
+        Files.createDirectories(report.getParent());
+        Path outputLink = createFileSymlinkOrSkip(tempDir.resolve("output-report.xml"), report);
+        Path junitLink = createFileSymlinkOrSkip(tempDir.resolve("junit-report.xml"), report);
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()),
+                "json",
+                false,
+                false,
+                outputLink,
+                junitLink,
+                8.0
+        ));
+
+        assertEquals("output and junitReport must not point to the same file", thrown.getMessage());
+    }
+
+    @Test
     void runWithExistingCoverageRejectsSymlinkedParentBeforeLeafExists() throws Exception {
         writeMixedCoverageSample();
         Path source = tempDir.resolve("src/main/java/demo/Sample.java");
@@ -880,6 +906,15 @@ class MainTest {
             return Files.createSymbolicLink(link, target);
         } catch (UnsupportedOperationException | IOException | SecurityException exception) {
             assumeTrue(false, "Directory symbolic links are unavailable: " + exception.getMessage());
+            return link;
+        }
+    }
+
+    private Path createFileSymlinkOrSkip(Path link, Path target) throws Exception {
+        try {
+            return Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | IOException | SecurityException exception) {
+            assumeTrue(false, "File symbolic links are unavailable: " + exception.getMessage());
             return link;
         }
     }

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -542,6 +542,31 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageRejectsCaseOnlyPrimaryAndJunitReportPathCollision() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path report = tempDir.resolve("target/crap-java/report.xml");
+        Path caseVariant = tempDir.resolve("target/crap-java/REPORT.XML");
+        Files.createDirectories(report.getParent());
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()),
+                "json",
+                false,
+                false,
+                report,
+                caseVariant,
+                8.0
+        ));
+
+        assertEquals("output and junitReport must not point to the same file", thrown.getMessage());
+    }
+
+    @Test
     void runWithExistingCoverageAnalyzesPreResolvedModules() throws Exception {
         Path moduleRoot = tempDir.resolve("app");
         Path source = moduleRoot.resolve("src/main/java/demo/Sample.java");

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -515,6 +515,33 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageRejectsAliasedPrimaryAndJunitReportPath() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path report = tempDir.resolve("target/crap-java/report.xml");
+        Path alias = tempDir.resolve("target/crap-java/report-alias.xml");
+        Files.createDirectories(report.getParent());
+        Files.writeString(report, "existing");
+        Files.createLink(alias, report);
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()),
+                "json",
+                false,
+                false,
+                report,
+                alias,
+                8.0
+        ));
+
+        assertEquals("output and junitReport must not point to the same file", thrown.getMessage());
+    }
+
+    @Test
     void runWithExistingCoverageAnalyzesPreResolvedModules() throws Exception {
         Path moduleRoot = tempDir.resolve("app");
         Path source = moduleRoot.resolve("src/main/java/demo/Sample.java");

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MainTest {
@@ -460,6 +461,29 @@ class MainTest {
         assertTrue(junit.contains("FAILED danger"));
         assertTrue(junit.contains("PASSED safe"));
         assertTrue(junit.contains("SKIPPED unknown"));
+    }
+
+    @Test
+    void runWithExistingCoverageRejectsSharedPrimaryAndJunitReportPath() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path report = tempDir.resolve("target/crap-java/report.xml");
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()),
+                "json",
+                false,
+                false,
+                report,
+                report,
+                8.0
+        ));
+
+        assertEquals("output and junitReport must not point to the same file", thrown.getMessage());
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -464,6 +464,34 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoveragePreResolvedModulesResolvesRelativeReportPathsAgainstReportRoot() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path jsonReport = Path.of("target/crap-java/relative.json");
+        Path junitReport = Path.of("target/crap-java/TEST-relative.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err),
+                "json",
+                false,
+                false,
+                jsonReport,
+                junitReport,
+                8.0
+        );
+
+        assertEquals(2, exit);
+        assertTrue(Files.exists(tempDir.resolve(jsonReport)));
+        assertTrue(Files.exists(tempDir.resolve(junitReport)));
+    }
+
+    @Test
     void runWithExistingCoverageRejectsSharedPrimaryAndJunitReportPath() throws Exception {
         writeMixedCoverageSample();
         Path source = tempDir.resolve("src/main/java/demo/Sample.java");

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class MainTest {
 
@@ -569,6 +571,33 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageRejectsSymlinkedParentBeforeLeafExists() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path realRoot = tempDir.resolve("real");
+        Files.createDirectories(realRoot);
+        Path aliasRoot = createDirectorySymlinkOrSkip(tempDir.resolve("alias"), realRoot);
+        Path report = realRoot.resolve("reports/report.xml");
+        Path aliasReport = aliasRoot.resolve("reports/report.xml");
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()),
+                "json",
+                false,
+                false,
+                report,
+                aliasReport,
+                8.0
+        ));
+
+        assertEquals("output and junitReport must not point to the same file", thrown.getMessage());
+    }
+
+    @Test
     void runWithExistingCoverageHandlesCaseOnlyPrimaryAndJunitReportPathCollision() throws Exception {
         writeMixedCoverageSample();
         Path source = tempDir.resolve("src/main/java/demo/Sample.java");
@@ -771,6 +800,15 @@ class MainTest {
             return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
         } finally {
             Files.deleteIfExists(probe);
+        }
+    }
+
+    private Path createDirectorySymlinkOrSkip(Path link, Path target) throws Exception {
+        try {
+            return Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | IOException | SecurityException exception) {
+            assumeTrue(false, "Directory symbolic links are unavailable: " + exception.getMessage());
+            return link;
         }
     }
 }

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -568,6 +568,54 @@ class MainTest {
     }
 
     @Test
+    void runWithExistingCoverageRejectsDirectoryPrimaryReportPath() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path reportDirectory = tempDir.resolve("target/crap-java/report.json");
+        Files.createDirectories(reportDirectory);
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()),
+                "json",
+                false,
+                false,
+                reportDirectory,
+                tempDir.resolve("target/crap-java/TEST-crap-java.xml"),
+                8.0
+        ));
+
+        assertEquals("output must not point to a directory", thrown.getMessage());
+    }
+
+    @Test
+    void runWithExistingCoverageRejectsDirectoryJunitReportPath() throws Exception {
+        writeMixedCoverageSample();
+        Path source = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        Path junitDirectory = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
+        Files.createDirectories(junitDirectory);
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
+                tempDir,
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()),
+                "json",
+                false,
+                false,
+                tempDir.resolve("target/crap-java/report.json"),
+                junitDirectory,
+                8.0
+        ));
+
+        assertEquals("junitReport must not point to a directory", thrown.getMessage());
+    }
+
+    @Test
     void runWithExistingCoverageRejectsAliasedPrimaryAndJunitReportPath() throws Exception {
         writeMixedCoverageSample();
         Path source = tempDir.resolve("src/main/java/demo/Sample.java");
@@ -576,7 +624,7 @@ class MainTest {
         Path alias = tempDir.resolve("target/crap-java/report-alias.xml");
         Files.createDirectories(report.getParent());
         Files.writeString(report, "existing");
-        Files.createLink(alias, report);
+        createHardLinkOrSkip(alias, report);
 
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Main.runWithExistingCoverage(
                 List.of(new Main.ResolvedCoverageModule(tempDir, jacocoXml, List.of(source))),
@@ -832,6 +880,15 @@ class MainTest {
             return Files.createSymbolicLink(link, target);
         } catch (UnsupportedOperationException | IOException | SecurityException exception) {
             assumeTrue(false, "Directory symbolic links are unavailable: " + exception.getMessage());
+            return link;
+        }
+    }
+
+    private Path createHardLinkOrSkip(Path link, Path target) throws Exception {
+        try {
+            return Files.createLink(link, target);
+        } catch (UnsupportedOperationException | IOException | SecurityException exception) {
+            assumeTrue(false, "Hard links are unavailable: " + exception.getMessage());
             return link;
         }
     }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -184,8 +184,8 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         }
     }
 
-    private void validateReportPaths(Path outputPath, Path junitReportPath) {
-        if (outputPath != null && outputPath.equals(junitReportPath)) {
+    private void validateReportPaths(Path outputPath, Path junitReportPath) throws IOException {
+        if (outputPath != null && junitReportPath != null && sameReportTarget(outputPath, junitReportPath)) {
             throw new GradleException("output and junitReport must not point to the same file");
         }
         validateReportPathDoesNotUseInternalFile("output", outputPath);
@@ -221,7 +221,10 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private boolean hasRememberedStateFileName(Path reportPath) {
         String fileName = reportPath.getFileName().toString();
-        return "primary-output.path".equals(fileName) || "junit-report.path".equals(fileName);
+        return "primary-output.path".equals(fileName)
+                || "junit-report.path".equals(fileName)
+                || "primary-output.owner".equals(fileName)
+                || "junit-report.owner".equals(fileName);
     }
 
     private void cleanupStaleReports(Path currentOutputPath, Path currentJunitReportPath) throws Exception {
@@ -247,10 +250,18 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private void deleteRememberedOutputIfMoved(RememberedReport rememberedReport, Path currentPath) throws Exception {
-        if (rememberedReport == null || rememberedReport.path().equals(currentPath)) {
+        if (shouldKeepRememberedOutput(rememberedReport, currentPath)) {
             return;
         }
         deleteRememberedReport(rememberedReport);
+    }
+
+    private boolean shouldKeepRememberedOutput(RememberedReport rememberedReport, Path currentPath) throws IOException {
+        return rememberedReport == null || isCurrentRememberedPath(rememberedReport, currentPath);
+    }
+
+    private boolean isCurrentRememberedPath(RememberedReport rememberedReport, Path currentPath) throws IOException {
+        return currentPath != null && sameReportTarget(rememberedReport.path(), currentPath);
     }
 
     private void deleteOutputStateIfUnset(Path currentPath) throws Exception {
@@ -264,9 +275,10 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return;
         }
         RememberedReport rememberedReport = rememberedJunitReportPath();
-        if (rememberedReport != null && !rememberedReport.path().equals(currentPath)) {
+        if (rememberedReport != null && !sameReportTarget(rememberedReport.path(), currentPath)) {
             deleteRememberedReport(rememberedReport);
         }
+        deleteDefaultJunitReportIfMoved(currentPath);
     }
 
     private Path outputPath() {
@@ -288,6 +300,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return;
         }
         deleteRememberedReport(rememberedJunitReportPath());
+        Files.deleteIfExists(defaultJunitReportPath());
         deleteReportState(junitReportStatePath());
     }
 
@@ -316,6 +329,17 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return "reports/crap-java/TEST-crap-java.xml";
         }
         return "reports/crap-java/" + getName() + "/TEST-crap-java.xml";
+    }
+
+    private void deleteDefaultJunitReportIfMoved(Path currentPath) throws IOException {
+        Path defaultPath = defaultJunitReportPath();
+        if (!sameReportTarget(defaultPath, currentPath)) {
+            Files.deleteIfExists(defaultPath);
+        }
+    }
+
+    private Path defaultJunitReportPath() {
+        return defaultJunitReport.get().getAsFile().toPath().toAbsolutePath().normalize();
     }
 
     private void rememberOutputPath(Path path) throws Exception {
@@ -440,7 +464,20 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (":".equals(projectPath)) {
             return "root";
         }
-        return projectPath.substring(1).replace(':', '-');
+        return projectPath.substring(1)
+                .replace("%", "%25")
+                .replace(":", "%3A");
+    }
+
+    private boolean sameReportTarget(Path first, Path second) throws IOException {
+        if (first.equals(second)) {
+            return true;
+        }
+        return sameExistingFile(first, second);
+    }
+
+    private boolean sameExistingFile(Path first, Path second) throws IOException {
+        return Files.exists(first) && Files.exists(second) && Files.isSameFile(first, second);
     }
 
     private record RememberedReport(Path path, String ownership, Path ownerLink) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -46,6 +46,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     private final Provider<RegularFile> executionMarker;
     private final RegularFileProperty junitReportState;
     private final RegularFileProperty outputState;
+    private final RegularFileProperty stateLock;
     private final Provider<String> absentString;
     private final Provider<RegularFile> absentRegularFile;
 
@@ -61,6 +62,8 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         junitReportState.fileValue(localStateFile("junit-report.path"));
         outputState = getProject().getObjects().fileProperty();
         outputState.fileValue(localStateFile("primary-output.path"));
+        stateLock = getProject().getObjects().fileProperty();
+        stateLock.fileValue(globalStateFile("state.lock"));
         getThreshold().convention(Main.DEFAULT_THRESHOLD);
         getAgent().convention(false);
         getFormat().convention(getAgent().map(agent -> agent ? "toon" : "none"));
@@ -246,6 +249,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (reportPath.getFileName() == null) {
             throw new GradleException(propertyName + " must not point to a filesystem root");
         }
+        if (Files.isDirectory(reportPath)) {
+            throw new GradleException(propertyName + " must not point to a directory");
+        }
         if (isInternalTaskFile(reportPath)) {
             throw new GradleException(propertyName + " must not point to a crap-java internal task file: "
                     + reportPath);
@@ -277,7 +283,11 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private List<Path> internalRememberedStateRoots() {
         return getProject().getRootProject().getAllprojects().stream()
-                .map(project -> projectCacheRoot(project).resolve("crap-java").resolve(projectStateName(project)))
+                .flatMap(project -> {
+                    Path stateRoot = projectCacheRoot(project).resolve("crap-java");
+                    return Stream.of(stateRoot, stateRoot.resolve(projectStateName(project)));
+                })
+                .distinct()
                 .toList();
     }
 
@@ -424,7 +434,10 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private Path stateLockPath() {
-        return outputStatePath().resolveSibling("state.lock");
+        return stateLock.get().getAsFile()
+                .toPath()
+                .toAbsolutePath()
+                .normalize();
     }
 
     private void writeExecutionMarker() throws Exception {
@@ -668,6 +681,13 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .resolve("crap-java")
                 .resolve(projectStateName(getProject()))
                 .resolve(getName())
+                .resolve(fileName)
+                .toFile();
+    }
+
+    private File globalStateFile(String fileName) {
+        return projectCacheRoot(getProject())
+                .resolve("crap-java")
                 .resolve(fileName)
                 .toFile();
     }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -5,6 +5,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
@@ -24,11 +25,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,12 +44,15 @@ import java.util.stream.Stream;
 public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private static final String LINK_OWNERSHIP = "link";
+    private static final String ENCODED_PATH_PREFIX = "path-base64\t";
 
     private final Provider<RegularFile> defaultJunitReport;
     private final Provider<RegularFile> executionMarker;
     private final RegularFileProperty junitReportState;
     private final RegularFileProperty outputState;
     private final RegularFileProperty stateLock;
+    private final List<Provider<Directory>> internalExecutionMarkerRootProviders;
+    private final List<Path> internalRememberedStateRootPaths;
     private final Provider<String> absentString;
     private final Provider<RegularFile> absentRegularFile;
 
@@ -64,6 +70,16 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         outputState.fileValue(localStateFile("primary-output.path"));
         stateLock = getProject().getObjects().fileProperty();
         stateLock.fileValue(globalStateFile("state.lock"));
+        internalExecutionMarkerRootProviders = getProject().getRootProject().getAllprojects().stream()
+                .map(project -> project.getLayout().getBuildDirectory().dir("tmp/crap-java"))
+                .toList();
+        internalRememberedStateRootPaths = getProject().getRootProject().getAllprojects().stream()
+                .flatMap(project -> {
+                    Path stateRoot = projectCacheRoot(project).resolve("crap-java");
+                    return Stream.of(stateRoot, stateRoot.resolve(projectStateName(project)));
+                })
+                .distinct()
+                .toList();
         getThreshold().convention(Main.DEFAULT_THRESHOLD);
         getAgent().convention(false);
         getFormat().convention(getAgent().map(agent -> agent ? "toon" : "none"));
@@ -259,44 +275,77 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private boolean isInternalTaskFile(Path reportPath) {
-        return isExecutionMarkerPath(reportPath) || isRememberedPathStateFile(reportPath);
+        return isUnderAnyInternalRoot(reportPath) || sameFileAsExistingInternalFile(reportPath);
     }
 
-    private boolean isExecutionMarkerPath(Path reportPath) {
-        return isInternalFileName(reportPath, "execution.marker")
-                && internalExecutionMarkerRoots().stream()
-                .anyMatch(internalRoot -> isUnderInternalRoot(reportPath, internalRoot));
-    }
-
-    private boolean isRememberedPathStateFile(Path reportPath) {
-        return hasRememberedStateFileName(reportPath)
-                && internalRememberedStateRoots().stream()
+    private boolean isUnderAnyInternalRoot(Path reportPath) {
+        return internalTaskRoots().stream()
                 .anyMatch(internalRoot -> isUnderInternalRoot(reportPath, internalRoot));
     }
 
     private List<Path> internalExecutionMarkerRoots() {
-        return getProject().getRootProject().getAllprojects().stream()
-                .map(project -> project.getLayout().getBuildDirectory().dir("tmp/crap-java").get())
+        return internalExecutionMarkerRootProviders.stream()
+                .map(Provider::get)
                 .map(directory -> directory.getAsFile().toPath().toAbsolutePath().normalize())
                 .toList();
     }
 
     private List<Path> internalRememberedStateRoots() {
-        return getProject().getRootProject().getAllprojects().stream()
-                .flatMap(project -> {
-                    Path stateRoot = projectCacheRoot(project).resolve("crap-java");
-                    return Stream.of(stateRoot, stateRoot.resolve(projectStateName(project)));
-                })
+        return internalRememberedStateRootPaths;
+    }
+
+    private List<Path> internalTaskRoots() {
+        return Stream.concat(internalExecutionMarkerRoots().stream(), internalRememberedStateRoots().stream())
                 .distinct()
                 .toList();
     }
 
-    private boolean hasRememberedStateFileName(Path reportPath) {
-        return isInternalFileName(reportPath, "primary-output.path")
-                || isInternalFileName(reportPath, "junit-report.path")
-                || isInternalFileName(reportPath, "primary-output.owner")
-                || isInternalFileName(reportPath, "junit-report.owner")
-                || isInternalFileName(reportPath, "state.lock");
+    private boolean sameFileAsExistingInternalFile(Path reportPath) {
+        if (!Files.exists(reportPath)) {
+            return false;
+        }
+        return internalTaskRoots().stream()
+                .anyMatch(internalRoot -> sameFileAsExistingInternalFile(reportPath, internalRoot));
+    }
+
+    private boolean sameFileAsExistingInternalFile(Path reportPath, Path internalRoot) {
+        if (!Files.isDirectory(internalRoot)) {
+            return false;
+        }
+        try (Stream<Path> candidates = Files.walk(internalRoot)) {
+            return candidates
+                    .filter(this::isInternalStateOrMarkerFile)
+                    .filter(Files::isRegularFile)
+                    .anyMatch(candidate -> sameFile(reportPath, candidate));
+        } catch (IOException | SecurityException exception) {
+            return false;
+        }
+    }
+
+    private boolean isInternalStateOrMarkerFile(Path path) {
+        return isInternalFileName(path, "execution.marker")
+                || isInternalFileName(path, "primary-output.path")
+                || isInternalFileName(path, "junit-report.path")
+                || isInternalFileName(path, "state.lock");
+    }
+
+    private boolean isInternalFileName(Path path, String internalFileName) {
+        Path fileName = path.getFileName();
+        if (fileName == null) {
+            return false;
+        }
+        String name = fileName.toString();
+        return name.equals(internalFileName)
+                || sameCaseInsensitiveFileName(name, internalFileName, path.getParent());
+    }
+
+    private boolean sameFile(Path first, Path second) {
+        try {
+            return !first.toAbsolutePath().normalize().equals(second.toAbsolutePath().normalize())
+                    && Files.isSameFile(first, second);
+        } catch (IOException | SecurityException exception) {
+            return false;
+        }
     }
 
     private boolean isUnderInternalRoot(Path reportPath, Path internalRoot) {
@@ -334,12 +383,6 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             current = current.getParent();
         }
         return null;
-    }
-
-    private boolean isInternalFileName(Path reportPath, String internalFileName) {
-        String fileName = reportPath.getFileName().toString();
-        return fileName.equals(internalFileName)
-                || sameCaseInsensitiveFileName(fileName, internalFileName, reportPath.getParent());
     }
 
     private boolean sameCaseInsensitiveFileName(String fileName, String internalFileName, Path parent) {
@@ -645,7 +688,13 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             Files.deleteIfExists(statePath);
             return;
         }
-        Files.writeString(statePath, reportPath + "\n" + ownership + "\n");
+        Files.writeString(statePath, encodeRememberedReportPath(reportPath) + "\n" + ownership + "\n");
+    }
+
+    private String encodeRememberedReportPath(Path reportPath) {
+        String encoded = Base64.getEncoder()
+                .encodeToString(reportPath.toString().getBytes(StandardCharsets.UTF_8));
+        return ENCODED_PATH_PREFIX + encoded;
     }
 
     private String ownership(Path reportPath, Path ownerLink) throws Exception {
@@ -695,11 +744,31 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (!hasRememberedReport(lines)) {
             return null;
         }
+        Path reportPath = parseRememberedReportPath(lines.get(0));
+        if (reportPath == null) {
+            return null;
+        }
         return new RememberedReport(
-                Path.of(lines.get(0)).toAbsolutePath().normalize(),
+                reportPath,
                 lines.get(1),
                 ownerLinkPath(statePath)
         );
+    }
+
+    private Path parseRememberedReportPath(String line) {
+        if (line.startsWith(ENCODED_PATH_PREFIX)) {
+            return decodeRememberedReportPath(line.substring(ENCODED_PATH_PREFIX.length()));
+        }
+        return Path.of(line).toAbsolutePath().normalize();
+    }
+
+    private Path decodeRememberedReportPath(String encoded) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(encoded);
+            return Path.of(new String(decoded, StandardCharsets.UTF_8)).toAbsolutePath().normalize();
+        } catch (IllegalArgumentException exception) {
+            return null;
+        }
     }
 
     private boolean hasRememberedReport(List<String> lines) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -400,11 +400,31 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             ReportSnapshot outputBefore,
             ReportSnapshot junitBefore
     ) throws Exception {
-        if (shouldRememberChangedReport(currentOutputPath, outputBefore, rememberedOutputPath())) {
+        RememberedReport rememberedOutput = rememberedOutputPath();
+        RememberedReport rememberedJunitReport = rememberedJunitReportPath();
+        deleteNewUnrememberedChangedReport(currentOutputPath, outputBefore, rememberedOutput);
+        deleteNewUnrememberedChangedReport(currentJunitReportPath, junitBefore, rememberedJunitReport);
+        if (shouldRememberChangedReport(currentOutputPath, outputBefore, rememberedOutput)) {
             rememberOutputPath(currentOutputPath);
         }
-        if (shouldRememberChangedReport(currentJunitReportPath, junitBefore, rememberedJunitReportPath())) {
+        if (shouldRememberChangedReport(currentJunitReportPath, junitBefore, rememberedJunitReport)) {
             rememberJunitReportPath(currentJunitReportPath);
+        }
+    }
+
+    private void deleteNewUnrememberedChangedReport(
+            Path reportPath,
+            ReportSnapshot before,
+            RememberedReport rememberedReport
+    ) throws IOException {
+        if (rememberedReport == null || before.exists()) {
+            return;
+        }
+        if (isCurrentRememberedPath(rememberedReport, reportPath)) {
+            return;
+        }
+        if (reportChanged(reportPath, before)) {
+            Files.deleteIfExists(reportPath);
         }
     }
 

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -30,9 +30,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -802,9 +805,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private File localStateFile(String fileName) {
-        return projectCacheRoot(getProject())
-                .resolve("crap-java")
-                .resolve(projectStateName(getProject()))
+        return localStateRoot(getProject())
                 .resolve(getName())
                 .resolve(fileName)
                 .toFile();
@@ -817,12 +818,35 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .toFile();
     }
 
+    private Path localStateRoot(Project project) {
+        Path stateRoot = projectCacheRoot(project).resolve("crap-java");
+        if (hasCustomProjectCacheDir(project)) {
+            stateRoot = stateRoot.resolve(rootProjectStateName(project));
+        }
+        return stateRoot.resolve(projectStateName(project));
+    }
+
     private Path projectCacheRoot(Project project) {
         File projectCacheDir = project.getGradle().getStartParameter().getProjectCacheDir();
         if (projectCacheDir != null) {
             return projectCacheDir.toPath().toAbsolutePath().normalize();
         }
         return project.getRootProject().getProjectDir().toPath().resolve(".gradle").toAbsolutePath().normalize();
+    }
+
+    private boolean hasCustomProjectCacheDir(Project project) {
+        return project.getGradle().getStartParameter().getProjectCacheDir() != null;
+    }
+
+    private String rootProjectStateName(Project project) {
+        String rootPath = project.getRootProject().getProjectDir().toPath().toAbsolutePath().normalize().toString();
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(rootPath.getBytes(StandardCharsets.UTF_8));
+            return "workspace-" + HexFormat.of().formatHex(hash, 0, 12);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
     }
 
     private String projectStateName(Project project) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -530,17 +530,34 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private boolean isOwnedRememberedReport(RememberedReport rememberedReport) throws Exception {
-        if (rememberedReport == null) {
+        if (!hasRegularRememberedReport(rememberedReport)) {
             return false;
         }
-        if (!Files.isRegularFile(rememberedReport.path())) {
+        if (!hasCurrentOwnerLink(rememberedReport)) {
             return false;
         }
-        return rememberedReport.ownership().startsWith(LINK_OWNERSHIP + "\t")
-                && Files.exists(rememberedReport.ownerLink())
-                && Files.isSameFile(rememberedReport.path(), rememberedReport.ownerLink())
-                && !hasOtherOwnerLink(rememberedReport)
-                && rememberedReport.ownership().equals(ownership(rememberedReport.path()));
+        if (hasOtherOwnerLink(rememberedReport)) {
+            return false;
+        }
+        return hasCurrentOwnership(rememberedReport);
+    }
+
+    private boolean hasRegularRememberedReport(RememberedReport rememberedReport) {
+        return rememberedReport != null && Files.isRegularFile(rememberedReport.path());
+    }
+
+    private boolean hasCurrentOwnerLink(RememberedReport rememberedReport) throws IOException {
+        if (!rememberedReport.ownership().startsWith(LINK_OWNERSHIP + "\t")) {
+            return false;
+        }
+        if (!Files.exists(rememberedReport.ownerLink())) {
+            return false;
+        }
+        return Files.isSameFile(rememberedReport.path(), rememberedReport.ownerLink());
+    }
+
+    private boolean hasCurrentOwnership(RememberedReport rememberedReport) throws Exception {
+        return rememberedReport.ownership().equals(ownership(rememberedReport.path()));
     }
 
     private boolean hasOtherOwnerLink(RememberedReport rememberedReport) throws IOException {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -273,12 +273,20 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private void deleteRememberedReport(RememberedReport rememberedReport) throws Exception {
-        if (rememberedReport == null || !Files.isRegularFile(rememberedReport.path())) {
+        if (!isOwnedRememberedReport(rememberedReport)) {
             return;
         }
-        if (rememberedReport.fingerprint().equals(fileFingerprint(rememberedReport.path()))) {
-            Files.deleteIfExists(rememberedReport.path());
+        Files.deleteIfExists(rememberedReport.path());
+    }
+
+    private boolean isOwnedRememberedReport(RememberedReport rememberedReport) throws Exception {
+        if (rememberedReport == null) {
+            return false;
         }
+        if (!Files.isRegularFile(rememberedReport.path())) {
+            return false;
+        }
+        return rememberedReport.fingerprint().equals(fileFingerprint(rememberedReport.path()));
     }
 
     private String defaultJunitReportRelativePath() {
@@ -327,14 +335,18 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (!Files.isRegularFile(statePath)) {
             return null;
         }
-        List<String> lines = Files.readAllLines(statePath);
-        if (lines.isEmpty() || lines.get(0).isBlank()) {
-            return null;
-        }
-        if (lines.size() < 2 || lines.get(1).isBlank()) {
+        return parseRememberedReport(Files.readAllLines(statePath));
+    }
+
+    private RememberedReport parseRememberedReport(List<String> lines) {
+        if (!hasRememberedReport(lines)) {
             return null;
         }
         return new RememberedReport(Path.of(lines.get(0).trim()).toAbsolutePath().normalize(), lines.get(1).trim());
+    }
+
+    private boolean hasRememberedReport(List<String> lines) {
+        return lines.size() >= 2 && !lines.get(0).isBlank() && !lines.get(1).isBlank();
     }
 
     private String fileFingerprint(Path path) throws Exception {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -234,7 +234,8 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         return "primary-output.path".equals(fileName)
                 || "junit-report.path".equals(fileName)
                 || "primary-output.owner".equals(fileName)
-                || "junit-report.owner".equals(fileName);
+                || "junit-report.owner".equals(fileName)
+                || "state.lock".equals(fileName);
     }
 
     private void cleanupStaleReports(Path currentOutputPath, Path currentJunitReportPath) throws Exception {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -21,13 +21,13 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public abstract class CrapJavaCheckTask extends DefaultTask {
 
@@ -130,12 +130,11 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         Path analysisRoot = getAnalysisRoot().get().getAsFile().toPath().toAbsolutePath().normalize();
         Path configuredOutputPath = outputPath();
         Path configuredJunitReportPath = junitReportPath();
-        deleteMovedOutput(configuredOutputPath);
-        deleteMovedJunitReport(configuredJunitReportPath);
+        validateReportPaths(configuredOutputPath, configuredJunitReportPath);
         if (sourceFiles.isEmpty()) {
             try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
                  var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
-                Main.runWithExistingCoverage(
+                int exit = Main.runWithExistingCoverage(
                         List.of(),
                         analysisRoot,
                         out,
@@ -147,8 +146,12 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                         configuredJunitReportPath,
                         getThreshold().get()
                 );
+                cleanupStaleReports(configuredOutputPath, configuredJunitReportPath);
                 rememberOutputPath(configuredOutputPath);
                 rememberJunitReportPath(configuredJunitReportPath);
+                if (exit != 0) {
+                    throw new GradleException("crap-java-check failed with exit " + exit);
+                }
                 writeExecutionMarker();
             }
             return;
@@ -168,6 +171,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                     configuredJunitReportPath,
                     getThreshold().get()
             );
+            cleanupStaleReports(configuredOutputPath, configuredJunitReportPath);
             rememberOutputPath(configuredOutputPath);
             rememberJunitReportPath(configuredJunitReportPath);
             if (exit != 0) {
@@ -177,23 +181,57 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         }
     }
 
+    private void validateReportPaths(Path outputPath, Path junitReportPath) {
+        if (outputPath != null && outputPath.equals(junitReportPath)) {
+            throw new GradleException("output and junitReport must not point to the same file");
+        }
+        validateReportPathDoesNotUseInternalFile("output", outputPath);
+        validateReportPathDoesNotUseInternalFile("junitReport", junitReportPath);
+    }
+
+    private void validateReportPathDoesNotUseInternalFile(String propertyName, Path reportPath) {
+        if (reportPath == null) {
+            return;
+        }
+        for (Path internalPath : internalStatePaths()) {
+            if (reportPath.equals(internalPath)) {
+                throw new GradleException(propertyName + " must not point to a crap-java internal task file: "
+                        + reportPath);
+            }
+        }
+    }
+
+    private List<Path> internalStatePaths() {
+        return List.of(executionMarkerPath(), outputStatePath(), junitReportStatePath());
+    }
+
+    private void cleanupStaleReports(Path currentOutputPath, Path currentJunitReportPath) throws Exception {
+        deleteMovedOutput(currentOutputPath);
+        deleteMovedJunitReport(currentJunitReportPath);
+        deleteDisabledJunitReport();
+    }
+
     private void writeExecutionMarker() throws Exception {
-        Path markerPath = getExecutionMarkerOutput().get().getAsFile().toPath().toAbsolutePath().normalize();
+        Path markerPath = executionMarkerPath();
         Files.createDirectories(markerPath.getParent());
         Files.writeString(markerPath, "ok\n");
     }
 
+    private Path executionMarkerPath() {
+        return getExecutionMarkerOutput().get().getAsFile().toPath().toAbsolutePath().normalize();
+    }
+
     private void deleteMovedOutput(Path currentPath) throws Exception {
-        Path rememberedPath = rememberedOutputPath();
-        deleteRememberedOutputIfMoved(rememberedPath, currentPath);
+        RememberedReport rememberedReport = rememberedOutputPath();
+        deleteRememberedOutputIfMoved(rememberedReport, currentPath);
         deleteOutputStateIfUnset(currentPath);
     }
 
-    private void deleteRememberedOutputIfMoved(Path rememberedPath, Path currentPath) throws Exception {
-        if (rememberedPath == null || rememberedPath.equals(currentPath)) {
+    private void deleteRememberedOutputIfMoved(RememberedReport rememberedReport, Path currentPath) throws Exception {
+        if (rememberedReport == null || rememberedReport.path().equals(currentPath)) {
             return;
         }
-        Files.deleteIfExists(rememberedPath);
+        deleteRememberedReport(rememberedReport);
     }
 
     private void deleteOutputStateIfUnset(Path currentPath) throws Exception {
@@ -206,9 +244,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (currentPath == null) {
             return;
         }
-        Path rememberedPath = rememberedJunitReportPath();
-        if (rememberedPath != null && !rememberedPath.equals(currentPath)) {
-            Files.deleteIfExists(rememberedPath);
+        RememberedReport rememberedReport = rememberedJunitReportPath();
+        if (rememberedReport != null && !rememberedReport.path().equals(currentPath)) {
+            deleteRememberedReport(rememberedReport);
         }
     }
 
@@ -230,31 +268,17 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (getJunit().get()) {
             return;
         }
-        for (Path path : disabledJunitReportPaths()) {
-            Files.deleteIfExists(path);
-        }
+        deleteRememberedReport(rememberedJunitReportPath());
         Files.deleteIfExists(junitReportStatePath());
     }
 
-    private Set<Path> disabledJunitReportPaths() throws Exception {
-        Set<Path> paths = new LinkedHashSet<>();
-        if (getJunitReport().isPresent()) {
-            paths.add(getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize());
+    private void deleteRememberedReport(RememberedReport rememberedReport) throws Exception {
+        if (rememberedReport == null || !Files.isRegularFile(rememberedReport.path())) {
+            return;
         }
-        paths.add(defaultJunitReportPath());
-        Path rememberedPath = rememberedJunitReportPath();
-        if (rememberedPath != null) {
-            paths.add(rememberedPath);
+        if (rememberedReport.fingerprint().equals(fileFingerprint(rememberedReport.path()))) {
+            Files.deleteIfExists(rememberedReport.path());
         }
-        return paths;
-    }
-
-    private Path defaultJunitReportPath() {
-        return defaultJunitReport.get()
-                .getAsFile()
-                .toPath()
-                .toAbsolutePath()
-                .normalize();
     }
 
     private String defaultJunitReportRelativePath() {
@@ -269,21 +293,11 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             Files.deleteIfExists(outputStatePath());
             return;
         }
-        Path statePath = outputStatePath();
-        Files.createDirectories(statePath.getParent());
-        Files.writeString(statePath, path.toString());
+        rememberReportPath(outputStatePath(), path);
     }
 
-    private Path rememberedOutputPath() throws Exception {
-        Path statePath = outputStatePath();
-        if (!Files.isRegularFile(statePath)) {
-            return null;
-        }
-        String value = Files.readString(statePath).trim();
-        if (value.isBlank()) {
-            return null;
-        }
-        return Path.of(value).toAbsolutePath().normalize();
+    private RememberedReport rememberedOutputPath() throws Exception {
+        return rememberedReportPath(outputStatePath());
     }
 
     private Path outputStatePath() {
@@ -297,21 +311,35 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (path == null) {
             return;
         }
-        Path statePath = junitReportStatePath();
-        Files.createDirectories(statePath.getParent());
-        Files.writeString(statePath, path.toString());
+        rememberReportPath(junitReportStatePath(), path);
     }
 
-    private Path rememberedJunitReportPath() throws Exception {
-        Path statePath = junitReportStatePath();
+    private void rememberReportPath(Path statePath, Path reportPath) throws Exception {
+        Files.createDirectories(statePath.getParent());
+        Files.writeString(statePath, reportPath + "\n" + fileFingerprint(reportPath) + "\n");
+    }
+
+    private RememberedReport rememberedJunitReportPath() throws Exception {
+        return rememberedReportPath(junitReportStatePath());
+    }
+
+    private RememberedReport rememberedReportPath(Path statePath) throws Exception {
         if (!Files.isRegularFile(statePath)) {
             return null;
         }
-        String value = Files.readString(statePath).trim();
-        if (value.isBlank()) {
+        List<String> lines = Files.readAllLines(statePath);
+        if (lines.isEmpty() || lines.get(0).isBlank()) {
             return null;
         }
-        return Path.of(value).toAbsolutePath().normalize();
+        if (lines.size() < 2 || lines.get(1).isBlank()) {
+            return null;
+        }
+        return new RememberedReport(Path.of(lines.get(0).trim()).toAbsolutePath().normalize(), lines.get(1).trim());
+    }
+
+    private String fileFingerprint(Path path) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path));
+        return HexFormat.of().formatHex(digest);
     }
 
     private Path junitReportStatePath() {
@@ -319,6 +347,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .toPath()
                 .toAbsolutePath()
                 .normalize();
+    }
+
+    private record RememberedReport(Path path, String fingerprint) {
     }
 
     private List<Main.ResolvedCoverageModule> resolvedModules(List<Path> sourceFiles) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -32,8 +32,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 public abstract class CrapJavaCheckTask extends DefaultTask {
 
@@ -207,7 +210,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private boolean isExecutionMarkerPath(Path reportPath) {
-        return "execution.marker".equals(reportPath.getFileName().toString())
+        return isInternalFileName(reportPath, "execution.marker")
                 && internalExecutionMarkerRoots().stream()
                 .anyMatch(internalRoot -> isUnderInternalRoot(reportPath, internalRoot));
     }
@@ -232,12 +235,11 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private boolean hasRememberedStateFileName(Path reportPath) {
-        String fileName = reportPath.getFileName().toString();
-        return "primary-output.path".equals(fileName)
-                || "junit-report.path".equals(fileName)
-                || "primary-output.owner".equals(fileName)
-                || "junit-report.owner".equals(fileName)
-                || "state.lock".equals(fileName);
+        return isInternalFileName(reportPath, "primary-output.path")
+                || isInternalFileName(reportPath, "junit-report.path")
+                || isInternalFileName(reportPath, "primary-output.owner")
+                || isInternalFileName(reportPath, "junit-report.owner")
+                || isInternalFileName(reportPath, "state.lock");
     }
 
     private boolean isUnderInternalRoot(Path reportPath, Path internalRoot) {
@@ -275,6 +277,53 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             current = current.getParent();
         }
         return null;
+    }
+
+    private boolean isInternalFileName(Path reportPath, String internalFileName) {
+        String fileName = reportPath.getFileName().toString();
+        return fileName.equals(internalFileName)
+                || sameCaseInsensitiveFileName(fileName, internalFileName, reportPath.getParent());
+    }
+
+    private boolean sameCaseInsensitiveFileName(String fileName, String internalFileName, Path parent) {
+        return fileName.equalsIgnoreCase(internalFileName) && isCaseInsensitive(parent);
+    }
+
+    private boolean isCaseInsensitive(Path path) {
+        Path directory = nearestExistingDirectory(path);
+        return directory == null ? isLikelyCaseInsensitiveOs() : directoryIsCaseInsensitive(directory);
+    }
+
+    private boolean directoryIsCaseInsensitive(Path directory) {
+        try {
+            Path probe = Files.createTempFile(directory, ".crap-java-case-", ".tmp");
+            try {
+                return caseVariantExists(probe);
+            } finally {
+                Files.deleteIfExists(probe);
+            }
+        } catch (IOException | SecurityException exception) {
+            return isLikelyCaseInsensitiveOs();
+        }
+    }
+
+    private Path nearestExistingDirectory(Path path) {
+        Path start = path == null ? Path.of(".").toAbsolutePath().normalize() : path.toAbsolutePath().normalize();
+        return ancestors(start).filter(Files::isDirectory).findFirst().orElse(null);
+    }
+
+    private Stream<Path> ancestors(Path path) {
+        return Stream.iterate(path, Objects::nonNull, Path::getParent);
+    }
+
+    private boolean caseVariantExists(Path probe) {
+        Path variant = probe.resolveSibling(probe.getFileName().toString().toUpperCase(Locale.ROOT));
+        return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
+    }
+
+    private boolean isLikelyCaseInsensitiveOs() {
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        return os.contains("win") || os.contains("mac");
     }
 
     private void cleanupStaleReports(Path currentOutputPath, Path currentJunitReportPath) throws Exception {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -32,6 +32,7 @@ import java.util.Set;
 public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private final Provider<RegularFile> defaultJunitReport;
+    private final Provider<RegularFile> executionMarker;
     private final RegularFile junitReportState;
     private final RegularFile outputState;
     private final Provider<String> absentString;
@@ -41,6 +42,8 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         defaultJunitReport = getProject().getProviders()
                 .provider(this::defaultJunitReportRelativePath)
                 .flatMap(path -> getProject().getLayout().getBuildDirectory().file(path));
+        executionMarker = getProject().getLayout().getBuildDirectory()
+                .file("tmp/crap-java/" + getName() + "/execution.marker");
         junitReportState = getProject().getLayout().getProjectDirectory()
                 .file(".gradle/crap-java/" + getName() + "/junit-report.path");
         outputState = getProject().getLayout().getProjectDirectory()
@@ -110,6 +113,11 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 : getProject().getProviders().provider(() -> (RegularFile) null));
     }
 
+    @OutputFile
+    public Provider<RegularFile> getExecutionMarkerOutput() {
+        return executionMarker;
+    }
+
     @TaskAction
     void runCheck() throws Exception {
         deleteDisabledJunitReport();
@@ -139,6 +147,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 );
                 rememberOutputPath(configuredOutputPath);
                 rememberJunitReportPath(configuredJunitReportPath);
+                writeExecutionMarker();
             }
             return;
         }
@@ -162,7 +171,14 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             if (exit != 0) {
                 throw new GradleException("crap-java-check failed with exit " + exit);
             }
+            writeExecutionMarker();
         }
+    }
+
+    private void writeExecutionMarker() throws Exception {
+        Path markerPath = getExecutionMarkerOutput().get().getAsFile().toPath().toAbsolutePath().normalize();
+        Files.createDirectories(markerPath.getParent());
+        Files.writeString(markerPath, "ok\n");
     }
 
     private void deleteMovedOutput(Path currentPath) throws Exception {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -164,7 +164,6 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         Files.createDirectories(lockPath.getParent());
         try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
              FileLock ignored = channel.lock()) {
-            cleanupStaleReports(configuredOutputPath, configuredJunitReportPath);
             return runAndRememberReports(
                     modules,
                     analysisRoot,
@@ -196,6 +195,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                     configuredJunitReportPath,
                     getThreshold().get()
             );
+            cleanupStaleReports(configuredOutputPath, configuredJunitReportPath);
             rememberReportState(configuredOutputPath, configuredJunitReportPath);
             return exit;
         } catch (Exception exception) {
@@ -473,7 +473,6 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (!shouldKeepRememberedReport(rememberedReport, currentPath, otherCurrentPath)) {
             deleteRememberedReport(rememberedReport);
         }
-        deleteDefaultJunitReportIfMoved(currentPath, otherCurrentPath);
     }
 
     private Path outputPath() {
@@ -498,7 +497,6 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (!shouldKeepRememberedReport(rememberedReport, currentOutputPath, null)) {
             deleteRememberedReport(rememberedReport);
         }
-        deleteDefaultJunitReportIfDisabled(currentOutputPath);
         deleteReportState(junitReportStatePath());
     }
 
@@ -527,24 +525,6 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return "reports/crap-java/TEST-crap-java.xml";
         }
         return "reports/crap-java/" + getName() + "/TEST-crap-java.xml";
-    }
-
-    private void deleteDefaultJunitReportIfMoved(Path currentPath, Path otherCurrentPath) throws IOException {
-        Path defaultPath = defaultJunitReportPath();
-        if (!isCurrentPath(defaultPath, currentPath) && !isCurrentPath(defaultPath, otherCurrentPath)) {
-            Files.deleteIfExists(defaultPath);
-        }
-    }
-
-    private void deleteDefaultJunitReportIfDisabled(Path currentOutputPath) throws IOException {
-        Path defaultPath = defaultJunitReportPath();
-        if (!isCurrentPath(defaultPath, currentOutputPath)) {
-            Files.deleteIfExists(defaultPath);
-        }
-    }
-
-    private boolean isCurrentPath(Path path, Path currentPath) throws IOException {
-        return currentPath != null && sameReportTarget(path, currentPath);
     }
 
     private Path defaultJunitReportPath() {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -839,7 +839,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (first.equals(second)) {
             return true;
         }
-        return sameExistingFile(first, second) || sameParentAndFileName(first, second);
+        return sameExistingFile(first, second)
+                || sameRealPath(first, second)
+                || sameParentAndFileName(first, second);
     }
 
     private boolean sameExistingFile(Path first, Path second) throws IOException {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -199,6 +199,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (reportPath == null) {
             return;
         }
+        if (reportPath.getFileName() == null) {
+            throw new GradleException(propertyName + " must not point to a filesystem root");
+        }
         if (isInternalTaskFile(reportPath)) {
             throw new GradleException(propertyName + " must not point to a crap-java internal task file: "
                     + reportPath);
@@ -327,9 +330,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private void cleanupStaleReports(Path currentOutputPath, Path currentJunitReportPath) throws Exception {
-        deleteMovedOutput(currentOutputPath);
-        deleteMovedJunitReport(currentJunitReportPath);
-        deleteDisabledJunitReport();
+        deleteMovedOutput(currentOutputPath, currentJunitReportPath);
+        deleteMovedJunitReport(currentJunitReportPath, currentOutputPath);
+        deleteDisabledJunitReport(currentOutputPath);
     }
 
     private void updateReportState(Path currentOutputPath, Path currentJunitReportPath) throws Exception {
@@ -357,21 +360,31 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         return getExecutionMarkerOutput().get().getAsFile().toPath().toAbsolutePath().normalize();
     }
 
-    private void deleteMovedOutput(Path currentPath) throws Exception {
+    private void deleteMovedOutput(Path currentPath, Path otherCurrentPath) throws Exception {
         RememberedReport rememberedReport = rememberedOutputPath();
-        deleteRememberedOutputIfMoved(rememberedReport, currentPath);
+        deleteRememberedOutputIfMoved(rememberedReport, currentPath, otherCurrentPath);
         deleteOutputStateIfUnset(currentPath);
     }
 
-    private void deleteRememberedOutputIfMoved(RememberedReport rememberedReport, Path currentPath) throws Exception {
-        if (shouldKeepRememberedOutput(rememberedReport, currentPath)) {
+    private void deleteRememberedOutputIfMoved(
+            RememberedReport rememberedReport,
+            Path currentPath,
+            Path otherCurrentPath
+    ) throws Exception {
+        if (shouldKeepRememberedReport(rememberedReport, currentPath, otherCurrentPath)) {
             return;
         }
         deleteRememberedReport(rememberedReport);
     }
 
-    private boolean shouldKeepRememberedOutput(RememberedReport rememberedReport, Path currentPath) throws IOException {
-        return rememberedReport == null || isCurrentRememberedPath(rememberedReport, currentPath);
+    private boolean shouldKeepRememberedReport(
+            RememberedReport rememberedReport,
+            Path currentPath,
+            Path otherCurrentPath
+    ) throws IOException {
+        return rememberedReport == null
+                || isCurrentRememberedPath(rememberedReport, currentPath)
+                || isCurrentRememberedPath(rememberedReport, otherCurrentPath);
     }
 
     private boolean isCurrentRememberedPath(RememberedReport rememberedReport, Path currentPath) throws IOException {
@@ -384,15 +397,15 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         }
     }
 
-    private void deleteMovedJunitReport(Path currentPath) throws Exception {
+    private void deleteMovedJunitReport(Path currentPath, Path otherCurrentPath) throws Exception {
         if (currentPath == null) {
             return;
         }
         RememberedReport rememberedReport = rememberedJunitReportPath();
-        if (rememberedReport != null && !sameReportTarget(rememberedReport.path(), currentPath)) {
+        if (!shouldKeepRememberedReport(rememberedReport, currentPath, otherCurrentPath)) {
             deleteRememberedReport(rememberedReport);
         }
-        deleteDefaultJunitReportIfMoved(currentPath);
+        deleteDefaultJunitReportIfMoved(currentPath, otherCurrentPath);
     }
 
     private Path outputPath() {
@@ -409,12 +422,15 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         return getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize();
     }
 
-    private void deleteDisabledJunitReport() throws Exception {
+    private void deleteDisabledJunitReport(Path currentOutputPath) throws Exception {
         if (getJunit().get()) {
             return;
         }
-        deleteRememberedReport(rememberedJunitReportPath());
-        Files.deleteIfExists(defaultJunitReportPath());
+        RememberedReport rememberedReport = rememberedJunitReportPath();
+        if (!shouldKeepRememberedReport(rememberedReport, currentOutputPath, null)) {
+            deleteRememberedReport(rememberedReport);
+        }
+        deleteDefaultJunitReportIfDisabled(currentOutputPath);
         deleteReportState(junitReportStatePath());
     }
 
@@ -445,11 +461,22 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         return "reports/crap-java/" + getName() + "/TEST-crap-java.xml";
     }
 
-    private void deleteDefaultJunitReportIfMoved(Path currentPath) throws IOException {
+    private void deleteDefaultJunitReportIfMoved(Path currentPath, Path otherCurrentPath) throws IOException {
         Path defaultPath = defaultJunitReportPath();
-        if (!sameReportTarget(defaultPath, currentPath)) {
+        if (!isCurrentPath(defaultPath, currentPath) && !isCurrentPath(defaultPath, otherCurrentPath)) {
             Files.deleteIfExists(defaultPath);
         }
+    }
+
+    private void deleteDefaultJunitReportIfDisabled(Path currentOutputPath) throws IOException {
+        Path defaultPath = defaultJunitReportPath();
+        if (!isCurrentPath(defaultPath, currentOutputPath)) {
+            Files.deleteIfExists(defaultPath);
+        }
+    }
+
+    private boolean isCurrentPath(Path path, Path currentPath) throws IOException {
+        return currentPath != null && sameReportTarget(path, currentPath);
     }
 
     private Path defaultJunitReportPath() {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -33,13 +33,18 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private final Provider<RegularFile> defaultJunitReport;
     private final RegularFile junitReportState;
+    private final RegularFile outputState;
+    private final Provider<String> absentString;
 
     public CrapJavaCheckTask() {
+        absentString = getProject().getProviders().provider(() -> (String) null);
         defaultJunitReport = getProject().getProviders()
                 .provider(this::defaultJunitReportRelativePath)
                 .flatMap(path -> getProject().getLayout().getBuildDirectory().file(path));
         junitReportState = getProject().getLayout().getProjectDirectory()
                 .file(".gradle/crap-java/" + getName() + "/junit-report.path");
+        outputState = getProject().getLayout().getProjectDirectory()
+                .file(".gradle/crap-java/" + getName() + "/primary-output.path");
         getThreshold().convention(Main.DEFAULT_THRESHOLD);
         getAgent().convention(false);
         getFormat().convention(getAgent().map(agent -> agent ? "toon" : "none"));
@@ -89,6 +94,14 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     @Internal
     public abstract RegularFileProperty getJunitReport();
 
+    @Input
+    @Optional
+    public Provider<String> getDisabledJunitReportPathInput() {
+        return getJunit().flatMap(enabled -> enabled
+                ? absentString
+                : getJunitReport().map(file -> file.getAsFile().toPath().toAbsolutePath().normalize().toString()));
+    }
+
     @OutputFile
     @Optional
     public Provider<RegularFile> getJunitReportOutput() {
@@ -107,6 +120,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         Path analysisRoot = getAnalysisRoot().get().getAsFile().toPath().toAbsolutePath().normalize();
         Path configuredOutputPath = outputPath();
         Path configuredJunitReportPath = junitReportPath();
+        deleteMovedOutput(configuredOutputPath);
         deleteMovedJunitReport(configuredJunitReportPath);
         if (sourceFiles.isEmpty()) {
             try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
@@ -123,6 +137,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                         configuredJunitReportPath,
                         getThreshold().get()
                 );
+                rememberOutputPath(configuredOutputPath);
                 rememberJunitReportPath(configuredJunitReportPath);
             }
             return;
@@ -142,10 +157,30 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                     configuredJunitReportPath,
                     getThreshold().get()
             );
+            rememberOutputPath(configuredOutputPath);
             rememberJunitReportPath(configuredJunitReportPath);
             if (exit != 0) {
                 throw new GradleException("crap-java-check failed with exit " + exit);
             }
+        }
+    }
+
+    private void deleteMovedOutput(Path currentPath) throws Exception {
+        Path rememberedPath = rememberedOutputPath();
+        deleteRememberedOutputIfMoved(rememberedPath, currentPath);
+        deleteOutputStateIfUnset(currentPath);
+    }
+
+    private void deleteRememberedOutputIfMoved(Path rememberedPath, Path currentPath) throws Exception {
+        if (rememberedPath == null || rememberedPath.equals(currentPath)) {
+            return;
+        }
+        Files.deleteIfExists(rememberedPath);
+    }
+
+    private void deleteOutputStateIfUnset(Path currentPath) throws Exception {
+        if (currentPath == null) {
+            Files.deleteIfExists(outputStatePath());
         }
     }
 
@@ -209,6 +244,35 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return "reports/crap-java/TEST-crap-java.xml";
         }
         return "reports/crap-java/" + getName() + "/TEST-crap-java.xml";
+    }
+
+    private void rememberOutputPath(Path path) throws Exception {
+        if (path == null) {
+            Files.deleteIfExists(outputStatePath());
+            return;
+        }
+        Path statePath = outputStatePath();
+        Files.createDirectories(statePath.getParent());
+        Files.writeString(statePath, path.toString());
+    }
+
+    private Path rememberedOutputPath() throws Exception {
+        Path statePath = outputStatePath();
+        if (!Files.isRegularFile(statePath)) {
+            return null;
+        }
+        String value = Files.readString(statePath).trim();
+        if (value.isBlank()) {
+            return null;
+        }
+        return Path.of(value).toAbsolutePath().normalize();
+    }
+
+    private Path outputStatePath() {
+        return outputState.getAsFile()
+                .toPath()
+                .toAbsolutePath()
+                .normalize();
     }
 
     private void rememberJunitReportPath(Path path) throws Exception {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -36,9 +36,11 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     private final RegularFile junitReportState;
     private final RegularFile outputState;
     private final Provider<String> absentString;
+    private final Provider<RegularFile> absentRegularFile;
 
     public CrapJavaCheckTask() {
         absentString = getProject().getProviders().provider(() -> (String) null);
+        absentRegularFile = getProject().getProviders().provider(() -> (RegularFile) null);
         defaultJunitReport = getProject().getProviders()
                 .provider(this::defaultJunitReportRelativePath)
                 .flatMap(path -> getProject().getLayout().getBuildDirectory().file(path));
@@ -110,7 +112,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     public Provider<RegularFile> getJunitReportOutput() {
         return getJunit().flatMap(enabled -> enabled
                 ? getJunitReport()
-                : getProject().getProviders().provider(() -> (RegularFile) null));
+                : absentRegularFile);
     }
 
     @OutputFile

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -390,12 +390,21 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             ReportSnapshot outputBefore,
             ReportSnapshot junitBefore
     ) throws Exception {
-        if (reportChanged(currentOutputPath, outputBefore)) {
+        if (shouldRememberChangedReport(currentOutputPath, outputBefore, rememberedOutputPath())) {
             rememberOutputPath(currentOutputPath);
         }
-        if (reportChanged(currentJunitReportPath, junitBefore)) {
+        if (shouldRememberChangedReport(currentJunitReportPath, junitBefore, rememberedJunitReportPath())) {
             rememberJunitReportPath(currentJunitReportPath);
         }
+    }
+
+    private boolean shouldRememberChangedReport(
+            Path reportPath,
+            ReportSnapshot before,
+            RememberedReport rememberedReport
+    ) throws IOException {
+        return reportChanged(reportPath, before)
+                && (rememberedReport == null || isCurrentRememberedPath(rememberedReport, reportPath));
     }
 
     private boolean reportChanged(Path reportPath, ReportSnapshot before) throws IOException {
@@ -517,7 +526,27 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         return rememberedReport.ownership().startsWith(LINK_OWNERSHIP + "\t")
                 && Files.exists(rememberedReport.ownerLink())
                 && Files.isSameFile(rememberedReport.path(), rememberedReport.ownerLink())
+                && !hasOtherOwnerLink(rememberedReport)
                 && rememberedReport.ownership().equals(ownership(rememberedReport.path()));
+    }
+
+    private boolean hasOtherOwnerLink(RememberedReport rememberedReport) throws IOException {
+        Path stateRoot = projectCacheRoot(getProject()).resolve("crap-java");
+        if (!Files.isDirectory(stateRoot)) {
+            return false;
+        }
+        try (Stream<Path> paths = Files.walk(stateRoot)) {
+            for (Path path : paths.filter(this::isOwnerLink).toList()) {
+                if (!path.equals(rememberedReport.ownerLink()) && sameExistingFile(path, rememberedReport.path())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isOwnerLink(Path path) {
+        return path.getFileName() != null && path.getFileName().toString().endsWith(".owner");
     }
 
     private String defaultJunitReportRelativePath() {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -28,6 +29,7 @@ import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public abstract class CrapJavaCheckTask extends DefaultTask {
 
@@ -193,16 +195,32 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (reportPath == null) {
             return;
         }
-        for (Path internalPath : internalStatePaths()) {
-            if (reportPath.equals(internalPath)) {
-                throw new GradleException(propertyName + " must not point to a crap-java internal task file: "
-                        + reportPath);
-            }
+        if (isInternalTaskFile(reportPath)) {
+            throw new GradleException(propertyName + " must not point to a crap-java internal task file: "
+                    + reportPath);
         }
     }
 
-    private List<Path> internalStatePaths() {
-        return List.of(executionMarkerPath(), outputStatePath(), junitReportStatePath());
+    private boolean isInternalTaskFile(Path reportPath) {
+        return isExecutionMarkerPath(reportPath) || isRememberedPathStateFile(reportPath);
+    }
+
+    private boolean isExecutionMarkerPath(Path reportPath) {
+        return reportPath.startsWith(executionMarkerPath().getParent().getParent())
+                && "execution.marker".equals(reportPath.getFileName().toString());
+    }
+
+    private boolean isRememberedPathStateFile(Path reportPath) {
+        return reportPath.startsWith(rememberedStateRoot()) && hasRememberedStateFileName(reportPath);
+    }
+
+    private Path rememberedStateRoot() {
+        return outputStatePath().getParent().getParent();
+    }
+
+    private boolean hasRememberedStateFileName(Path reportPath) {
+        String fileName = reportPath.getFileName().toString();
+        return "primary-output.path".equals(fileName) || "junit-report.path".equals(fileName);
     }
 
     private void cleanupStaleReports(Path currentOutputPath, Path currentJunitReportPath) throws Exception {
@@ -286,7 +304,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (!Files.isRegularFile(rememberedReport.path())) {
             return false;
         }
-        return rememberedReport.fingerprint().equals(fileFingerprint(rememberedReport.path()));
+        return rememberedReport.fingerprint().equals(ownershipFingerprint(rememberedReport.path()));
     }
 
     private String defaultJunitReportRelativePath() {
@@ -324,7 +342,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private void rememberReportPath(Path statePath, Path reportPath) throws Exception {
         Files.createDirectories(statePath.getParent());
-        Files.writeString(statePath, reportPath + "\n" + fileFingerprint(reportPath) + "\n");
+        Files.writeString(statePath, reportPath + "\n" + ownershipFingerprint(reportPath) + "\n");
     }
 
     private RememberedReport rememberedJunitReportPath() throws Exception {
@@ -342,14 +360,30 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (!hasRememberedReport(lines)) {
             return null;
         }
-        return new RememberedReport(Path.of(lines.get(0).trim()).toAbsolutePath().normalize(), lines.get(1).trim());
+        return new RememberedReport(Path.of(lines.get(0).trim()).toAbsolutePath().normalize(), lines.get(1));
     }
 
     private boolean hasRememberedReport(List<String> lines) {
         return lines.size() >= 2 && !lines.get(0).isBlank() && !lines.get(1).isBlank();
     }
 
-    private String fileFingerprint(Path path) throws Exception {
+    private String ownershipFingerprint(Path path) throws Exception {
+        BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
+        return fileKey(attributes) + "\t"
+                + attributes.lastModifiedTime().to(TimeUnit.NANOSECONDS) + "\t"
+                + attributes.size() + "\t"
+                + contentHash(path);
+    }
+
+    private String fileKey(BasicFileAttributes attributes) {
+        Object fileKey = attributes.fileKey();
+        if (fileKey == null) {
+            return "";
+        }
+        return fileKey.toString().replace('\n', ' ').replace('\r', ' ').replace('\t', ' ');
+    }
+
+    private String contentHash(Path path) throws Exception {
         byte[] digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path));
         return HexFormat.of().formatHex(digest);
     }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -202,29 +202,32 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         ReportSnapshot junitBefore = reportSnapshot(configuredJunitReportPath);
         try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
              var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
-            int exit = Main.runWithExistingCoverage(
-                    modules,
-                    analysisRoot,
-                    out,
-                    err,
-                    getFormat().get(),
-                    getFailuresOnly().get(),
-                    getOmitRedundancy().get(),
-                    configuredOutputPath,
-                    configuredJunitReportPath,
-                    getThreshold().get()
-            );
+            int exit;
+            try {
+                exit = Main.runWithExistingCoverage(
+                        modules,
+                        analysisRoot,
+                        out,
+                        err,
+                        getFormat().get(),
+                        getFailuresOnly().get(),
+                        getOmitRedundancy().get(),
+                        configuredOutputPath,
+                        configuredJunitReportPath,
+                        getThreshold().get()
+                );
+            } catch (Exception exception) {
+                rememberChangedReportState(
+                        configuredOutputPath,
+                        configuredJunitReportPath,
+                        outputBefore,
+                        junitBefore
+                );
+                throw exception;
+            }
             cleanupStaleReports(configuredOutputPath, configuredJunitReportPath);
             rememberReportState(configuredOutputPath, configuredJunitReportPath);
             return exit;
-        } catch (Exception exception) {
-            rememberChangedReportState(
-                    configuredOutputPath,
-                    configuredJunitReportPath,
-                    outputBefore,
-                    junitBefore
-            );
-            throw exception;
         }
     }
 
@@ -649,10 +652,6 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         return "reports/crap-java/" + getName() + "/TEST-crap-java.xml";
     }
 
-    private Path defaultJunitReportPath() {
-        return defaultJunitReport.get().getAsFile().toPath().toAbsolutePath().normalize();
-    }
-
     private void rememberOutputPath(Path path) throws Exception {
         if (path == null) {
             Files.deleteIfExists(outputStatePath());
@@ -756,16 +755,20 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private Path parseRememberedReportPath(String line) {
-        if (line.startsWith(ENCODED_PATH_PREFIX)) {
-            return decodeRememberedReportPath(line.substring(ENCODED_PATH_PREFIX.length()));
+        try {
+            String path = line.startsWith(ENCODED_PATH_PREFIX)
+                    ? decodeRememberedReportPath(line.substring(ENCODED_PATH_PREFIX.length()))
+                    : line;
+            return path == null ? null : Path.of(path).toAbsolutePath().normalize();
+        } catch (IllegalArgumentException | SecurityException exception) {
+            return null;
         }
-        return Path.of(line).toAbsolutePath().normalize();
     }
 
-    private Path decodeRememberedReportPath(String encoded) {
+    private String decodeRememberedReportPath(String encoded) {
         try {
             byte[] decoded = Base64.getDecoder().decode(encoded);
-            return Path.of(new String(decoded, StandardCharsets.UTF_8)).toAbsolutePath().normalize();
+            return new String(decoded, StandardCharsets.UTF_8);
         } catch (IllegalArgumentException exception) {
             return null;
         }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -573,7 +573,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (projectCacheDir != null) {
             return projectCacheDir.toPath().toAbsolutePath().normalize();
         }
-        return project.getProjectDir().toPath().resolve(".gradle").toAbsolutePath().normalize();
+        return project.getRootProject().getProjectDir().toPath().resolve(".gradle").toAbsolutePath().normalize();
     }
 
     private String projectStateName(Project project) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,8 +37,8 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private final Provider<RegularFile> defaultJunitReport;
     private final Provider<RegularFile> executionMarker;
-    private final RegularFile junitReportState;
-    private final RegularFile outputState;
+    private final RegularFileProperty junitReportState;
+    private final RegularFileProperty outputState;
     private final Provider<String> absentString;
     private final Provider<RegularFile> absentRegularFile;
 
@@ -49,10 +50,10 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .flatMap(path -> getProject().getLayout().getBuildDirectory().file(path));
         executionMarker = getProject().getLayout().getBuildDirectory()
                 .file("tmp/crap-java/" + getName() + "/execution.marker");
-        junitReportState = getProject().getLayout().getProjectDirectory()
-                .file(".gradle/crap-java/" + getName() + "/junit-report.path");
-        outputState = getProject().getLayout().getProjectDirectory()
-                .file(".gradle/crap-java/" + getName() + "/primary-output.path");
+        junitReportState = getProject().getObjects().fileProperty();
+        junitReportState.fileValue(localStateFile("junit-report.path"));
+        outputState = getProject().getObjects().fileProperty();
+        outputState.fileValue(localStateFile("primary-output.path"));
         getThreshold().convention(Main.DEFAULT_THRESHOLD);
         getAgent().convention(false);
         getFormat().convention(getAgent().map(agent -> agent ? "toon" : "none"));
@@ -206,16 +207,16 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private boolean isExecutionMarkerPath(Path reportPath) {
-        return reportPath.startsWith(executionMarkerPath().getParent().getParent())
-                && "execution.marker".equals(reportPath.getFileName().toString());
+        return "execution.marker".equals(reportPath.getFileName().toString())
+                && normalizedPath(reportPath).contains("/tmp/crap-java/");
     }
 
     private boolean isRememberedPathStateFile(Path reportPath) {
-        return reportPath.startsWith(rememberedStateRoot()) && hasRememberedStateFileName(reportPath);
+        return hasRememberedStateFileName(reportPath) && normalizedPath(reportPath).contains("/crap-java/");
     }
 
-    private Path rememberedStateRoot() {
-        return outputStatePath().getParent().getParent();
+    private String normalizedPath(Path path) {
+        return path.normalize().toString().replace('\\', '/');
     }
 
     private boolean hasRememberedStateFileName(Path reportPath) {
@@ -330,7 +331,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private Path outputStatePath() {
-        return outputState.getAsFile()
+        return outputState.get().getAsFile()
                 .toPath()
                 .toAbsolutePath()
                 .normalize();
@@ -411,10 +412,35 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private Path junitReportStatePath() {
-        return junitReportState.getAsFile()
+        return junitReportState.get().getAsFile()
                 .toPath()
                 .toAbsolutePath()
                 .normalize();
+    }
+
+    private File localStateFile(String fileName) {
+        return projectCacheRoot()
+                .resolve("crap-java")
+                .resolve(projectStateName())
+                .resolve(getName())
+                .resolve(fileName)
+                .toFile();
+    }
+
+    private Path projectCacheRoot() {
+        File projectCacheDir = getProject().getGradle().getStartParameter().getProjectCacheDir();
+        if (projectCacheDir != null) {
+            return projectCacheDir.toPath().toAbsolutePath().normalize();
+        }
+        return getProject().getProjectDir().toPath().resolve(".gradle").toAbsolutePath().normalize();
+    }
+
+    private String projectStateName() {
+        String projectPath = getProject().getPath();
+        if (":".equals(projectPath)) {
+            return "root";
+        }
+        return projectPath.substring(1).replace(':', '-');
     }
 
     private record RememberedReport(Path path, String ownership, Path ownerLink) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -3,6 +3,7 @@ package media.barney.crap.gradle;
 import media.barney.crap.core.Main;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
@@ -21,8 +22,11 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -149,9 +153,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                         configuredJunitReportPath,
                         getThreshold().get()
                 );
-                cleanupStaleReports(configuredOutputPath, configuredJunitReportPath);
-                rememberOutputPath(configuredOutputPath);
-                rememberJunitReportPath(configuredJunitReportPath);
+                updateReportState(configuredOutputPath, configuredJunitReportPath);
                 if (exit != 0) {
                     throw new GradleException("crap-java-check failed with exit " + exit);
                 }
@@ -174,9 +176,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                     configuredJunitReportPath,
                     getThreshold().get()
             );
-            cleanupStaleReports(configuredOutputPath, configuredJunitReportPath);
-            rememberOutputPath(configuredOutputPath);
-            rememberJunitReportPath(configuredJunitReportPath);
+            updateReportState(configuredOutputPath, configuredJunitReportPath);
             if (exit != 0) {
                 throw new GradleException("crap-java-check failed with exit " + exit);
             }
@@ -208,15 +208,25 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private boolean isExecutionMarkerPath(Path reportPath) {
         return "execution.marker".equals(reportPath.getFileName().toString())
-                && normalizedPath(reportPath).contains("/tmp/crap-java/");
+                && internalExecutionMarkerRoots().stream().anyMatch(reportPath::startsWith);
     }
 
     private boolean isRememberedPathStateFile(Path reportPath) {
-        return hasRememberedStateFileName(reportPath) && normalizedPath(reportPath).contains("/crap-java/");
+        return hasRememberedStateFileName(reportPath)
+                && internalRememberedStateRoots().stream().anyMatch(reportPath::startsWith);
     }
 
-    private String normalizedPath(Path path) {
-        return path.normalize().toString().replace('\\', '/');
+    private List<Path> internalExecutionMarkerRoots() {
+        return getProject().getRootProject().getAllprojects().stream()
+                .map(project -> project.getLayout().getBuildDirectory().dir("tmp/crap-java").get())
+                .map(directory -> directory.getAsFile().toPath().toAbsolutePath().normalize())
+                .toList();
+    }
+
+    private List<Path> internalRememberedStateRoots() {
+        return getProject().getRootProject().getAllprojects().stream()
+                .map(project -> projectCacheRoot(project).resolve("crap-java").resolve(projectStateName(project)))
+                .toList();
     }
 
     private boolean hasRememberedStateFileName(Path reportPath) {
@@ -231,6 +241,21 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         deleteMovedOutput(currentOutputPath);
         deleteMovedJunitReport(currentJunitReportPath);
         deleteDisabledJunitReport();
+    }
+
+    private void updateReportState(Path currentOutputPath, Path currentJunitReportPath) throws Exception {
+        Path lockPath = stateLockPath();
+        Files.createDirectories(lockPath.getParent());
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            cleanupStaleReports(currentOutputPath, currentJunitReportPath);
+            rememberOutputPath(currentOutputPath);
+            rememberJunitReportPath(currentJunitReportPath);
+        }
+    }
+
+    private Path stateLockPath() {
+        return outputStatePath().resolveSibling("state.lock");
     }
 
     private void writeExecutionMarker() throws Exception {
@@ -443,24 +468,24 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private File localStateFile(String fileName) {
-        return projectCacheRoot()
+        return projectCacheRoot(getProject())
                 .resolve("crap-java")
-                .resolve(projectStateName())
+                .resolve(projectStateName(getProject()))
                 .resolve(getName())
                 .resolve(fileName)
                 .toFile();
     }
 
-    private Path projectCacheRoot() {
-        File projectCacheDir = getProject().getGradle().getStartParameter().getProjectCacheDir();
+    private Path projectCacheRoot(Project project) {
+        File projectCacheDir = project.getGradle().getStartParameter().getProjectCacheDir();
         if (projectCacheDir != null) {
             return projectCacheDir.toPath().toAbsolutePath().normalize();
         }
-        return getProject().getProjectDir().toPath().resolve(".gradle").toAbsolutePath().normalize();
+        return project.getProjectDir().toPath().resolve(".gradle").toAbsolutePath().normalize();
     }
 
-    private String projectStateName() {
-        String projectPath = getProject().getPath();
+    private String projectStateName(Project project) {
+        String projectPath = project.getPath();
         if (":".equals(projectPath)) {
             return "root";
         }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -27,6 +28,17 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class CrapJavaCheckTask extends DefaultTask {
+
+    public CrapJavaCheckTask() {
+        getThreshold().convention(Main.DEFAULT_THRESHOLD);
+        getAgent().convention(false);
+        getFormat().convention(getAgent().map(agent -> agent ? "toon" : "none"));
+        getFailuresOnly().convention(getAgent());
+        getOmitRedundancy().convention(getAgent());
+        getJunit().convention(true);
+        getJunitReport().convention(getProject().getLayout().getBuildDirectory()
+                .file("reports/crap-java/TEST-crap-java.xml"));
+    }
 
     @Internal
     public abstract DirectoryProperty getAnalysisRoot();
@@ -78,6 +90,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     @TaskAction
     void runCheck() throws Exception {
+        deleteDisabledJunitReport();
         List<Path> sourceFiles = getAnalysisSources().getFiles().stream()
                 .map(file -> file.toPath().toAbsolutePath().normalize())
                 .sorted()
@@ -134,6 +147,13 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return null;
         }
         return getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize();
+    }
+
+    private void deleteDisabledJunitReport() throws Exception {
+        if (getJunit().get() || !getJunitReport().isPresent()) {
+            return;
+        }
+        Files.deleteIfExists(getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize());
     }
 
     private List<Main.ResolvedCoverageModule> resolvedModules(List<Path> sourceFiles) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -141,30 +141,47 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         Path configuredOutputPath = outputPath();
         Path configuredJunitReportPath = junitReportPath();
         validateReportPaths(configuredOutputPath, configuredJunitReportPath);
-        if (sourceFiles.isEmpty()) {
-            try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
-                 var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
-                int exit = Main.runWithExistingCoverage(
-                        List.of(),
-                        analysisRoot,
-                        out,
-                        err,
-                        getFormat().get(),
-                        getFailuresOnly().get(),
-                        getOmitRedundancy().get(),
-                        configuredOutputPath,
-                        configuredJunitReportPath,
-                        getThreshold().get()
-                );
-                updateReportState(configuredOutputPath, configuredJunitReportPath);
-                if (exit != 0) {
-                    throw new GradleException("crap-java-check failed with exit " + exit);
-                }
-                writeExecutionMarker();
-            }
-            return;
+        List<Main.ResolvedCoverageModule> modules = sourceFiles.isEmpty() ? List.of() : resolvedModules(sourceFiles);
+        int exit = runWithReportStateLock(
+                modules,
+                analysisRoot,
+                configuredOutputPath,
+                configuredJunitReportPath
+        );
+        if (exit != 0) {
+            throw new GradleException("crap-java-check failed with exit " + exit);
         }
-        List<Main.ResolvedCoverageModule> modules = resolvedModules(sourceFiles);
+        writeExecutionMarker();
+    }
+
+    private int runWithReportStateLock(
+            List<Main.ResolvedCoverageModule> modules,
+            Path analysisRoot,
+            Path configuredOutputPath,
+            Path configuredJunitReportPath
+    ) throws Exception {
+        Path lockPath = stateLockPath();
+        Files.createDirectories(lockPath.getParent());
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            cleanupStaleReports(configuredOutputPath, configuredJunitReportPath);
+            return runAndRememberReports(
+                    modules,
+                    analysisRoot,
+                    configuredOutputPath,
+                    configuredJunitReportPath
+            );
+        }
+    }
+
+    private int runAndRememberReports(
+            List<Main.ResolvedCoverageModule> modules,
+            Path analysisRoot,
+            Path configuredOutputPath,
+            Path configuredJunitReportPath
+    ) throws Exception {
+        ReportSnapshot outputBefore = reportSnapshot(configuredOutputPath);
+        ReportSnapshot junitBefore = reportSnapshot(configuredJunitReportPath);
         try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
              var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
             int exit = Main.runWithExistingCoverage(
@@ -179,11 +196,16 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                     configuredJunitReportPath,
                     getThreshold().get()
             );
-            updateReportState(configuredOutputPath, configuredJunitReportPath);
-            if (exit != 0) {
-                throw new GradleException("crap-java-check failed with exit " + exit);
-            }
-            writeExecutionMarker();
+            rememberReportState(configuredOutputPath, configuredJunitReportPath);
+            return exit;
+        } catch (Exception exception) {
+            rememberChangedReportState(
+                    configuredOutputPath,
+                    configuredJunitReportPath,
+                    outputBefore,
+                    junitBefore
+            );
+            throw exception;
         }
     }
 
@@ -335,15 +357,39 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         deleteDisabledJunitReport(currentOutputPath);
     }
 
-    private void updateReportState(Path currentOutputPath, Path currentJunitReportPath) throws Exception {
-        Path lockPath = stateLockPath();
-        Files.createDirectories(lockPath.getParent());
-        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-             FileLock ignored = channel.lock()) {
-            cleanupStaleReports(currentOutputPath, currentJunitReportPath);
+    private void rememberReportState(Path currentOutputPath, Path currentJunitReportPath) throws Exception {
+        rememberOutputPath(currentOutputPath);
+        rememberJunitReportPath(currentJunitReportPath);
+    }
+
+    private void rememberChangedReportState(
+            Path currentOutputPath,
+            Path currentJunitReportPath,
+            ReportSnapshot outputBefore,
+            ReportSnapshot junitBefore
+    ) throws Exception {
+        if (reportChanged(currentOutputPath, outputBefore)) {
             rememberOutputPath(currentOutputPath);
+        }
+        if (reportChanged(currentJunitReportPath, junitBefore)) {
             rememberJunitReportPath(currentJunitReportPath);
         }
+    }
+
+    private boolean reportChanged(Path reportPath, ReportSnapshot before) throws IOException {
+        return reportPath != null && !reportSnapshot(reportPath).equals(before);
+    }
+
+    private ReportSnapshot reportSnapshot(Path reportPath) throws IOException {
+        if (reportPath == null || !Files.isRegularFile(reportPath)) {
+            return ReportSnapshot.missing();
+        }
+        BasicFileAttributes attributes = Files.readAttributes(reportPath, BasicFileAttributes.class);
+        return new ReportSnapshot(
+                true,
+                attributes.lastModifiedTime().to(TimeUnit.NANOSECONDS),
+                attributes.size()
+        );
     }
 
     private Path stateLockPath() {
@@ -625,6 +671,13 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private record RememberedReport(Path path, String ownership, Path ownerLink) {
+    }
+
+    private record ReportSnapshot(boolean exists, long modifiedNanos, long size) {
+
+        private static ReportSnapshot missing() {
+            return new ReportSnapshot(false, 0, 0);
+        }
     }
 
     private List<Main.ResolvedCoverageModule> resolvedModules(List<Path> sourceFiles) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -362,8 +362,18 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private Path realPathForComparison(Path path) {
+        return realPathForComparison(path, 0);
+    }
+
+    private Path realPathForComparison(Path path, int symlinkDepth) {
+        if (symlinkDepth > 8) {
+            return null;
+        }
         Path normalized = path.toAbsolutePath().normalize();
         try {
+            if (Files.isSymbolicLink(normalized)) {
+                return symbolicLinkTargetForComparison(normalized, symlinkDepth);
+            }
             if (Files.exists(normalized)) {
                 return normalized.toRealPath();
             }
@@ -375,6 +385,12 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return null;
         }
         return null;
+    }
+
+    private Path symbolicLinkTargetForComparison(Path link, int symlinkDepth) throws IOException {
+        Path target = Files.readSymbolicLink(link);
+        Path resolved = link.resolveSibling(target);
+        return realPathForComparison(resolved, symlinkDepth + 1);
     }
 
     private Path nearestExistingPath(Path path) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -19,20 +19,20 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public abstract class CrapJavaCheckTask extends DefaultTask {
+
+    private static final String LINK_OWNERSHIP = "link";
 
     private final Provider<RegularFile> defaultJunitReport;
     private final Provider<RegularFile> executionMarker;
@@ -254,7 +254,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private void deleteOutputStateIfUnset(Path currentPath) throws Exception {
         if (currentPath == null) {
-            Files.deleteIfExists(outputStatePath());
+            deleteReportState(outputStatePath());
         }
     }
 
@@ -287,7 +287,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return;
         }
         deleteRememberedReport(rememberedJunitReportPath());
-        Files.deleteIfExists(junitReportStatePath());
+        deleteReportState(junitReportStatePath());
     }
 
     private void deleteRememberedReport(RememberedReport rememberedReport) throws Exception {
@@ -304,7 +304,10 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (!Files.isRegularFile(rememberedReport.path())) {
             return false;
         }
-        return rememberedReport.fingerprint().equals(ownershipFingerprint(rememberedReport.path()));
+        return rememberedReport.ownership().startsWith(LINK_OWNERSHIP + "\t")
+                && Files.exists(rememberedReport.ownerLink())
+                && Files.isSameFile(rememberedReport.path(), rememberedReport.ownerLink())
+                && rememberedReport.ownership().equals(ownership(rememberedReport.path()));
     }
 
     private String defaultJunitReportRelativePath() {
@@ -342,7 +345,43 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private void rememberReportPath(Path statePath, Path reportPath) throws Exception {
         Files.createDirectories(statePath.getParent());
-        Files.writeString(statePath, reportPath + "\n" + ownershipFingerprint(reportPath) + "\n");
+        Path ownerLink = ownerLinkPath(statePath);
+        Files.deleteIfExists(ownerLink);
+        String ownership = ownership(reportPath, ownerLink);
+        if (ownership.isBlank()) {
+            Files.deleteIfExists(statePath);
+            return;
+        }
+        Files.writeString(statePath, reportPath + "\n" + ownership + "\n");
+    }
+
+    private String ownership(Path reportPath, Path ownerLink) throws Exception {
+        try {
+            Files.createLink(ownerLink, reportPath);
+            return ownership(reportPath);
+        } catch (IOException | SecurityException | UnsupportedOperationException exception) {
+            return "";
+        }
+    }
+
+    private String ownership(Path reportPath) throws Exception {
+        BasicFileAttributes attributes = Files.readAttributes(reportPath, BasicFileAttributes.class);
+        return LINK_OWNERSHIP + "\t"
+                + attributes.lastModifiedTime().to(TimeUnit.NANOSECONDS) + "\t"
+                + attributes.size();
+    }
+
+    private void deleteReportState(Path statePath) throws Exception {
+        Files.deleteIfExists(ownerLinkPath(statePath));
+        Files.deleteIfExists(statePath);
+    }
+
+    private Path ownerLinkPath(Path statePath) {
+        String fileName = statePath.getFileName().toString();
+        String ownerFileName = fileName.endsWith(".path")
+                ? fileName.substring(0, fileName.length() - ".path".length()) + ".owner"
+                : fileName + ".owner";
+        return statePath.resolveSibling(ownerFileName);
     }
 
     private RememberedReport rememberedJunitReportPath() throws Exception {
@@ -353,45 +392,22 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (!Files.isRegularFile(statePath)) {
             return null;
         }
-        return parseRememberedReport(Files.readAllLines(statePath));
+        return parseRememberedReport(statePath, Files.readAllLines(statePath));
     }
 
-    private RememberedReport parseRememberedReport(List<String> lines) {
+    private RememberedReport parseRememberedReport(Path statePath, List<String> lines) {
         if (!hasRememberedReport(lines)) {
             return null;
         }
-        return new RememberedReport(Path.of(lines.get(0).trim()).toAbsolutePath().normalize(), lines.get(1));
+        return new RememberedReport(
+                Path.of(lines.get(0).trim()).toAbsolutePath().normalize(),
+                lines.get(1),
+                ownerLinkPath(statePath)
+        );
     }
 
     private boolean hasRememberedReport(List<String> lines) {
         return lines.size() >= 2 && !lines.get(0).isBlank() && !lines.get(1).isBlank();
-    }
-
-    private String ownershipFingerprint(Path path) throws Exception {
-        BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
-        return fileKey(attributes) + "\t"
-                + attributes.lastModifiedTime().to(TimeUnit.NANOSECONDS) + "\t"
-                + attributes.size() + "\t"
-                + contentHash(path);
-    }
-
-    private String fileKey(BasicFileAttributes attributes) {
-        Object fileKey = attributes.fileKey();
-        if (fileKey == null) {
-            return "";
-        }
-        return fileKey.toString().replace('\n', ' ').replace('\r', ' ').replace('\t', ' ');
-    }
-
-    private String contentHash(Path path) throws Exception {
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        try (DigestInputStream input = new DigestInputStream(Files.newInputStream(path), digest)) {
-            byte[] buffer = new byte[8192];
-            while (input.read(buffer) != -1) {
-                // Read the full stream so DigestInputStream can update the digest.
-            }
-        }
-        return HexFormat.of().formatHex(digest.digest());
     }
 
     private Path junitReportStatePath() {
@@ -401,7 +417,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .normalize();
     }
 
-    private record RememberedReport(Path path, String fingerprint) {
+    private record RememberedReport(Path path, String ownership, Path ownerLink) {
     }
 
     private List<Main.ResolvedCoverageModule> resolvedModules(List<Path> sourceFiles) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -696,7 +696,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return null;
         }
         return new RememberedReport(
-                Path.of(lines.get(0).trim()).toAbsolutePath().normalize(),
+                Path.of(lines.get(0)).toAbsolutePath().normalize(),
                 lines.get(1),
                 ownerLinkPath(statePath)
         );
@@ -742,7 +742,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (":".equals(projectPath)) {
             return "root";
         }
-        return projectPath.substring(1)
+        return projectPath
                 .replace("%", "%25")
                 .replace(":", "%3A");
     }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -22,6 +22,7 @@ import org.gradle.api.tasks.TaskAction;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -124,7 +125,6 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     @TaskAction
     void runCheck() throws Exception {
-        deleteDisabledJunitReport();
         List<Path> sourceFiles = getAnalysisSources().getFiles().stream()
                 .map(file -> file.toPath().toAbsolutePath().normalize())
                 .sorted()
@@ -384,8 +384,14 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private String contentHash(Path path) throws Exception {
-        byte[] digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path));
-        return HexFormat.of().formatHex(digest);
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (DigestInputStream input = new DigestInputStream(Files.newInputStream(path), digest)) {
+            byte[] buffer = new byte[8192];
+            while (input.read(buffer) != -1) {
+                // Read the full stream so DigestInputStream can update the digest.
+            }
+        }
+        return HexFormat.of().formatHex(digest.digest());
     }
 
     private Path junitReportStatePath() {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -208,12 +208,14 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private boolean isExecutionMarkerPath(Path reportPath) {
         return "execution.marker".equals(reportPath.getFileName().toString())
-                && internalExecutionMarkerRoots().stream().anyMatch(reportPath::startsWith);
+                && internalExecutionMarkerRoots().stream()
+                .anyMatch(internalRoot -> isUnderInternalRoot(reportPath, internalRoot));
     }
 
     private boolean isRememberedPathStateFile(Path reportPath) {
         return hasRememberedStateFileName(reportPath)
-                && internalRememberedStateRoots().stream().anyMatch(reportPath::startsWith);
+                && internalRememberedStateRoots().stream()
+                .anyMatch(internalRoot -> isUnderInternalRoot(reportPath, internalRoot));
     }
 
     private List<Path> internalExecutionMarkerRoots() {
@@ -236,6 +238,43 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 || "primary-output.owner".equals(fileName)
                 || "junit-report.owner".equals(fileName)
                 || "state.lock".equals(fileName);
+    }
+
+    private boolean isUnderInternalRoot(Path reportPath, Path internalRoot) {
+        return reportPath.startsWith(internalRoot) || realPathStartsWith(reportPath, internalRoot);
+    }
+
+    private boolean realPathStartsWith(Path reportPath, Path internalRoot) {
+        Path realReportPath = realPathForComparison(reportPath);
+        Path realInternalRoot = realPathForComparison(internalRoot);
+        return realReportPath != null && realInternalRoot != null && realReportPath.startsWith(realInternalRoot);
+    }
+
+    private Path realPathForComparison(Path path) {
+        Path normalized = path.toAbsolutePath().normalize();
+        try {
+            if (Files.exists(normalized)) {
+                return normalized.toRealPath();
+            }
+            Path existing = nearestExistingPath(normalized);
+            if (existing != null) {
+                return existing.toRealPath().resolve(existing.relativize(normalized)).normalize();
+            }
+        } catch (IOException | SecurityException exception) {
+            return null;
+        }
+        return null;
+    }
+
+    private Path nearestExistingPath(Path path) {
+        Path current = path;
+        while (current != null) {
+            if (Files.exists(current)) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        return null;
     }
 
     private void cleanupStaleReports(Path currentOutputPath, Path currentJunitReportPath) throws Exception {
@@ -411,6 +450,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             Files.createLink(ownerLink, reportPath);
             return ownership(reportPath);
         } catch (IOException | SecurityException | UnsupportedOperationException exception) {
+            getLogger().warn(
+                    "crap-java could not remember ownership for {}; stale cleanup for that report path is disabled.",
+                    reportPath);
             return "";
         }
     }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -44,7 +44,27 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     @Input
     public abstract Property<Double> getThreshold();
 
+    @Input
+    public abstract Property<String> getFormat();
+
+    @Input
+    public abstract Property<Boolean> getAgent();
+
+    @Input
+    public abstract Property<Boolean> getFailuresOnly();
+
+    @Input
+    public abstract Property<Boolean> getOmitRedundancy();
+
     @OutputFile
+    @Optional
+    public abstract RegularFileProperty getOutput();
+
+    @Input
+    public abstract Property<Boolean> getJunit();
+
+    @OutputFile
+    @Optional
     public abstract RegularFileProperty getJunitReport();
 
     @TaskAction
@@ -54,22 +74,57 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .sorted()
                 .toList();
         Path analysisRoot = getAnalysisRoot().get().getAsFile().toPath().toAbsolutePath().normalize();
-        Path junitReport = getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize();
         if (sourceFiles.isEmpty()) {
             try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
                  var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
-                Main.runWithExistingCoverage(List.of(), analysisRoot, out, err, junitReport, getThreshold().get());
+                Main.runWithExistingCoverage(
+                        List.of(),
+                        analysisRoot,
+                        out,
+                        err,
+                        getFormat().get(),
+                        getFailuresOnly().get(),
+                        getOmitRedundancy().get(),
+                        outputPath(),
+                        junitReportPath(),
+                        getThreshold().get()
+                );
             }
             return;
         }
         List<Main.ResolvedCoverageModule> modules = resolvedModules(sourceFiles);
         try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
              var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
-            int exit = Main.runWithExistingCoverage(modules, analysisRoot, out, err, junitReport, getThreshold().get());
+            int exit = Main.runWithExistingCoverage(
+                    modules,
+                    analysisRoot,
+                    out,
+                    err,
+                    getFormat().get(),
+                    getFailuresOnly().get(),
+                    getOmitRedundancy().get(),
+                    outputPath(),
+                    junitReportPath(),
+                    getThreshold().get()
+            );
             if (exit != 0) {
                 throw new GradleException("crap-java-check failed with exit " + exit);
             }
         }
+    }
+
+    private Path outputPath() {
+        if (!getOutput().isPresent()) {
+            return null;
+        }
+        return getOutput().get().getAsFile().toPath().toAbsolutePath().normalize();
+    }
+
+    private Path junitReportPath() {
+        if (!getJunit().get()) {
+            return null;
+        }
+        return getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize();
     }
 
     private List<Main.ResolvedCoverageModule> resolvedModules(List<Path> sourceFiles) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -140,7 +140,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         Path analysisRoot = getAnalysisRoot().get().getAsFile().toPath().toAbsolutePath().normalize();
         Path configuredOutputPath = outputPath();
         Path configuredJunitReportPath = junitReportPath();
-        validateReportPaths(configuredOutputPath, configuredJunitReportPath);
+        validateReportOptions(configuredOutputPath, configuredJunitReportPath);
         List<Main.ResolvedCoverageModule> modules = sourceFiles.isEmpty() ? List.of() : resolvedModules(sourceFiles);
         int exit = runWithReportStateLock(
                 modules,
@@ -206,6 +206,28 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                     junitBefore
             );
             throw exception;
+        }
+    }
+
+    private void validateReportOptions(Path outputPath, Path junitReportPath) throws IOException {
+        validateReportFormat(getFormat().get());
+        validateThreshold(getThreshold().get());
+        validateReportPaths(outputPath, junitReportPath);
+    }
+
+    private void validateReportFormat(String format) {
+        if (format == null) {
+            throw new GradleException("Unknown report format: null");
+        }
+        switch (format.toLowerCase(Locale.ROOT)) {
+            case "toon", "json", "text", "junit", "none" -> { return; }
+            default -> throw new GradleException("Unknown report format: " + format);
+        }
+    }
+
+    private void validateThreshold(double threshold) {
+        if (!Double.isFinite(threshold) || Double.compare(threshold, 0.0) <= 0) {
+            throw new GradleException("Threshold must be a finite number greater than 0");
         }
     }
 
@@ -663,11 +685,50 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (first.equals(second)) {
             return true;
         }
-        return sameExistingFile(first, second);
+        return sameExistingFile(first, second) || sameParentAndFileName(first, second);
     }
 
     private boolean sameExistingFile(Path first, Path second) throws IOException {
         return Files.exists(first) && Files.exists(second) && Files.isSameFile(first, second);
+    }
+
+    private boolean sameParentAndFileName(Path first, Path second) throws IOException {
+        Path firstParent = first.getParent();
+        Path secondParent = second.getParent();
+        return sameParent(firstParent, secondParent) && sameFileName(first, second, firstParent);
+    }
+
+    private boolean sameParent(Path firstParent, Path secondParent) throws IOException {
+        return (firstParent == null || secondParent == null)
+                ? firstParent == secondParent
+                : sameNonNullParent(firstParent, secondParent);
+    }
+
+    private boolean sameNonNullParent(Path firstParent, Path secondParent) throws IOException {
+        return firstParent.equals(secondParent)
+                || sameAliasedParent(firstParent, secondParent);
+    }
+
+    private boolean sameAliasedParent(Path firstParent, Path secondParent) throws IOException {
+        return sameExistingFile(firstParent, secondParent)
+                || sameRealPath(firstParent, secondParent)
+                || sameCaseInsensitivePath(firstParent, secondParent);
+    }
+
+    private boolean sameRealPath(Path first, Path second) {
+        Path firstRealPath = realPathForComparison(first);
+        Path secondRealPath = realPathForComparison(second);
+        return firstRealPath != null && firstRealPath.equals(secondRealPath);
+    }
+
+    private boolean sameCaseInsensitivePath(Path first, Path second) {
+        return first.toString().equalsIgnoreCase(second.toString()) && isCaseInsensitive(first);
+    }
+
+    private boolean sameFileName(Path first, Path second, Path parent) {
+        String firstName = first.getFileName().toString();
+        String secondName = second.getFileName().toString();
+        return firstName.equals(secondName) || sameCaseInsensitiveFileName(firstName, secondName, parent);
     }
 
     private record RememberedReport(Path path, String ownership, Path ownerLink) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -38,8 +38,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         getFailuresOnly().convention(getAgent());
         getOmitRedundancy().convention(getAgent());
         getJunit().convention(true);
-        getJunitReport().convention(getProject().getLayout().getBuildDirectory()
-                .file("reports/crap-java/TEST-crap-java.xml"));
+        getJunitReport().convention(getProject().getProviders()
+                .provider(this::defaultJunitReportRelativePath)
+                .flatMap(path -> getProject().getLayout().getBuildDirectory().file(path)));
     }
 
     @Internal
@@ -177,6 +178,13 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .toPath()
                 .toAbsolutePath()
                 .normalize();
+    }
+
+    private String defaultJunitReportRelativePath() {
+        if ("crap-java-check".equals(getName())) {
+            return "reports/crap-java/TEST-crap-java.xml";
+        }
+        return "reports/crap-java/" + getName() + "/TEST-crap-java.xml";
     }
 
     private List<Main.ResolvedCoverageModule> resolvedModules(List<Path> sourceFiles) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -32,14 +32,14 @@ import java.util.Set;
 public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private final Provider<RegularFile> defaultJunitReport;
-    private final Provider<RegularFile> junitReportState;
+    private final RegularFile junitReportState;
 
     public CrapJavaCheckTask() {
         defaultJunitReport = getProject().getProviders()
                 .provider(this::defaultJunitReportRelativePath)
                 .flatMap(path -> getProject().getLayout().getBuildDirectory().file(path));
-        junitReportState = getProject().getLayout().getBuildDirectory()
-                .file("tmp/crap-java/" + getName() + "/junit-report.path");
+        junitReportState = getProject().getLayout().getProjectDirectory()
+                .file(".gradle/crap-java/" + getName() + "/junit-report.path");
         getThreshold().convention(Main.DEFAULT_THRESHOLD);
         getAgent().convention(false);
         getFormat().convention(getAgent().map(agent -> agent ? "toon" : "none"));
@@ -107,6 +107,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         Path analysisRoot = getAnalysisRoot().get().getAsFile().toPath().toAbsolutePath().normalize();
         Path configuredOutputPath = outputPath();
         Path configuredJunitReportPath = junitReportPath();
+        deleteMovedJunitReport(configuredJunitReportPath);
         if (sourceFiles.isEmpty()) {
             try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
                  var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
@@ -145,6 +146,16 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             if (exit != 0) {
                 throw new GradleException("crap-java-check failed with exit " + exit);
             }
+        }
+    }
+
+    private void deleteMovedJunitReport(Path currentPath) throws Exception {
+        if (currentPath == null) {
+            return;
+        }
+        Path rememberedPath = rememberedJunitReportPath();
+        if (rememberedPath != null && !rememberedPath.equals(currentPath)) {
+            Files.deleteIfExists(rememberedPath);
         }
     }
 
@@ -222,8 +233,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private Path junitReportStatePath() {
-        return junitReportState.get()
-                .getAsFile()
+        return junitReportState.getAsFile()
                 .toPath()
                 .toAbsolutePath()
                 .normalize();

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -24,8 +24,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public abstract class CrapJavaCheckTask extends DefaultTask {
 
@@ -150,10 +152,31 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private void deleteDisabledJunitReport() throws Exception {
-        if (getJunit().get() || !getJunitReport().isPresent()) {
+        if (getJunit().get()) {
             return;
         }
-        Files.deleteIfExists(getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize());
+        for (Path path : disabledJunitReportPaths()) {
+            Files.deleteIfExists(path);
+        }
+    }
+
+    private Set<Path> disabledJunitReportPaths() {
+        Set<Path> paths = new LinkedHashSet<>();
+        if (getJunitReport().isPresent()) {
+            paths.add(getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize());
+        }
+        paths.add(defaultJunitReportPath());
+        return paths;
+    }
+
+    private Path defaultJunitReportPath() {
+        return getProject().getLayout().getBuildDirectory()
+                .file("reports/crap-java/TEST-crap-java.xml")
+                .get()
+                .getAsFile()
+                .toPath()
+                .toAbsolutePath()
+                .normalize();
     }
 
     private List<Main.ResolvedCoverageModule> resolvedModules(List<Path> sourceFiles) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -31,16 +31,22 @@ import java.util.Set;
 
 public abstract class CrapJavaCheckTask extends DefaultTask {
 
+    private final Provider<RegularFile> defaultJunitReport;
+    private final Provider<RegularFile> junitReportState;
+
     public CrapJavaCheckTask() {
+        defaultJunitReport = getProject().getProviders()
+                .provider(this::defaultJunitReportRelativePath)
+                .flatMap(path -> getProject().getLayout().getBuildDirectory().file(path));
+        junitReportState = getProject().getLayout().getBuildDirectory()
+                .file("tmp/crap-java/" + getName() + "/junit-report.path");
         getThreshold().convention(Main.DEFAULT_THRESHOLD);
         getAgent().convention(false);
         getFormat().convention(getAgent().map(agent -> agent ? "toon" : "none"));
         getFailuresOnly().convention(getAgent());
         getOmitRedundancy().convention(getAgent());
         getJunit().convention(true);
-        getJunitReport().convention(getProject().getProviders()
-                .provider(this::defaultJunitReportRelativePath)
-                .flatMap(path -> getProject().getLayout().getBuildDirectory().file(path)));
+        getJunitReport().convention(defaultJunitReport);
     }
 
     @Internal
@@ -99,6 +105,8 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .sorted()
                 .toList();
         Path analysisRoot = getAnalysisRoot().get().getAsFile().toPath().toAbsolutePath().normalize();
+        Path configuredOutputPath = outputPath();
+        Path configuredJunitReportPath = junitReportPath();
         if (sourceFiles.isEmpty()) {
             try (var out = GradleLoggingPrintStreams.standardOut(getLogger());
                  var err = GradleLoggingPrintStreams.standardErr(getLogger())) {
@@ -110,10 +118,11 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                         getFormat().get(),
                         getFailuresOnly().get(),
                         getOmitRedundancy().get(),
-                        outputPath(),
-                        junitReportPath(),
+                        configuredOutputPath,
+                        configuredJunitReportPath,
                         getThreshold().get()
                 );
+                rememberJunitReportPath(configuredJunitReportPath);
             }
             return;
         }
@@ -128,10 +137,11 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                     getFormat().get(),
                     getFailuresOnly().get(),
                     getOmitRedundancy().get(),
-                    outputPath(),
-                    junitReportPath(),
+                    configuredOutputPath,
+                    configuredJunitReportPath,
                     getThreshold().get()
             );
+            rememberJunitReportPath(configuredJunitReportPath);
             if (exit != 0) {
                 throw new GradleException("crap-java-check failed with exit " + exit);
             }
@@ -159,21 +169,24 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         for (Path path : disabledJunitReportPaths()) {
             Files.deleteIfExists(path);
         }
+        Files.deleteIfExists(junitReportStatePath());
     }
 
-    private Set<Path> disabledJunitReportPaths() {
+    private Set<Path> disabledJunitReportPaths() throws Exception {
         Set<Path> paths = new LinkedHashSet<>();
         if (getJunitReport().isPresent()) {
             paths.add(getJunitReport().get().getAsFile().toPath().toAbsolutePath().normalize());
         }
         paths.add(defaultJunitReportPath());
+        Path rememberedPath = rememberedJunitReportPath();
+        if (rememberedPath != null) {
+            paths.add(rememberedPath);
+        }
         return paths;
     }
 
     private Path defaultJunitReportPath() {
-        return getProject().getLayout().getBuildDirectory()
-                .file("reports/crap-java/TEST-crap-java.xml")
-                .get()
+        return defaultJunitReport.get()
                 .getAsFile()
                 .toPath()
                 .toAbsolutePath()
@@ -185,6 +198,35 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return "reports/crap-java/TEST-crap-java.xml";
         }
         return "reports/crap-java/" + getName() + "/TEST-crap-java.xml";
+    }
+
+    private void rememberJunitReportPath(Path path) throws Exception {
+        if (path == null) {
+            return;
+        }
+        Path statePath = junitReportStatePath();
+        Files.createDirectories(statePath.getParent());
+        Files.writeString(statePath, path.toString());
+    }
+
+    private Path rememberedJunitReportPath() throws Exception {
+        Path statePath = junitReportStatePath();
+        if (!Files.isRegularFile(statePath)) {
+            return null;
+        }
+        String value = Files.readString(statePath).trim();
+        if (value.isBlank()) {
+            return null;
+        }
+        return Path.of(value).toAbsolutePath().normalize();
+    }
+
+    private Path junitReportStatePath() {
+        return junitReportState.get()
+                .getAsFile()
+                .toPath()
+                .toAbsolutePath()
+                .normalize();
     }
 
     private List<Main.ResolvedCoverageModule> resolvedModules(List<Path> sourceFiles) {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -5,9 +5,11 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -63,9 +65,16 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     @Input
     public abstract Property<Boolean> getJunit();
 
+    @Internal
+    public abstract RegularFileProperty getJunitReport();
+
     @OutputFile
     @Optional
-    public abstract RegularFileProperty getJunitReport();
+    public Provider<RegularFile> getJunitReportOutput() {
+        return getJunit().flatMap(enabled -> enabled
+                ? getJunitReport()
+                : getProject().getProviders().provider(() -> (RegularFile) null));
+    }
 
     @TaskAction
     void runCheck() throws Exception {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaExtension.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaExtension.java
@@ -1,8 +1,23 @@
 package media.barney.crap.gradle;
 
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 
 public abstract class CrapJavaExtension {
 
     public abstract Property<Double> getThreshold();
+
+    public abstract Property<String> getFormat();
+
+    public abstract Property<Boolean> getAgent();
+
+    public abstract Property<Boolean> getFailuresOnly();
+
+    public abstract Property<Boolean> getOmitRedundancy();
+
+    public abstract RegularFileProperty getOutput();
+
+    public abstract Property<Boolean> getJunit();
+
+    public abstract RegularFileProperty getJunitReport();
 }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
@@ -3,6 +3,8 @@ package media.barney.crap.gradle;
 import media.barney.crap.core.Main;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -37,9 +39,9 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
                     task.getAnalysisRoot().set(project.getLayout().getProjectDirectory());
                     task.getThreshold().convention(extension.getThreshold());
                     task.getAgent().convention(extension.getAgent());
-                    task.getFormat().convention(extension.getFormat());
-                    task.getFailuresOnly().convention(extension.getFailuresOnly());
-                    task.getOmitRedundancy().convention(extension.getOmitRedundancy());
+                    task.getFormat().convention(taskFormatDefault(project, task, extension));
+                    task.getFailuresOnly().convention(taskPrimaryFlagDefault(project, task, extension, extension.getFailuresOnly()));
+                    task.getOmitRedundancy().convention(taskPrimaryFlagDefault(project, task, extension, extension.getOmitRedundancy()));
                     task.getOutput().convention(extension.getOutput());
                     task.getJunit().convention(extension.getJunit());
                     task.getJunitReport().convention(extension.getJunitReport());
@@ -94,6 +96,35 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
             return JACOCO_XML_RELATIVE_PATH;
         }
         return modulePath + "/" + JACOCO_XML_RELATIVE_PATH;
+    }
+
+    private static Provider<String> taskFormatDefault(Project project,
+                                                      CrapJavaCheckTask task,
+                                                      CrapJavaExtension extension) {
+        return project.getProviders().provider(() -> {
+            boolean extensionAgent = extension.getAgent().getOrElse(false);
+            boolean taskAgent = task.getAgent().getOrElse(extensionAgent);
+            String extensionFormat = extension.getFormat().getOrElse(extensionAgent ? "toon" : "none");
+            if (taskAgent && !extensionAgent && "none".equals(extensionFormat)) {
+                return "toon";
+            }
+            return extensionFormat;
+        });
+    }
+
+    private static Provider<Boolean> taskPrimaryFlagDefault(Project project,
+                                                           CrapJavaCheckTask task,
+                                                           CrapJavaExtension extension,
+                                                           Property<Boolean> extensionControl) {
+        return project.getProviders().provider(() -> {
+            boolean extensionAgent = extension.getAgent().getOrElse(false);
+            boolean extensionValue = extensionControl.getOrElse(extensionAgent);
+            boolean taskAgent = task.getAgent().getOrElse(extensionAgent);
+            if (taskAgent && !extensionAgent && !extensionValue) {
+                return true;
+            }
+            return extensionValue;
+        });
     }
 }
 

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
@@ -3,14 +3,15 @@ package media.barney.crap.gradle;
 import media.barney.crap.core.Main;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.testing.jacoco.tasks.JacocoReport;
 
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
-import java.nio.file.Path;
 
 public class CrapJavaGradlePlugin implements Plugin<Project> {
 
@@ -20,6 +21,8 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
     public void apply(Project project) {
         CrapJavaExtension extension = project.getExtensions().create("crapJava", CrapJavaExtension.class);
         extension.getThreshold().convention(Main.DEFAULT_THRESHOLD);
+        extension.getAgent().convention(false);
+        extension.getJunit().convention(true);
 
         TaskProvider<CrapJavaCheckTask> checkTask = project.getTasks().register(
                 "crap-java-check",
@@ -29,8 +32,19 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
                     task.setDescription("Runs the crap-java CRAP metric gate.");
                     task.getAnalysisRoot().set(project.getLayout().getProjectDirectory());
                     task.getThreshold().convention(extension.getThreshold());
-                    task.getJunitReport().convention(project.getLayout().getBuildDirectory()
-                            .file("reports/crap-java/TEST-crap-java.xml"));
+                    task.getAgent().convention(extension.getAgent());
+                    Provider<String> effectiveFormat = extension.getFormat().orElse(task.getAgent()
+                            .map(agent -> agent ? "toon" : "none"));
+                    Provider<Boolean> effectiveFailuresOnly = extension.getFailuresOnly().orElse(task.getAgent());
+                    Provider<Boolean> effectiveOmitRedundancy = extension.getOmitRedundancy().orElse(task.getAgent());
+                    task.getFormat().convention(effectiveFormat);
+                    task.getFailuresOnly().convention(effectiveFailuresOnly);
+                    task.getOmitRedundancy().convention(effectiveOmitRedundancy);
+                    task.getOutput().convention(extension.getOutput());
+                    task.getJunit().convention(extension.getJunit());
+                    task.getJunitReport().convention(extension.getJunitReport()
+                            .orElse(project.getLayout().getBuildDirectory()
+                                    .file("reports/crap-java/TEST-crap-java.xml")));
                 }
         );
 

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
@@ -3,7 +3,6 @@ package media.barney.crap.gradle;
 import media.barney.crap.core.Main;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -22,7 +21,12 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
         CrapJavaExtension extension = project.getExtensions().create("crapJava", CrapJavaExtension.class);
         extension.getThreshold().convention(Main.DEFAULT_THRESHOLD);
         extension.getAgent().convention(false);
+        extension.getFormat().convention(extension.getAgent().map(agent -> agent ? "toon" : "none"));
+        extension.getFailuresOnly().convention(extension.getAgent());
+        extension.getOmitRedundancy().convention(extension.getAgent());
         extension.getJunit().convention(true);
+        extension.getJunitReport().convention(project.getLayout().getBuildDirectory()
+                .file("reports/crap-java/TEST-crap-java.xml"));
 
         TaskProvider<CrapJavaCheckTask> checkTask = project.getTasks().register(
                 "crap-java-check",
@@ -33,18 +37,12 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
                     task.getAnalysisRoot().set(project.getLayout().getProjectDirectory());
                     task.getThreshold().convention(extension.getThreshold());
                     task.getAgent().convention(extension.getAgent());
-                    Provider<String> effectiveFormat = extension.getFormat().orElse(task.getAgent()
-                            .map(agent -> agent ? "toon" : "none"));
-                    Provider<Boolean> effectiveFailuresOnly = extension.getFailuresOnly().orElse(task.getAgent());
-                    Provider<Boolean> effectiveOmitRedundancy = extension.getOmitRedundancy().orElse(task.getAgent());
-                    task.getFormat().convention(effectiveFormat);
-                    task.getFailuresOnly().convention(effectiveFailuresOnly);
-                    task.getOmitRedundancy().convention(effectiveOmitRedundancy);
+                    task.getFormat().convention(extension.getFormat());
+                    task.getFailuresOnly().convention(extension.getFailuresOnly());
+                    task.getOmitRedundancy().convention(extension.getOmitRedundancy());
                     task.getOutput().convention(extension.getOutput());
                     task.getJunit().convention(extension.getJunit());
-                    task.getJunitReport().convention(extension.getJunitReport()
-                            .orElse(project.getLayout().getBuildDirectory()
-                                    .file("reports/crap-java/TEST-crap-java.xml")));
+                    task.getJunitReport().convention(extension.getJunitReport());
                 }
         );
 

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
@@ -105,8 +105,8 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
             boolean extensionAgent = extension.getAgent().getOrElse(false);
             boolean taskAgent = task.getAgent().getOrElse(extensionAgent);
             String extensionFormat = extension.getFormat().getOrElse(extensionAgent ? "toon" : "none");
-            if (taskAgent && !extensionAgent && "none".equals(extensionFormat)) {
-                return "toon";
+            if (taskAgent != extensionAgent && isDefaultAgentFormat(extensionAgent, extensionFormat)) {
+                return taskAgent ? "toon" : "none";
             }
             return extensionFormat;
         });
@@ -120,11 +120,15 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
             boolean extensionAgent = extension.getAgent().getOrElse(false);
             boolean extensionValue = extensionControl.getOrElse(extensionAgent);
             boolean taskAgent = task.getAgent().getOrElse(extensionAgent);
-            if (taskAgent && !extensionAgent && !extensionValue) {
-                return true;
+            if (taskAgent != extensionAgent && extensionValue == extensionAgent) {
+                return taskAgent;
             }
             return extensionValue;
         });
+    }
+
+    private static boolean isDefaultAgentFormat(boolean agent, String format) {
+        return agent ? "toon".equals(format) : "none".equals(format);
     }
 }
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -222,6 +222,26 @@ class CrapJavaGradlePluginFunctionalTest {
         assertTrue(junitReport.contains("<property name=\"status\" value=\"passed\"/>"));
     }
 
+    @Test
+    void disabledJunitRemovesStaleSidecarAndDoesNotWriteNewSidecar() throws Exception {
+        Path defaultJunit = tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        Files.createDirectories(defaultJunit.getParent());
+        Files.writeString(defaultJunit, "<testsuites tests=\"99\"/>");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junit.set(false)
+                }
+                """);
+
+        BuildResult result = runBuild("crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
+        assertFalse(Files.exists(defaultJunit));
+        assertFalse(result.getOutput().contains("<testsuites"));
+        assertFalse(result.getOutput().contains("CRAP Report"));
+    }
+
     private BuildResult runBuild(String... arguments) {
         List<String> gradleArguments = new ArrayList<>();
         gradleArguments.add("-Dgradle.user.home=" + tempDir.resolve("gradle-user-home"));

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -174,6 +174,31 @@ class CrapJavaGradlePluginFunctionalTest {
     }
 
     @Test
+    void configuredReportControlsReuseConfigurationCache() throws Exception {
+        writeSingleModuleProject("""
+
+                crapJava {
+                    agent.set(true)
+                    format.set("json")
+                    output.set(layout.buildDirectory.file("reports/crap-java/report.json"))
+                    junit.set(false)
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/custom-junit.xml"))
+                }
+                """);
+
+        BuildResult first = runBuild("--configuration-cache", "crap-java-check");
+        BuildResult second = runBuild("--configuration-cache", "crap-java-check");
+
+        assertTrue(first.getOutput().contains("Configuration cache entry stored."));
+        assertTrue(second.getOutput().contains("Configuration cache entry reused."));
+        TaskOutcome outcome = second.task(":crap-java-check").getOutcome();
+        assertTrue(outcome == TaskOutcome.SUCCESS || outcome == TaskOutcome.UP_TO_DATE);
+        assertTrue(Files.exists(tempDir.resolve("build/reports/crap-java/report.json")));
+        assertFalse(Files.exists(tempDir.resolve("build/reports/crap-java/custom-junit.xml")));
+        assertFalse(Files.exists(tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml")));
+    }
+
+    @Test
     void configuredThresholdIsWrittenToJunitReport() throws Exception {
         writeSingleModuleProject("""
 
@@ -410,6 +435,27 @@ class CrapJavaGradlePluginFunctionalTest {
 
         assertEquals(TaskOutcome.SUCCESS, thirdResult.task(":crap-java-check").getOutcome());
         assertFalse(Files.exists(newOutput));
+    }
+
+    @Test
+    void primaryOutputCleanupRemovesLastWrittenExternalOutputAfterClean() throws Exception {
+        Path oldOutput = tempDir.resolve("outside-report.json");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    format.set("json")
+                    output.set(layout.projectDirectory.file("outside-report.json"))
+                }
+                """);
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        assertTrue(Files.exists(oldOutput));
+        writeSingleModuleProject();
+
+        BuildResult secondResult = runBuild("clean", "crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, secondResult.task(":crap-java-check").getOutcome());
+        assertFalse(Files.exists(oldOutput));
     }
 
     private BuildResult runBuild(String... arguments) {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -250,15 +250,14 @@ class CrapJavaGradlePluginFunctionalTest {
     @Test
     void disabledJunitRemovesStaleSidecarAndDoesNotWriteNewSidecar() throws Exception {
         Path defaultJunit = tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml");
-        Path customJunit = tempDir.resolve("build/reports/crap-java/custom-junit.xml");
-        Files.createDirectories(defaultJunit.getParent());
-        Files.writeString(defaultJunit, "<testsuites tests=\"99\"/>");
-        Files.writeString(customJunit, "<testsuites tests=\"88\"/>");
+        writeSingleModuleProject();
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        assertTrue(Files.exists(defaultJunit));
         writeSingleModuleProject("""
 
                 crapJava {
                     junit.set(false)
-                    junitReport.set(layout.buildDirectory.file("reports/crap-java/custom-junit.xml"))
                 }
                 """);
 
@@ -266,7 +265,6 @@ class CrapJavaGradlePluginFunctionalTest {
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
         assertFalse(Files.exists(defaultJunit));
-        assertFalse(Files.exists(customJunit));
         assertFalse(result.getOutput().contains("<testsuites"));
         assertFalse(result.getOutput().contains("CRAP Report"));
     }
@@ -372,7 +370,7 @@ class CrapJavaGradlePluginFunctionalTest {
     }
 
     @Test
-    void disabledJunitReportPathChangeInvalidatesCleanupTask() throws Exception {
+    void disabledJunitReportPathChangeInvalidatesTaskWithoutDeletingUnownedFile() throws Exception {
         Path newJunit = tempDir.resolve("build/reports/crap-java/new-junit.xml");
         writeSingleModuleProject("""
 
@@ -396,7 +394,7 @@ class CrapJavaGradlePluginFunctionalTest {
         BuildResult secondResult = runBuild("crap-java-check");
 
         assertEquals(TaskOutcome.SUCCESS, secondResult.task(":crap-java-check").getOutcome());
-        assertFalse(Files.exists(newJunit));
+        assertTrue(Files.exists(newJunit));
     }
 
     @Test
@@ -458,7 +456,101 @@ class CrapJavaGradlePluginFunctionalTest {
         assertFalse(Files.exists(oldOutput));
     }
 
+    @Test
+    void primaryOutputCleanupDoesNotDeleteRecreatedExternalOutputAfterClean() throws Exception {
+        Path oldOutput = tempDir.resolve("outside-report.json");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    format.set("json")
+                    output.set(layout.projectDirectory.file("outside-report.json"))
+                }
+                """);
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        Files.writeString(oldOutput, "unrelated");
+        writeSingleModuleProject();
+
+        BuildResult secondResult = runBuild("clean", "crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, secondResult.task(":crap-java-check").getOutcome());
+        assertEquals("unrelated", Files.readString(oldOutput));
+    }
+
+    @Test
+    void disabledJunitDoesNotDeleteRecreatedExternalSidecarAfterClean() throws Exception {
+        Path oldJunit = tempDir.resolve("outside-junit.xml");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junitReport.set(layout.projectDirectory.file("outside-junit.xml"))
+                }
+                """);
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        Files.writeString(oldJunit, "unrelated");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junit.set(false)
+                }
+                """);
+
+        BuildResult secondResult = runBuild("clean", "crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, secondResult.task(":crap-java-check").getOutcome());
+        assertEquals("unrelated", Files.readString(oldJunit));
+    }
+
+    @Test
+    void invalidReportPathDoesNotDeletePreviousOutput() throws Exception {
+        Path oldOutput = tempDir.resolve("outside-report.json");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    format.set("json")
+                    output.set(layout.projectDirectory.file("outside-report.json"))
+                }
+                """);
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        writeSingleModuleProject("""
+
+                crapJava {
+                    output.set(layout.buildDirectory.file("reports/crap-java/collision.xml"))
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/collision.xml"))
+                }
+                """);
+
+        BuildResult secondResult = runBuildAndFail("crap-java-check");
+
+        assertTrue(secondResult.getOutput().contains("output and junitReport must not point to the same file"));
+        assertTrue(Files.exists(oldOutput));
+    }
+
+    @Test
+    void reportPathsMustNotUseInternalTaskFiles() throws Exception {
+        writeSingleModuleProject("""
+
+                crapJava {
+                    output.set(layout.buildDirectory.file("tmp/crap-java/crap-java-check/execution.marker"))
+                }
+                """);
+
+        BuildResult result = runBuildAndFail("crap-java-check");
+
+        assertTrue(result.getOutput().contains("output must not point to a crap-java internal task file"));
+    }
+
     private BuildResult runBuild(String... arguments) {
+        return gradleRunner(arguments).build();
+    }
+
+    private BuildResult runBuildAndFail(String... arguments) {
+        return gradleRunner(arguments).buildAndFail();
+    }
+
+    private GradleRunner gradleRunner(String... arguments) {
         List<String> gradleArguments = new ArrayList<>();
         gradleArguments.add("-Dgradle.user.home=" + tempDir.resolve("gradle-user-home"));
         gradleArguments.add("-Dorg.gradle.daemon=false");
@@ -466,8 +558,7 @@ class CrapJavaGradlePluginFunctionalTest {
         return GradleRunner.create()
                 .withProjectDir(tempDir.toFile())
                 .withArguments(gradleArguments)
-                .withPluginClasspath()
-                .build();
+                .withPluginClasspath();
     }
 
     private void writeSingleModuleProject() throws IOException {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -328,6 +328,72 @@ class CrapJavaGradlePluginFunctionalTest {
         assertFalse(secondResult.getOutput().contains("<testsuites"));
     }
 
+    @Test
+    void disabledJunitReportPathChangeInvalidatesCleanupTask() throws Exception {
+        Path newJunit = tempDir.resolve("build/reports/crap-java/new-junit.xml");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junit.set(false)
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/old-junit.xml"))
+                }
+                """);
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        Files.createDirectories(newJunit.getParent());
+        Files.writeString(newJunit, "<testsuites tests=\"99\"/>");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junit.set(false)
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/new-junit.xml"))
+                }
+                """);
+
+        BuildResult secondResult = runBuild("crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, secondResult.task(":crap-java-check").getOutcome());
+        assertFalse(Files.exists(newJunit));
+    }
+
+    @Test
+    void primaryOutputCleanupFollowsConfiguredOutputPath() throws Exception {
+        Path oldOutput = tempDir.resolve("build/reports/crap-java/old-report.json");
+        Path newOutput = tempDir.resolve("build/reports/crap-java/new-report.json");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    format.set("json")
+                    output.set(layout.buildDirectory.file("reports/crap-java/old-report.json"))
+                }
+                """);
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        assertTrue(Files.exists(oldOutput));
+        writeSingleModuleProject("""
+
+                crapJava {
+                    format.set("json")
+                    output.set(layout.buildDirectory.file("reports/crap-java/new-report.json"))
+                }
+                """);
+        BuildResult secondResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, secondResult.task(":crap-java-check").getOutcome());
+        assertFalse(Files.exists(oldOutput));
+        assertTrue(Files.exists(newOutput));
+        writeSingleModuleProject("""
+
+                crapJava {
+                    format.set("json")
+                }
+                """);
+
+        BuildResult thirdResult = runBuild("crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, thirdResult.task(":crap-java-check").getOutcome());
+        assertFalse(Files.exists(newOutput));
+    }
+
     private BuildResult runBuild(String... arguments) {
         List<String> gradleArguments = new ArrayList<>();
         gradleArguments.add("-Dgradle.user.home=" + tempDir.resolve("gradle-user-home"));

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -533,7 +533,7 @@ class CrapJavaGradlePluginFunctionalTest {
         writeSingleModuleProject("""
 
                 crapJava {
-                    output.set(layout.buildDirectory.file("tmp/crap-java/crap-java-check/execution.marker"))
+                    output.set(layout.buildDirectory.file("tmp/crap-java/other-crap-java-check/execution.marker"))
                 }
                 """);
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -11,9 +11,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CrapJavaGradlePluginFunctionalTest {
@@ -30,6 +32,11 @@ class CrapJavaGradlePluginFunctionalTest {
         assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
         assertEquals(TaskOutcome.SUCCESS, result.task(":jacocoTestReport").getOutcome());
         assertTrue(Files.exists(tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml")));
+        assertEquals(List.of("TEST-crap-java.xml"), reportFileNames("build/reports/crap-java"));
+        assertFalse(result.getOutput().contains("CRAP Report"));
+        assertFalse(result.getOutput().contains("\"status\""));
+        assertFalse(result.getOutput().contains("status:"));
+        assertFalse(result.getOutput().contains("<testsuites"));
     }
 
     @Test
@@ -182,6 +189,39 @@ class CrapJavaGradlePluginFunctionalTest {
                 .contains("<property name=\"threshold\" value=\"6.0\"/>"));
     }
 
+    @Test
+    void configuredReportControlsWritePrimaryReportAndFullJunitSidecar() throws Exception {
+        writeSingleModuleProject("""
+
+                crapJava {
+                    format.set("json")
+                    agent.set(true)
+                    failuresOnly.set(false)
+                    omitRedundancy.set(true)
+                    output.set(layout.buildDirectory.file("reports/crap-java/report.json"))
+                    junit.set(true)
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/custom-junit.xml"))
+                }
+                """);
+
+        BuildResult result = runBuild("crap-java-check");
+
+        Path primary = tempDir.resolve("build/reports/crap-java/report.json");
+        Path junit = tempDir.resolve("build/reports/crap-java/custom-junit.xml");
+        String primaryReport = Files.readString(primary);
+        String junitReport = Files.readString(junit);
+        assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
+        assertTrue(Files.exists(primary));
+        assertTrue(Files.exists(junit));
+        assertFalse(Files.exists(tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml")));
+        assertTrue(primaryReport.contains("\"status\": \"passed\""));
+        assertTrue(primaryReport.contains("\"threshold\": 8.0"));
+        assertTrue(primaryReport.contains("\"method\": \"alpha\""));
+        assertFalse(primaryReport.contains("      \"status\":"));
+        assertTrue(junitReport.contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
+        assertTrue(junitReport.contains("<property name=\"status\" value=\"passed\"/>"));
+    }
+
     private BuildResult runBuild(String... arguments) {
         List<String> gradleArguments = new ArrayList<>();
         gradleArguments.add("-Dgradle.user.home=" + tempDir.resolve("gradle-user-home"));
@@ -251,6 +291,15 @@ class CrapJavaGradlePluginFunctionalTest {
         Path file = tempDir.resolve(relativePath);
         Files.createDirectories(file.getParent());
         Files.writeString(file, content);
+    }
+
+    private List<String> reportFileNames(String relativePath) throws IOException {
+        try (var files = Files.list(tempDir.resolve(relativePath))) {
+            return files
+                    .map(path -> path.getFileName().toString())
+                    .sorted(Comparator.naturalOrder())
+                    .toList();
+        }
     }
 }
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -247,6 +247,24 @@ class CrapJavaGradlePluginFunctionalTest {
     }
 
     @Test
+    void disabledJunitWithoutPrimaryOutputCanBeUpToDate() throws Exception {
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junit.set(false)
+                }
+                """);
+
+        BuildResult firstResult = runBuild("crap-java-check");
+        BuildResult secondResult = runBuild("crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        assertEquals(TaskOutcome.UP_TO_DATE, secondResult.task(":crap-java-check").getOutcome());
+        assertFalse(Files.exists(tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml")));
+        assertFalse(secondResult.getOutput().contains("CRAP Report"));
+    }
+
+    @Test
     void disabledJunitRemovesLastWrittenNonDefaultSidecar() throws Exception {
         Path oldJunit = tempDir.resolve("build/reports/crap-java/old-junit.xml");
         Path newJunit = tempDir.resolve("build/reports/crap-java/new-junit.xml");

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -533,7 +533,7 @@ class CrapJavaGradlePluginFunctionalTest {
         writeSingleModuleProject("""
 
                 crapJava {
-                    output.set(layout.buildDirectory.file("tmp/crap-java/other-crap-java-check/execution.marker"))
+                    output.set(layout.projectDirectory.file("sub/build/tmp/crap-java/sub-crap-java-check/execution.marker"))
                 }
                 """);
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -533,7 +533,7 @@ class CrapJavaGradlePluginFunctionalTest {
         writeSingleModuleProject("""
 
                 crapJava {
-                    output.set(layout.projectDirectory.file("sub/build/tmp/crap-java/sub-crap-java-check/execution.marker"))
+                    output.set(layout.buildDirectory.file("tmp/crap-java/crap-java-check/execution.marker"))
                 }
                 """);
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -225,12 +225,15 @@ class CrapJavaGradlePluginFunctionalTest {
     @Test
     void disabledJunitRemovesStaleSidecarAndDoesNotWriteNewSidecar() throws Exception {
         Path defaultJunit = tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        Path customJunit = tempDir.resolve("build/reports/crap-java/custom-junit.xml");
         Files.createDirectories(defaultJunit.getParent());
         Files.writeString(defaultJunit, "<testsuites tests=\"99\"/>");
+        Files.writeString(customJunit, "<testsuites tests=\"88\"/>");
         writeSingleModuleProject("""
 
                 crapJava {
                     junit.set(false)
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/custom-junit.xml"))
                 }
                 """);
 
@@ -238,6 +241,7 @@ class CrapJavaGradlePluginFunctionalTest {
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
         assertFalse(Files.exists(defaultJunit));
+        assertFalse(Files.exists(customJunit));
         assertFalse(result.getOutput().contains("<testsuites"));
         assertFalse(result.getOutput().contains("CRAP Report"));
     }

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -275,6 +275,59 @@ class CrapJavaGradlePluginFunctionalTest {
         assertFalse(secondResult.getOutput().contains("<testsuites"));
     }
 
+    @Test
+    void enabledJunitRemovesPreviousSidecarWhenReportPathChanges() throws Exception {
+        Path oldJunit = tempDir.resolve("build/reports/crap-java/old-junit.xml");
+        Path newJunit = tempDir.resolve("build/reports/crap-java/new-junit.xml");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/old-junit.xml"))
+                }
+                """);
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        assertTrue(Files.exists(oldJunit));
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/new-junit.xml"))
+                }
+                """);
+
+        BuildResult secondResult = runBuild("crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, secondResult.task(":crap-java-check").getOutcome());
+        assertFalse(Files.exists(oldJunit));
+        assertTrue(Files.exists(newJunit));
+    }
+
+    @Test
+    void disabledJunitRemovesLastWrittenSidecarAfterClean() throws Exception {
+        Path oldJunit = tempDir.resolve("outside-junit.xml");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junitReport.set(layout.projectDirectory.file("outside-junit.xml"))
+                }
+                """);
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        assertTrue(Files.exists(oldJunit));
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junit.set(false)
+                }
+                """);
+
+        BuildResult secondResult = runBuild("clean", "crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, secondResult.task(":crap-java-check").getOutcome());
+        assertFalse(Files.exists(oldJunit));
+        assertFalse(secondResult.getOutput().contains("<testsuites"));
+    }
+
     private BuildResult runBuild(String... arguments) {
         List<String> gradleArguments = new ArrayList<>();
         gradleArguments.add("-Dgradle.user.home=" + tempDir.resolve("gradle-user-home"));

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -246,6 +246,35 @@ class CrapJavaGradlePluginFunctionalTest {
         assertFalse(result.getOutput().contains("CRAP Report"));
     }
 
+    @Test
+    void disabledJunitRemovesLastWrittenNonDefaultSidecar() throws Exception {
+        Path oldJunit = tempDir.resolve("build/reports/crap-java/old-junit.xml");
+        Path newJunit = tempDir.resolve("build/reports/crap-java/new-junit.xml");
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/old-junit.xml"))
+                }
+                """);
+        BuildResult firstResult = runBuild("crap-java-check");
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":crap-java-check").getOutcome());
+        assertTrue(Files.exists(oldJunit));
+        writeSingleModuleProject("""
+
+                crapJava {
+                    junit.set(false)
+                    junitReport.set(layout.buildDirectory.file("reports/crap-java/new-junit.xml"))
+                }
+                """);
+
+        BuildResult secondResult = runBuild("crap-java-check");
+
+        assertEquals(TaskOutcome.SUCCESS, secondResult.task(":crap-java-check").getOutcome());
+        assertFalse(Files.exists(oldJunit));
+        assertFalse(Files.exists(newJunit));
+        assertFalse(secondResult.getOutput().contains("<testsuites"));
+    }
+
     private BuildResult runBuild(String... arguments) {
         List<String> gradleArguments = new ArrayList<>();
         gradleArguments.add("-Dgradle.user.home=" + tempDir.resolve("gradle-user-home"));

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -426,6 +427,46 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void runCheckHandlesCaseOnlyInternalExecutionMarkerPathByFileSystem() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path markerPath = projectRoot.resolve("build/tmp/crap-java/crap-java-check/EXECUTION.MARKER");
+        Files.createDirectories(markerPath.getParent());
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(markerPath.toFile());
+
+        if (isCaseInsensitiveFileSystem(projectRoot)) {
+            GradleException exception = assertThrows(GradleException.class, task::runCheck);
+            assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+        } else {
+            task.runCheck();
+            assertTrue(Files.exists(markerPath));
+        }
+    }
+
+    @Test
+    void runCheckHandlesCaseOnlyInternalStatePathByFileSystem() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path statePath = projectRoot.resolve(".gradle/crap-java/root/other-task/PRIMARY-OUTPUT.PATH");
+        Files.createDirectories(statePath.getParent());
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(statePath.toFile());
+
+        if (isCaseInsensitiveFileSystem(projectRoot)) {
+            GradleException exception = assertThrows(GradleException.class, task::runCheck);
+            assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+        } else {
+            task.runCheck();
+            assertTrue(Files.exists(statePath));
+        }
+    }
+
+    @Test
     void runCheckRejectsSymlinkedInternalStatePath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Path stateRoot = projectRoot.resolve(".gradle/crap-java/root/other-task");
@@ -598,6 +639,16 @@ class CrapJavaGradlePluginTest {
         } catch (UnsupportedOperationException | IOException | SecurityException exception) {
             assumeTrue(false, "Directory symbolic links are unavailable: " + exception.getMessage());
             return link;
+        }
+    }
+
+    private boolean isCaseInsensitiveFileSystem(Path directory) throws Exception {
+        Path probe = Files.createTempFile(directory, ".crap-java-case-", ".tmp");
+        try {
+            Path variant = probe.resolveSibling(probe.getFileName().toString().toUpperCase(Locale.ROOT));
+            return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
+        } finally {
+            Files.deleteIfExists(probe);
         }
     }
 }

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -346,6 +346,20 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void runCheckRejectsOtherTaskInternalJunitReportPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getJunitReport().fileValue(projectRoot.resolve(".gradle/crap-java/other-task/junit-report.path").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("junitReport must not point to a crap-java internal task file"));
+    }
+
+    @Test
     void disabledCustomTaskDoesNotDeleteBuiltInTaskSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -297,6 +297,7 @@ class CrapJavaGradlePluginTest {
     @Test
     void movedJunitReportDeletesOwnedRememberedDefaultSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Path defaultJunitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
         Path customJunitReport = projectRoot.resolve("custom-junit.xml");
         CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
@@ -315,6 +316,7 @@ class CrapJavaGradlePluginTest {
     @Test
     void disabledJunitDeletesOwnedRememberedDefaultSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Path defaultJunitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
         CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
         firstTask.runCheck();
@@ -331,6 +333,7 @@ class CrapJavaGradlePluginTest {
     @Test
     void disabledJunitDeletesOwnedRememberedExternalSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         Path junitReport = projectRoot.resolve("outside-junit.xml");
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
@@ -408,16 +411,18 @@ class CrapJavaGradlePluginTest {
     @Test
     void failedJunitPublishRemembersWrittenPrimaryOutput() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         Path output = projectRoot.resolve("primary.json");
-        Path junitDirectory = projectRoot.resolve("junit-directory");
-        Files.createDirectories(junitDirectory);
+        Path junitParentFile = projectRoot.resolve("junit-parent-file");
+        Path badJunitReport = junitParentFile.resolve("TEST-crap-java.xml");
+        Files.writeString(junitParentFile, "not a directory");
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
         task.getFormat().set("json");
         task.getOutput().fileValue(output.toFile());
-        task.getJunitReport().fileValue(junitDirectory.toFile());
+        task.getJunitReport().fileValue(badJunitReport.toFile());
 
         assertThrows(Exception.class, task::runCheck);
 
@@ -508,15 +513,17 @@ class CrapJavaGradlePluginTest {
     @Test
     void failedMovedJunitReplacementDoesNotForgetRememberedOutput() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Path oldOutput = projectRoot.resolve("outside-report.json");
         Path replacementOutput = projectRoot.resolve("replacement-report.json");
-        Path badJunitReport = projectRoot.resolve("bad-junit.xml");
+        Path junitParentFile = projectRoot.resolve("junit-parent-file");
+        Path badJunitReport = junitParentFile.resolve("TEST-crap-java.xml");
         CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
         firstTask.getFormat().set("json");
         firstTask.getOutput().fileValue(oldOutput.toFile());
         firstTask.runCheck();
         assertTrue(Files.exists(oldOutput));
-        Files.createDirectories(badJunitReport);
+        Files.writeString(junitParentFile, "not a directory");
 
         CrapJavaCheckTask secondTask = newCheckTask(projectRoot);
         secondTask.getFormat().set("json");
@@ -540,6 +547,7 @@ class CrapJavaGradlePluginTest {
     @Test
     void movedOutputDoesNotDeleteReportStillOwnedByAnotherTask() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Path sharedOutput = projectRoot.resolve("shared-report.json");
         Path movedOutput = projectRoot.resolve("moved-report.json");
         CrapJavaCheckTask firstTask = newCheckTask(projectRoot, "first-crap-java-check");
@@ -791,6 +799,7 @@ class CrapJavaGradlePluginTest {
     @Test
     void rememberedStateUsesGradleProjectCacheDir() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Path projectCacheDir = projectRoot.resolve("custom-project-cache");
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         project.getGradle().getStartParameter().setProjectCacheDir(projectCacheDir.toFile());
@@ -805,8 +814,20 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void reportStateLockIsSharedAcrossTasksInProjectCache() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        CrapJavaCheckTask firstTask = newCheckTask(projectRoot, "first-crap-java-check");
+        CrapJavaCheckTask secondTask = newCheckTask(projectRoot, "second-crap-java-check");
+        Path expectedLockPath = projectRoot.resolve(".gradle/crap-java/state.lock").toAbsolutePath().normalize();
+
+        assertEquals(expectedLockPath, stateLockPath(firstTask));
+        assertEquals(expectedLockPath, stateLockPath(secondTask));
+    }
+
+    @Test
     void rememberedStateFallsBackToRootProjectGradleDirForSubprojects() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Path subprojectRoot = projectRoot.resolve("sub");
         Files.createDirectories(subprojectRoot);
         Project root = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
@@ -828,6 +849,7 @@ class CrapJavaGradlePluginTest {
     @Test
     void rememberedStateEscapesProjectPathSeparators() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Path projectCacheDir = projectRoot.resolve("custom-project-cache");
         Project root = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         root.getGradle().getStartParameter().setProjectCacheDir(projectCacheDir.toFile());
@@ -887,6 +909,7 @@ class CrapJavaGradlePluginTest {
     @Test
     void disabledCustomTaskOnlyDeletesOwnedDefaultSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
+        assumeHardLinksAvailable(projectRoot);
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         Path builtInJunit = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
         Path customJunit = projectRoot.resolve("build/reports/crap-java/custom-crap-java-check/TEST-crap-java.xml");
@@ -956,8 +979,28 @@ class CrapJavaGradlePluginTest {
     private void rememberOwnedReport(Path statePath, Path reportPath) throws Exception {
         Files.createDirectories(statePath.getParent());
         Path ownerPath = statePath.resolveSibling("primary-output.owner");
-        Files.createLink(ownerPath, reportPath);
+        createHardLinkOrSkip(ownerPath, reportPath);
         Files.writeString(statePath, reportPath + "\n" + ownership(reportPath) + "\n");
+    }
+
+    private void assumeHardLinksAvailable(Path directory) throws Exception {
+        Path target = Files.createTempFile(directory, ".crap-java-hard-link-target-", ".tmp");
+        Path link = target.resolveSibling(target.getFileName() + ".link");
+        try {
+            createHardLinkOrSkip(link, target);
+        } finally {
+            Files.deleteIfExists(link);
+            Files.deleteIfExists(target);
+        }
+    }
+
+    private Path createHardLinkOrSkip(Path link, Path target) throws Exception {
+        try {
+            return Files.createLink(link, target);
+        } catch (UnsupportedOperationException | IOException | SecurityException exception) {
+            assumeTrue(false, "Hard links are unavailable: " + exception.getMessage());
+            return link;
+        }
     }
 
     private String ownership(Path reportPath) throws Exception {
@@ -979,6 +1022,12 @@ class CrapJavaGradlePluginTest {
         );
         cleanup.setAccessible(true);
         cleanup.invoke(task, currentOutputPath, currentJunitReportPath);
+    }
+
+    private Path stateLockPath(CrapJavaCheckTask task) throws Exception {
+        Method stateLockPath = CrapJavaCheckTask.class.getDeclaredMethod("stateLockPath");
+        stateLockPath.setAccessible(true);
+        return (Path) stateLockPath.invoke(task);
     }
 
     private boolean isCaseInsensitiveFileSystem(Path directory) throws Exception {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -309,6 +309,27 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void invalidReportPathDoesNotDeleteRememberedJunitSidecar() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path junitReport = projectRoot.resolve("outside-junit.xml");
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getJunitReport().fileValue(junitReport.toFile());
+        task.runCheck();
+        assertTrue(Files.exists(junitReport));
+
+        task.getJunit().set(false);
+        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/other-task/primary-output.path").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+        assertTrue(Files.exists(junitReport));
+    }
+
+    @Test
     void runCheckRejectsOtherTaskInternalStatePath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -683,6 +683,32 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void runCheckRejectsDirectoryPrimaryReportPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path outputDirectory = projectRoot.resolve("reports/output.json");
+        Files.createDirectories(outputDirectory);
+        CrapJavaCheckTask task = newCheckTask(projectRoot);
+        task.getOutput().fileValue(outputDirectory.toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a directory"));
+    }
+
+    @Test
+    void runCheckRejectsDirectoryJunitReportPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path junitDirectory = projectRoot.resolve("reports/TEST-crap-java.xml");
+        Files.createDirectories(junitDirectory);
+        CrapJavaCheckTask task = newCheckTask(projectRoot);
+        task.getJunitReport().fileValue(junitDirectory.toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("junitReport must not point to a directory"));
+    }
+
+    @Test
     void runCheckRejectsInternalExecutionMarkerRootPath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Path markerPath = projectRoot.resolve("build/tmp/crap-java/crap-java-check/report.xml");
@@ -899,8 +925,35 @@ class CrapJavaGradlePluginTest {
 
         task.runCheck();
 
-        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/root/crap-java-check/junit-report.path")));
+        Path statePath = junitReportStatePath(task);
+        assertTrue(Files.exists(statePath));
+        assertTrue(statePath.startsWith(projectCacheDir.resolve("crap-java")));
+        assertTrue(statePath.getParent().getParent().getParent().getFileName().toString().startsWith("workspace-"));
         assertFalse(Files.exists(projectRoot.resolve(".gradle/crap-java/root/crap-java-check/junit-report.path")));
+    }
+
+    @Test
+    void rememberedStateNamespacesSharedCustomProjectCacheByRootProject() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path sharedProjectCacheDir = projectRoot.resolve("shared-project-cache");
+        Path firstRoot = projectRoot.resolve("first");
+        Path secondRoot = projectRoot.resolve("second");
+        Files.createDirectories(firstRoot);
+        Files.createDirectories(secondRoot);
+        assumeHardLinksAvailable(projectRoot);
+        CrapJavaCheckTask firstTask = newCheckTask(firstRoot, "crap-java-check", sharedProjectCacheDir);
+        CrapJavaCheckTask secondTask = newCheckTask(secondRoot, "crap-java-check", sharedProjectCacheDir);
+
+        firstTask.runCheck();
+        secondTask.runCheck();
+
+        Path firstStatePath = junitReportStatePath(firstTask);
+        Path secondStatePath = junitReportStatePath(secondTask);
+        assertTrue(Files.exists(firstStatePath));
+        assertTrue(Files.exists(secondStatePath));
+        assertFalse(firstStatePath.equals(secondStatePath));
+        assertFalse(firstStatePath.getParent().getParent().getParent()
+                .equals(secondStatePath.getParent().getParent().getParent()));
     }
 
     @Test
@@ -982,10 +1035,13 @@ class CrapJavaGradlePluginTest {
         nestedTask.runCheck();
         rootNamedTask.runCheck();
 
-        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/%3Aa-b/crap-java-check/junit-report.path")));
-        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/%3Aa%3Ab/crap-java-check/junit-report.path")));
-        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/%3Aroot/crap-java-check/junit-report.path")));
-        assertFalse(Files.exists(projectCacheDir.resolve("crap-java/root/crap-java-check/junit-report.path")));
+        Path stateNamespace = junitReportStatePath(dashTask).getParent().getParent().getParent();
+        assertTrue(stateNamespace.startsWith(projectCacheDir.resolve("crap-java")));
+        assertTrue(stateNamespace.getFileName().toString().startsWith("workspace-"));
+        assertTrue(Files.exists(stateNamespace.resolve("%3Aa-b/crap-java-check/junit-report.path")));
+        assertTrue(Files.exists(stateNamespace.resolve("%3Aa%3Ab/crap-java-check/junit-report.path")));
+        assertTrue(Files.exists(stateNamespace.resolve("%3Aroot/crap-java-check/junit-report.path")));
+        assertFalse(Files.exists(stateNamespace.resolve("root/crap-java-check/junit-report.path")));
     }
 
     @Test
@@ -1127,6 +1183,16 @@ class CrapJavaGradlePluginTest {
 
     private CrapJavaCheckTask newCheckTask(Path projectRoot, String name) {
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        return newCheckTask(project, projectRoot, name);
+    }
+
+    private CrapJavaCheckTask newCheckTask(Path projectRoot, String name, Path projectCacheDir) {
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        project.getGradle().getStartParameter().setProjectCacheDir(projectCacheDir.toFile());
+        return newCheckTask(project, projectRoot, name);
+    }
+
+    private CrapJavaCheckTask newCheckTask(Project project, Path projectRoot, String name) {
         CrapJavaCheckTask task = project.getTasks().register(name, CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
@@ -1185,6 +1251,12 @@ class CrapJavaGradlePluginTest {
         Method stateLockPath = CrapJavaCheckTask.class.getDeclaredMethod("stateLockPath");
         stateLockPath.setAccessible(true);
         return (Path) stateLockPath.invoke(task);
+    }
+
+    private Path junitReportStatePath(CrapJavaCheckTask task) throws Exception {
+        Method junitReportStatePath = CrapJavaCheckTask.class.getDeclaredMethod("junitReportStatePath");
+        junitReportStatePath.setAccessible(true);
+        return (Path) junitReportStatePath.invoke(task);
     }
 
     private Path rememberedReportPath(CrapJavaCheckTask task, Path statePath) throws Exception {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -410,6 +410,20 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void runCheckRejectsOtherTaskInternalLockPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/root/other-task/state.lock").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
     void runCheckRejectsSubprojectInternalExecutionMarkerPath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Files.createDirectories(projectRoot.resolve("sub"));

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -595,6 +595,22 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void runCheckRejectsDanglingSymlinkedPrimaryAndJunitReportPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path report = projectRoot.resolve("reports/collision.xml");
+        Files.createDirectories(report.getParent());
+        Path outputLink = createFileSymlinkOrSkip(projectRoot.resolve("output-report.xml"), report);
+        Path junitLink = createFileSymlinkOrSkip(projectRoot.resolve("junit-report.xml"), report);
+        CrapJavaCheckTask task = newCheckTask(projectRoot);
+        task.getOutput().fileValue(outputLink.toFile());
+        task.getJunitReport().fileValue(junitLink.toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output and junitReport must not point to the same file"));
+    }
+
+    @Test
     void runCheckRejectsOtherTaskInternalStatePath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
@@ -749,6 +765,20 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void runCheckRejectsDanglingFileSymlinkAliasToInternalStatePath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path statePath = projectRoot.resolve(".gradle/crap-java/root/other-task/primary-output.path");
+        Files.createDirectories(statePath.getParent());
+        Path stateAlias = createFileSymlinkOrSkip(projectRoot.resolve("state-report.xml"), statePath);
+        CrapJavaCheckTask task = newCheckTask(projectRoot);
+        task.getOutput().fileValue(stateAlias.toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
     void runCheckRejectsFileSymlinkAliasToInternalExecutionMarkerPath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Path markerPath = projectRoot.resolve("build/tmp/crap-java/crap-java-check/execution.marker");
@@ -759,6 +789,20 @@ class CrapJavaGradlePluginTest {
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(markerAlias.toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
+    void runCheckRejectsDanglingFileSymlinkAliasToInternalExecutionMarkerPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path markerPath = projectRoot.resolve("build/tmp/crap-java/crap-java-check/execution.marker");
+        Files.createDirectories(markerPath.getParent());
+        Path markerAlias = createFileSymlinkOrSkip(projectRoot.resolve("marker-report.xml"), markerPath);
+        CrapJavaCheckTask task = newCheckTask(projectRoot);
         task.getOutput().fileValue(markerAlias.toFile());
 
         GradleException exception = assertThrows(GradleException.class, task::runCheck);

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -372,6 +372,26 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void failedJunitPublishRemembersWrittenPrimaryOutput() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path output = projectRoot.resolve("primary.json");
+        Path junitDirectory = projectRoot.resolve("junit-directory");
+        Files.createDirectories(junitDirectory);
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getFormat().set("json");
+        task.getOutput().fileValue(output.toFile());
+        task.getJunitReport().fileValue(junitDirectory.toFile());
+
+        assertThrows(Exception.class, task::runCheck);
+
+        assertTrue(Files.exists(output));
+        assertTrue(Files.exists(projectRoot.resolve(".gradle/crap-java/root/crap-java-check/primary-output.path")));
+    }
+
+    @Test
     void invalidReportPathDoesNotDeleteRememberedJunitSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -977,6 +978,17 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void rememberedStateIgnoresMalformedStoredPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path statePath = projectRoot.resolve(".gradle/crap-java/root/crap-java-check/primary-output.path");
+        Files.createDirectories(statePath.getParent());
+        Files.writeString(statePath, "\u0000\nlink\t1\t2\n");
+        CrapJavaCheckTask task = newCheckTask(projectRoot);
+
+        assertNull(rememberedReport(task, statePath));
+    }
+
+    @Test
     void disabledCustomTaskDoesNotDeleteUnownedDefaultSidecars() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
@@ -1132,13 +1144,17 @@ class CrapJavaGradlePluginTest {
     }
 
     private Path rememberedReportPath(CrapJavaCheckTask task, Path statePath) throws Exception {
-        Method rememberedReportPath = CrapJavaCheckTask.class.getDeclaredMethod("rememberedReportPath", Path.class);
-        rememberedReportPath.setAccessible(true);
-        Object rememberedReport = rememberedReportPath.invoke(task, statePath);
+        Object rememberedReport = rememberedReport(task, statePath);
         assertNotNull(rememberedReport);
         Method path = rememberedReport.getClass().getDeclaredMethod("path");
         path.setAccessible(true);
         return (Path) path.invoke(rememberedReport);
+    }
+
+    private Object rememberedReport(CrapJavaCheckTask task, Path statePath) throws Exception {
+        Method rememberedReportPath = CrapJavaCheckTask.class.getDeclaredMethod("rememberedReportPath", Path.class);
+        rememberedReportPath.setAccessible(true);
+        return rememberedReportPath.invoke(task, statePath);
     }
 
     private boolean isWindows() {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -360,6 +360,22 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void rememberedStateUsesGradleProjectCacheDir() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path projectCacheDir = projectRoot.resolve("custom-project-cache");
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        project.getGradle().getStartParameter().setProjectCacheDir(projectCacheDir.toFile());
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+
+        task.runCheck();
+
+        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/root/crap-java-check/junit-report.path")));
+        assertFalse(Files.exists(projectRoot.resolve(".gradle/crap-java/root/crap-java-check/junit-report.path")));
+    }
+
+    @Test
     void disabledCustomTaskDoesNotDeleteBuiltInTaskSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -106,6 +106,25 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void directlyRegisteredCheckTaskHasReportControlDefaults() {
+        Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+
+        CrapJavaCheckTask checkTask = project.getTasks().register("custom-crap-java-check", CrapJavaCheckTask.class).get();
+
+        assertEquals(8.0, checkTask.getThreshold().get());
+        assertFalse(checkTask.getAgent().get());
+        assertEquals("none", checkTask.getFormat().get());
+        assertFalse(checkTask.getFailuresOnly().get());
+        assertFalse(checkTask.getOmitRedundancy().get());
+        assertFalse(checkTask.getOutput().isPresent());
+        assertTrue(checkTask.getJunit().get());
+        assertTrue(checkTask.getJunitReport().get().getAsFile().toPath().normalize().toString()
+                .replace('\\', '/')
+                .endsWith("build/reports/crap-java/TEST-crap-java.xml"));
+        assertTrue(checkTask.getJunitReportOutput().isPresent());
+    }
+
+    @Test
     void agentExtensionComposesPrimaryDefaultsWhenControlsAreUnset() {
         Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
 
@@ -119,6 +138,20 @@ class CrapJavaGradlePluginTest {
         assertEquals("toon", extension.getFormat().get());
         assertTrue(extension.getFailuresOnly().get());
         assertTrue(extension.getOmitRedundancy().get());
+        assertEquals("toon", checkTask.getFormat().get());
+        assertTrue(checkTask.getFailuresOnly().get());
+        assertTrue(checkTask.getOmitRedundancy().get());
+    }
+
+    @Test
+    void agentTaskComposesPrimaryDefaultsWhenControlsAreUnset() {
+        Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+
+        project.getPluginManager().apply("java");
+        project.getPluginManager().apply(CrapJavaGradlePlugin.class);
+        CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
+        checkTask.getAgent().set(true);
+
         assertEquals("toon", checkTask.getFormat().get());
         assertTrue(checkTask.getFailuresOnly().get());
         assertTrue(checkTask.getOmitRedundancy().get());

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -268,7 +268,7 @@ class CrapJavaGradlePluginTest {
         task.runCheck();
 
         assertTrue(Files.exists(builtInJunit));
-        assertFalse(Files.exists(customJunit));
+        assertTrue(Files.exists(customJunit));
     }
 
     @Test

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -253,6 +253,42 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void movedJunitReportDeletesStaleDefaultSidecarWithoutRememberedState() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path defaultJunitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        Path customJunitReport = projectRoot.resolve("custom-junit.xml");
+        Files.createDirectories(defaultJunitReport.getParent());
+        Files.writeString(defaultJunitReport, "stale");
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getJunitReport().fileValue(customJunitReport.toFile());
+
+        task.runCheck();
+
+        assertTrue(Files.exists(customJunitReport));
+        assertFalse(Files.exists(defaultJunitReport));
+    }
+
+    @Test
+    void disabledJunitDeletesStaleDefaultSidecarWithoutRememberedState() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path defaultJunitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        Files.createDirectories(defaultJunitReport.getParent());
+        Files.writeString(defaultJunitReport, "stale");
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getJunit().set(false);
+
+        task.runCheck();
+
+        assertFalse(Files.exists(defaultJunitReport));
+    }
+
+    @Test
     void disabledJunitDeletesOwnedRememberedExternalSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
@@ -360,6 +396,20 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void runCheckRejectsOtherTaskInternalOwnerPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/other-task/primary-output.owner").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
     void rememberedStateUsesGradleProjectCacheDir() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Path projectCacheDir = projectRoot.resolve("custom-project-cache");
@@ -376,7 +426,44 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
-    void disabledCustomTaskDoesNotDeleteBuiltInTaskSidecar() throws Exception {
+    void rememberedStateEscapesProjectPathSeparators() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path projectCacheDir = projectRoot.resolve("custom-project-cache");
+        Project root = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        root.getGradle().getStartParameter().setProjectCacheDir(projectCacheDir.toFile());
+        Files.createDirectories(projectRoot.resolve("a-b"));
+        Files.createDirectories(projectRoot.resolve("a/b"));
+        Project dashProject = ProjectBuilder.builder()
+                .withName("a-b")
+                .withParent(root)
+                .withProjectDir(projectRoot.resolve("a-b").toFile())
+                .build();
+        Project nestedParent = ProjectBuilder.builder()
+                .withName("a")
+                .withParent(root)
+                .withProjectDir(projectRoot.resolve("a").toFile())
+                .build();
+        Project nestedProject = ProjectBuilder.builder()
+                .withName("b")
+                .withParent(nestedParent)
+                .withProjectDir(projectRoot.resolve("a/b").toFile())
+                .build();
+        CrapJavaCheckTask dashTask = dashProject.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        CrapJavaCheckTask nestedTask = nestedProject.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        dashTask.getAnalysisRoot().fileValue(projectRoot.toFile());
+        dashTask.getModuleCoverageReports().set(Map.of());
+        nestedTask.getAnalysisRoot().fileValue(projectRoot.toFile());
+        nestedTask.getModuleCoverageReports().set(Map.of());
+
+        dashTask.runCheck();
+        nestedTask.runCheck();
+
+        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/a-b/crap-java-check/junit-report.path")));
+        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/a%3Ab/crap-java-check/junit-report.path")));
+    }
+
+    @Test
+    void disabledCustomTaskOnlyDeletesOwnDefaultSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         Path builtInJunit = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
@@ -394,7 +481,7 @@ class CrapJavaGradlePluginTest {
         task.runCheck();
 
         assertTrue(Files.exists(builtInJunit));
-        assertTrue(Files.exists(customJunit));
+        assertFalse(Files.exists(customJunit));
     }
 
     @Test

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -250,6 +250,42 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void disabledJunitDeletesOwnedRememberedExternalSidecar() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path junitReport = projectRoot.resolve("outside-junit.xml");
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getJunitReport().fileValue(junitReport.toFile());
+        task.runCheck();
+        assertTrue(Files.exists(junitReport));
+
+        task.getJunit().set(false);
+        task.runCheck();
+
+        assertFalse(Files.exists(junitReport));
+    }
+
+    @Test
+    void disabledJunitKeepsRecreatedRememberedExternalSidecar() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path junitReport = projectRoot.resolve("outside-junit.xml");
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getJunitReport().fileValue(junitReport.toFile());
+        task.runCheck();
+        Files.writeString(junitReport, "unrelated");
+
+        task.getJunit().set(false);
+        task.runCheck();
+
+        assertEquals("unrelated", Files.readString(junitReport));
+    }
+
+    @Test
     void disabledCustomTaskDoesNotDeleteBuiltInTaskSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -523,6 +523,26 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void runCheckRejectsSubprojectInternalStatePathInRootCache() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Files.createDirectories(projectRoot.resolve("sub"));
+        Project root = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        ProjectBuilder.builder()
+                .withName("sub")
+                .withParent(root)
+                .withProjectDir(projectRoot.resolve("sub").toFile())
+                .build();
+        CrapJavaCheckTask task = root.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/sub/crap-java-check/state.lock").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
     void runCheckAllowsNormalReportPathWithInternalFileName() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
@@ -552,6 +572,27 @@ class CrapJavaGradlePluginTest {
 
         assertTrue(Files.exists(projectCacheDir.resolve("crap-java/root/crap-java-check/junit-report.path")));
         assertFalse(Files.exists(projectRoot.resolve(".gradle/crap-java/root/crap-java-check/junit-report.path")));
+    }
+
+    @Test
+    void rememberedStateFallsBackToRootProjectGradleDirForSubprojects() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path subprojectRoot = projectRoot.resolve("sub");
+        Files.createDirectories(subprojectRoot);
+        Project root = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Project subproject = ProjectBuilder.builder()
+                .withName("sub")
+                .withParent(root)
+                .withProjectDir(subprojectRoot.toFile())
+                .build();
+        CrapJavaCheckTask task = subproject.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+
+        task.runCheck();
+
+        assertTrue(Files.exists(projectRoot.resolve(".gradle/crap-java/sub/crap-java-check/junit-report.path")));
+        assertFalse(Files.exists(subprojectRoot.resolve(".gradle/crap-java/sub/crap-java-check/junit-report.path")));
     }
 
     @Test

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -35,7 +35,15 @@ class CrapJavaGradlePluginTest {
         assertEquals("verification", checkTask.getGroup());
         assertEquals("Runs the crap-java CRAP metric gate.", checkTask.getDescription());
         assertEquals(8.0, extension.getThreshold().get());
+        assertFalse(extension.getAgent().get());
+        assertTrue(extension.getJunit().get());
         assertEquals(8.0, checkTask.getThreshold().get());
+        assertEquals("none", checkTask.getFormat().get());
+        assertFalse(checkTask.getAgent().get());
+        assertFalse(checkTask.getFailuresOnly().get());
+        assertFalse(checkTask.getOmitRedundancy().get());
+        assertFalse(checkTask.getOutput().isPresent());
+        assertTrue(checkTask.getJunit().get());
         Set<String> dependencyNames = checkTask.getTaskDependencies().getDependencies(checkTask).stream()
                 .map(Task::getName)
                 .collect(Collectors.toSet());
@@ -58,6 +66,63 @@ class CrapJavaGradlePluginTest {
         CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
 
         assertEquals(6.0, checkTask.getThreshold().get());
+    }
+
+    @Test
+    void configuredExtensionReportControlsFlowToCheckTask() {
+        Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+
+        project.getPluginManager().apply("java");
+        project.getPluginManager().apply(CrapJavaGradlePlugin.class);
+        CrapJavaExtension extension = project.getExtensions().getByType(CrapJavaExtension.class);
+        Path output = tempDir.resolve("build/reports/crap-java/report.json");
+        Path junitReport = tempDir.resolve("build/reports/crap-java/custom-junit.xml");
+        extension.getFormat().set("json");
+        extension.getAgent().set(true);
+        extension.getFailuresOnly().set(false);
+        extension.getOmitRedundancy().set(true);
+        extension.getOutput().fileValue(output.toFile());
+        extension.getJunit().set(false);
+        extension.getJunitReport().fileValue(junitReport.toFile());
+
+        CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
+
+        assertEquals("json", checkTask.getFormat().get());
+        assertTrue(checkTask.getAgent().get());
+        assertFalse(checkTask.getFailuresOnly().get());
+        assertTrue(checkTask.getOmitRedundancy().get());
+        assertEquals(output.normalize(), checkTask.getOutput().get().getAsFile().toPath().normalize());
+        assertFalse(checkTask.getJunit().get());
+        assertEquals(junitReport.normalize(), checkTask.getJunitReport().get().getAsFile().toPath().normalize());
+    }
+
+    @Test
+    void agentExtensionComposesPrimaryDefaultsWhenControlsAreUnset() {
+        Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+
+        project.getPluginManager().apply("java");
+        project.getPluginManager().apply(CrapJavaGradlePlugin.class);
+        project.getExtensions().getByType(CrapJavaExtension.class).getAgent().set(true);
+
+        CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
+
+        assertEquals("toon", checkTask.getFormat().get());
+        assertTrue(checkTask.getFailuresOnly().get());
+        assertTrue(checkTask.getOmitRedundancy().get());
+    }
+
+    @Test
+    void taskAgentComposesPrimaryDefaultsWhenControlsAreUnset() {
+        Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+
+        project.getPluginManager().apply("java");
+        project.getPluginManager().apply(CrapJavaGradlePlugin.class);
+        CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
+        checkTask.getAgent().set(true);
+
+        assertEquals("toon", checkTask.getFormat().get());
+        assertTrue(checkTask.getFailuresOnly().get());
+        assertTrue(checkTask.getOmitRedundancy().get());
     }
 
     @Test
@@ -96,6 +161,11 @@ class CrapJavaGradlePluginTest {
         task.getCoverageReports().from(jacocoXml);
         task.getModuleCoverageReports().put(".", "build/reports/jacoco/test/jacocoTestReport.xml");
         task.getThreshold().set(8.0);
+        task.getFormat().set("none");
+        task.getAgent().set(false);
+        task.getFailuresOnly().set(false);
+        task.getOmitRedundancy().set(false);
+        task.getJunit().set(true);
         Path junitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
         task.getJunitReport().fileValue(junitReport.toFile());
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -532,7 +532,7 @@ class CrapJavaGradlePluginTest {
 
         assertThrows(Exception.class, secondTask::runCheck);
         assertTrue(Files.exists(oldOutput));
-        assertTrue(Files.exists(replacementOutput));
+        assertFalse(Files.exists(replacementOutput));
 
         CrapJavaCheckTask thirdTask = newCheckTask(projectRoot);
         thirdTask.getFormat().set("json");

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -359,7 +359,7 @@ class CrapJavaGradlePluginTest {
         assertTrue(Files.exists(junitReport));
 
         task.getJunit().set(false);
-        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/other-task/primary-output.path").toFile());
+        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/root/other-task/primary-output.path").toFile());
 
         GradleException exception = assertThrows(GradleException.class, task::runCheck);
 
@@ -374,7 +374,7 @@ class CrapJavaGradlePluginTest {
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
-        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/other-task/primary-output.path").toFile());
+        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/root/other-task/primary-output.path").toFile());
 
         GradleException exception = assertThrows(GradleException.class, task::runCheck);
 
@@ -388,7 +388,7 @@ class CrapJavaGradlePluginTest {
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
-        task.getJunitReport().fileValue(projectRoot.resolve(".gradle/crap-java/other-task/junit-report.path").toFile());
+        task.getJunitReport().fileValue(projectRoot.resolve(".gradle/crap-java/root/other-task/junit-report.path").toFile());
 
         GradleException exception = assertThrows(GradleException.class, task::runCheck);
 
@@ -402,11 +402,49 @@ class CrapJavaGradlePluginTest {
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
-        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/other-task/primary-output.owner").toFile());
+        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/root/other-task/primary-output.owner").toFile());
 
         GradleException exception = assertThrows(GradleException.class, task::runCheck);
 
         assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
+    void runCheckRejectsSubprojectInternalExecutionMarkerPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Files.createDirectories(projectRoot.resolve("sub"));
+        Project root = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Project subproject = ProjectBuilder.builder()
+                .withName("sub")
+                .withParent(root)
+                .withProjectDir(projectRoot.resolve("sub").toFile())
+                .build();
+        CrapJavaCheckTask task = root.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(subproject.getLayout().getBuildDirectory().get().getAsFile().toPath()
+                .resolve("tmp/crap-java/crap-java-check/execution.marker")
+                .toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
+    void runCheckAllowsNormalReportPathWithInternalFileName() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path output = projectRoot.resolve("reports/crap-java/primary-output.path");
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getFormat().set("json");
+        task.getOutput().fileValue(output.toFile());
+
+        task.runCheck();
+
+        assertTrue(Files.exists(output));
     }
 
     @Test

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -842,8 +842,8 @@ class CrapJavaGradlePluginTest {
 
         task.runCheck();
 
-        assertTrue(Files.exists(projectRoot.resolve(".gradle/crap-java/sub/crap-java-check/junit-report.path")));
-        assertFalse(Files.exists(subprojectRoot.resolve(".gradle/crap-java/sub/crap-java-check/junit-report.path")));
+        assertTrue(Files.exists(projectRoot.resolve(".gradle/crap-java/%3Asub/crap-java-check/junit-report.path")));
+        assertFalse(Files.exists(subprojectRoot.resolve(".gradle/crap-java/%3Asub/crap-java-check/junit-report.path")));
     }
 
     @Test
@@ -855,6 +855,7 @@ class CrapJavaGradlePluginTest {
         root.getGradle().getStartParameter().setProjectCacheDir(projectCacheDir.toFile());
         Files.createDirectories(projectRoot.resolve("a-b"));
         Files.createDirectories(projectRoot.resolve("a/b"));
+        Files.createDirectories(projectRoot.resolve("root"));
         Project dashProject = ProjectBuilder.builder()
                 .withName("a-b")
                 .withParent(root)
@@ -870,18 +871,46 @@ class CrapJavaGradlePluginTest {
                 .withParent(nestedParent)
                 .withProjectDir(projectRoot.resolve("a/b").toFile())
                 .build();
+        Project rootNamedProject = ProjectBuilder.builder()
+                .withName("root")
+                .withParent(root)
+                .withProjectDir(projectRoot.resolve("root").toFile())
+                .build();
         CrapJavaCheckTask dashTask = dashProject.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         CrapJavaCheckTask nestedTask = nestedProject.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        CrapJavaCheckTask rootNamedTask = rootNamedProject.getTasks()
+                .register("crap-java-check", CrapJavaCheckTask.class)
+                .get();
         dashTask.getAnalysisRoot().fileValue(projectRoot.toFile());
         dashTask.getModuleCoverageReports().set(Map.of());
         nestedTask.getAnalysisRoot().fileValue(projectRoot.toFile());
         nestedTask.getModuleCoverageReports().set(Map.of());
+        rootNamedTask.getAnalysisRoot().fileValue(projectRoot.toFile());
+        rootNamedTask.getModuleCoverageReports().set(Map.of());
 
         dashTask.runCheck();
         nestedTask.runCheck();
+        rootNamedTask.runCheck();
 
-        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/a-b/crap-java-check/junit-report.path")));
-        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/a%3Ab/crap-java-check/junit-report.path")));
+        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/%3Aa-b/crap-java-check/junit-report.path")));
+        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/%3Aa%3Ab/crap-java-check/junit-report.path")));
+        assertTrue(Files.exists(projectCacheDir.resolve("crap-java/%3Aroot/crap-java-check/junit-report.path")));
+        assertFalse(Files.exists(projectCacheDir.resolve("crap-java/root/crap-java-check/junit-report.path")));
+    }
+
+    @Test
+    void rememberedStatePreservesTrailingSpacesInStoredPath() throws Exception {
+        assumeTrue(!isWindows(), "Windows does not support filenames ending with spaces");
+        Path projectRoot = tempDir.toRealPath();
+        Path statePath = projectRoot.resolve(".gradle/crap-java/root/crap-java-check/primary-output.path");
+        Path storedPath = projectRoot.resolve("report.json ");
+        Files.createDirectories(statePath.getParent());
+        Files.writeString(statePath, storedPath + "\nlink\t1\t2\n");
+        CrapJavaCheckTask task = newCheckTask(projectRoot);
+
+        Path rememberedPath = rememberedReportPath(task, statePath);
+
+        assertEquals(storedPath.toAbsolutePath().normalize(), rememberedPath);
     }
 
     @Test
@@ -1030,6 +1059,16 @@ class CrapJavaGradlePluginTest {
         return (Path) stateLockPath.invoke(task);
     }
 
+    private Path rememberedReportPath(CrapJavaCheckTask task, Path statePath) throws Exception {
+        Method rememberedReportPath = CrapJavaCheckTask.class.getDeclaredMethod("rememberedReportPath", Path.class);
+        rememberedReportPath.setAccessible(true);
+        Object rememberedReport = rememberedReportPath.invoke(task, statePath);
+        assertNotNull(rememberedReport);
+        Method path = rememberedReport.getClass().getDeclaredMethod("path");
+        path.setAccessible(true);
+        return (Path) path.invoke(rememberedReport);
+    }
+
     private boolean isCaseInsensitiveFileSystem(Path directory) throws Exception {
         Path probe = Files.createTempFile(directory, ".crap-java-case-", ".tmp");
         try {
@@ -1038,6 +1077,10 @@ class CrapJavaGradlePluginTest {
         } finally {
             Files.deleteIfExists(probe);
         }
+    }
+
+    private boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
     }
 }
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -298,9 +299,10 @@ class CrapJavaGradlePluginTest {
         task.getJunitReport().fileValue(junitReport.toFile());
         task.runCheck();
         String originalReport = Files.readString(junitReport);
+        FileTime originalModified = Files.getLastModifiedTime(junitReport);
         Files.delete(junitReport);
-        Thread.sleep(20);
         Files.writeString(junitReport, originalReport);
+        Files.setLastModifiedTime(junitReport, FileTime.fromMillis(originalModified.toMillis() + 5_000));
 
         task.getJunit().set(false);
         task.runCheck();

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -259,13 +259,13 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
-    void movedJunitReportDeletesStaleDefaultSidecarWithoutRememberedState() throws Exception {
+    void movedJunitReportDoesNotDeleteUnownedDefaultSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         Path defaultJunitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
         Path customJunitReport = projectRoot.resolve("custom-junit.xml");
         Files.createDirectories(defaultJunitReport.getParent());
-        Files.writeString(defaultJunitReport, "stale");
+        Files.writeString(defaultJunitReport, "user-managed");
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
@@ -274,22 +274,56 @@ class CrapJavaGradlePluginTest {
         task.runCheck();
 
         assertTrue(Files.exists(customJunitReport));
-        assertFalse(Files.exists(defaultJunitReport));
+        assertEquals("user-managed", Files.readString(defaultJunitReport));
     }
 
     @Test
-    void disabledJunitDeletesStaleDefaultSidecarWithoutRememberedState() throws Exception {
+    void disabledJunitDoesNotDeleteUnownedDefaultSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         Path defaultJunitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
         Files.createDirectories(defaultJunitReport.getParent());
-        Files.writeString(defaultJunitReport, "stale");
+        Files.writeString(defaultJunitReport, "user-managed");
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
         task.getJunit().set(false);
 
         task.runCheck();
+
+        assertEquals("user-managed", Files.readString(defaultJunitReport));
+    }
+
+    @Test
+    void movedJunitReportDeletesOwnedRememberedDefaultSidecar() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path defaultJunitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        Path customJunitReport = projectRoot.resolve("custom-junit.xml");
+        CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
+        firstTask.runCheck();
+        assertTrue(Files.exists(defaultJunitReport));
+
+        CrapJavaCheckTask secondTask = newCheckTask(projectRoot);
+        secondTask.getJunitReport().fileValue(customJunitReport.toFile());
+
+        secondTask.runCheck();
+
+        assertTrue(Files.exists(customJunitReport));
+        assertFalse(Files.exists(defaultJunitReport));
+    }
+
+    @Test
+    void disabledJunitDeletesOwnedRememberedDefaultSidecar() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path defaultJunitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
+        firstTask.runCheck();
+        assertTrue(Files.exists(defaultJunitReport));
+
+        CrapJavaCheckTask secondTask = newCheckTask(projectRoot);
+        secondTask.getJunit().set(false);
+
+        secondTask.runCheck();
 
         assertFalse(Files.exists(defaultJunitReport));
     }
@@ -448,6 +482,27 @@ class CrapJavaGradlePluginTest {
 
         assertTrue(exception.getMessage().contains("Threshold must be a finite number greater than 0"));
         assertTrue(Files.exists(output));
+    }
+
+    @Test
+    void failedReplacementOutputDoesNotDeleteRememberedOutput() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path oldOutput = projectRoot.resolve("outside-report.json");
+        Path replacementOutput = projectRoot.resolve("replacement-report.json");
+        CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
+        firstTask.getFormat().set("json");
+        firstTask.getOutput().fileValue(oldOutput.toFile());
+        firstTask.runCheck();
+        assertTrue(Files.exists(oldOutput));
+        Files.createDirectories(replacementOutput);
+
+        CrapJavaCheckTask secondTask = newCheckTask(projectRoot);
+        secondTask.getFormat().set("json");
+        secondTask.getOutput().fileValue(replacementOutput.toFile());
+
+        assertThrows(Exception.class, secondTask::runCheck);
+
+        assertTrue(Files.exists(oldOutput));
     }
 
     @Test
@@ -752,7 +807,7 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
-    void disabledCustomTaskOnlyDeletesOwnDefaultSidecar() throws Exception {
+    void disabledCustomTaskDoesNotDeleteUnownedDefaultSidecars() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         Path builtInJunit = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
@@ -768,6 +823,34 @@ class CrapJavaGradlePluginTest {
         task.getJunit().set(false);
 
         task.runCheck();
+
+        assertTrue(Files.exists(builtInJunit));
+        assertEquals("<testsuites tests=\"2\"/>", Files.readString(customJunit));
+    }
+
+    @Test
+    void disabledCustomTaskOnlyDeletesOwnedDefaultSidecar() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path builtInJunit = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        Path customJunit = projectRoot.resolve("build/reports/crap-java/custom-crap-java-check/TEST-crap-java.xml");
+        Files.createDirectories(builtInJunit.getParent());
+        Files.writeString(builtInJunit, "<testsuites tests=\"1\"/>");
+        CrapJavaCheckTask firstTask = project.getTasks().register("custom-crap-java-check", CrapJavaCheckTask.class).get();
+        firstTask.getAnalysisRoot().fileValue(projectRoot.toFile());
+        firstTask.getModuleCoverageReports().set(Map.of());
+        firstTask.runCheck();
+        assertTrue(Files.exists(customJunit));
+
+        Project secondProject = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask secondTask = secondProject.getTasks()
+                .register("custom-crap-java-check", CrapJavaCheckTask.class)
+                .get();
+        secondTask.getAnalysisRoot().fileValue(projectRoot.toFile());
+        secondTask.getModuleCoverageReports().set(Map.of());
+        secondTask.getJunit().set(false);
+
+        secondTask.runCheck();
 
         assertTrue(Files.exists(builtInJunit));
         assertFalse(Files.exists(customJunit));

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -665,43 +666,33 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
-    void runCheckHandlesCaseOnlyInternalExecutionMarkerPathByFileSystem() throws Exception {
+    void runCheckRejectsInternalExecutionMarkerRootPath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
-        Path markerPath = projectRoot.resolve("build/tmp/crap-java/crap-java-check/EXECUTION.MARKER");
-        Files.createDirectories(markerPath.getParent());
+        Path markerPath = projectRoot.resolve("build/tmp/crap-java/crap-java-check/report.xml");
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
         task.getOutput().fileValue(markerPath.toFile());
 
-        if (isCaseInsensitiveFileSystem(projectRoot)) {
-            GradleException exception = assertThrows(GradleException.class, task::runCheck);
-            assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
-        } else {
-            task.runCheck();
-            assertTrue(Files.exists(markerPath));
-        }
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
     }
 
     @Test
-    void runCheckHandlesCaseOnlyInternalStatePathByFileSystem() throws Exception {
+    void runCheckRejectsInternalStateRootPath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
-        Path statePath = projectRoot.resolve(".gradle/crap-java/root/other-task/PRIMARY-OUTPUT.PATH");
-        Files.createDirectories(statePath.getParent());
+        Path statePath = projectRoot.resolve(".gradle/crap-java/root/other-task/report.xml");
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
         CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
         task.getOutput().fileValue(statePath.toFile());
 
-        if (isCaseInsensitiveFileSystem(projectRoot)) {
-            GradleException exception = assertThrows(GradleException.class, task::runCheck);
-            assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
-        } else {
-            task.runCheck();
-            assertTrue(Files.exists(statePath));
-        }
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
     }
 
     @Test
@@ -732,6 +723,60 @@ class CrapJavaGradlePluginTest {
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
         task.getOutput().fileValue(markerAlias.resolve("crap-java-check/execution.marker").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
+    void runCheckRejectsFileSymlinkAliasToInternalStatePath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path statePath = projectRoot.resolve(".gradle/crap-java/root/other-task/primary-output.path");
+        Files.createDirectories(statePath.getParent());
+        Files.writeString(statePath, "state");
+        Path stateAlias = createFileSymlinkOrSkip(projectRoot.resolve("state-report.xml"), statePath);
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(stateAlias.toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
+    void runCheckRejectsFileSymlinkAliasToInternalExecutionMarkerPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path markerPath = projectRoot.resolve("build/tmp/crap-java/crap-java-check/execution.marker");
+        Files.createDirectories(markerPath.getParent());
+        Files.writeString(markerPath, "ok");
+        Path markerAlias = createFileSymlinkOrSkip(projectRoot.resolve("marker-report.xml"), markerPath);
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(markerAlias.toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
+    void runCheckRejectsHardLinkAliasToInternalStatePath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path statePath = projectRoot.resolve(".gradle/crap-java/root/other-task/primary-output.path");
+        Files.createDirectories(statePath.getParent());
+        Files.writeString(statePath, "state");
+        Path stateAlias = createHardLinkOrSkip(projectRoot.resolve("state-report.xml"), statePath);
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(stateAlias.toFile());
 
         GradleException exception = assertThrows(GradleException.class, task::runCheck);
 
@@ -914,6 +959,24 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void rememberedStatePreservesNewlinesInStoredPath() throws Exception {
+        assumeTrue(!isWindows(), "Windows does not support filenames containing newlines");
+        Path projectRoot = tempDir.toRealPath();
+        Path output = projectRoot.resolve("report\nname.json");
+        Path statePath = projectRoot.resolve(".gradle/crap-java/root/crap-java-check/primary-output.path");
+        CrapJavaCheckTask task = newCheckTask(projectRoot);
+        task.getFormat().set("json");
+        task.getOutput().fileValue(output.toFile());
+
+        task.runCheck();
+
+        List<String> lines = Files.readAllLines(statePath);
+        assertEquals(2, lines.size());
+        assertTrue(lines.get(0).startsWith("path-base64\t"));
+        assertEquals(output.toAbsolutePath().normalize(), rememberedReportPath(task, statePath));
+    }
+
+    @Test
     void disabledCustomTaskDoesNotDeleteUnownedDefaultSidecars() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
@@ -993,6 +1056,15 @@ class CrapJavaGradlePluginTest {
         }
     }
 
+    private Path createFileSymlinkOrSkip(Path link, Path target) throws Exception {
+        try {
+            return Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | IOException | SecurityException exception) {
+            assumeTrue(false, "File symbolic links are unavailable: " + exception.getMessage());
+            return link;
+        }
+    }
+
     private CrapJavaCheckTask newCheckTask(Path projectRoot) {
         return newCheckTask(projectRoot, "crap-java-check");
     }
@@ -1067,16 +1139,6 @@ class CrapJavaGradlePluginTest {
         Method path = rememberedReport.getClass().getDeclaredMethod("path");
         path.setAccessible(true);
         return (Path) path.invoke(rememberedReport);
-    }
-
-    private boolean isCaseInsensitiveFileSystem(Path directory) throws Exception {
-        Path probe = Files.createTempFile(directory, ".crap-java-case-", ".tmp");
-        try {
-            Path variant = probe.resolveSibling(probe.getFileName().toString().toUpperCase(Locale.ROOT));
-            return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
-        } finally {
-            Files.deleteIfExists(probe);
-        }
     }
 
     private boolean isWindows() {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -506,6 +506,62 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void failedMovedJunitReplacementDoesNotForgetRememberedOutput() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path oldOutput = projectRoot.resolve("outside-report.json");
+        Path replacementOutput = projectRoot.resolve("replacement-report.json");
+        Path badJunitReport = projectRoot.resolve("bad-junit.xml");
+        CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
+        firstTask.getFormat().set("json");
+        firstTask.getOutput().fileValue(oldOutput.toFile());
+        firstTask.runCheck();
+        assertTrue(Files.exists(oldOutput));
+        Files.createDirectories(badJunitReport);
+
+        CrapJavaCheckTask secondTask = newCheckTask(projectRoot);
+        secondTask.getFormat().set("json");
+        secondTask.getOutput().fileValue(replacementOutput.toFile());
+        secondTask.getJunitReport().fileValue(badJunitReport.toFile());
+
+        assertThrows(Exception.class, secondTask::runCheck);
+        assertTrue(Files.exists(oldOutput));
+        assertTrue(Files.exists(replacementOutput));
+
+        CrapJavaCheckTask thirdTask = newCheckTask(projectRoot);
+        thirdTask.getFormat().set("json");
+        thirdTask.getOutput().fileValue(replacementOutput.toFile());
+
+        thirdTask.runCheck();
+
+        assertFalse(Files.exists(oldOutput));
+        assertTrue(Files.exists(replacementOutput));
+    }
+
+    @Test
+    void movedOutputDoesNotDeleteReportStillOwnedByAnotherTask() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path sharedOutput = projectRoot.resolve("shared-report.json");
+        Path movedOutput = projectRoot.resolve("moved-report.json");
+        CrapJavaCheckTask firstTask = newCheckTask(projectRoot, "first-crap-java-check");
+        firstTask.getFormat().set("json");
+        firstTask.getOutput().fileValue(sharedOutput.toFile());
+        firstTask.runCheck();
+        CrapJavaCheckTask secondTask = newCheckTask(projectRoot, "second-crap-java-check");
+        secondTask.getFormat().set("json");
+        secondTask.getOutput().fileValue(sharedOutput.toFile());
+        secondTask.runCheck();
+
+        CrapJavaCheckTask movedFirstTask = newCheckTask(projectRoot, "first-crap-java-check");
+        movedFirstTask.getFormat().set("json");
+        movedFirstTask.getOutput().fileValue(movedOutput.toFile());
+
+        movedFirstTask.runCheck();
+
+        assertTrue(Files.exists(sharedOutput));
+        assertTrue(Files.exists(movedOutput));
+    }
+
+    @Test
     void aliasedFutureReportPathCollisionDoesNotDeleteRememberedOutput() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Path output = projectRoot.resolve("outside-report.json");
@@ -886,8 +942,12 @@ class CrapJavaGradlePluginTest {
     }
 
     private CrapJavaCheckTask newCheckTask(Path projectRoot) {
+        return newCheckTask(projectRoot, "crap-java-check");
+    }
+
+    private CrapJavaCheckTask newCheckTask(Path projectRoot, String name) {
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
-        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        CrapJavaCheckTask task = project.getTasks().register(name, CrapJavaCheckTask.class).get();
         task.getAnalysisRoot().fileValue(projectRoot.toFile());
         task.getModuleCoverageReports().set(Map.of());
         return task;

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -7,6 +7,7 @@ import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class CrapJavaGradlePluginTest {
 
@@ -424,6 +426,40 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void runCheckRejectsSymlinkedInternalStatePath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path stateRoot = projectRoot.resolve(".gradle/crap-java/root/other-task");
+        Files.createDirectories(stateRoot);
+        Path stateAlias = createDirectorySymlinkOrSkip(projectRoot.resolve("state-alias"), stateRoot);
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(stateAlias.resolve("primary-output.path").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
+    void runCheckRejectsSymlinkedInternalExecutionMarkerPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path markerRoot = projectRoot.resolve("build/tmp/crap-java");
+        Files.createDirectories(markerRoot.resolve("crap-java-check"));
+        Path markerAlias = createDirectorySymlinkOrSkip(projectRoot.resolve("marker-alias"), markerRoot);
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(markerAlias.resolve("crap-java-check/execution.marker").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
     void runCheckRejectsSubprojectInternalExecutionMarkerPath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Files.createDirectories(projectRoot.resolve("sub"));
@@ -554,6 +590,15 @@ class CrapJavaGradlePluginTest {
     @Test
     void modulePathDoesNotMatchPartialPathSegment() {
         assertFalse(CrapJavaCheckTask.matchesModulePath("application/src/main/java/demo/Sample.java", "app"));
+    }
+
+    private Path createDirectorySymlinkOrSkip(Path link, Path target) throws Exception {
+        try {
+            return Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | IOException | SecurityException exception) {
+            assumeTrue(false, "Directory symbolic links are unavailable: " + exception.getMessage());
+            return link;
+        }
     }
 }
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -1,5 +1,6 @@
 package media.barney.crap.gradle;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -15,6 +16,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CrapJavaGradlePluginTest {
@@ -283,6 +285,41 @@ class CrapJavaGradlePluginTest {
         task.runCheck();
 
         assertEquals("unrelated", Files.readString(junitReport));
+    }
+
+    @Test
+    void disabledJunitKeepsRecreatedIdenticalRememberedExternalSidecar() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path junitReport = projectRoot.resolve("outside-junit.xml");
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getJunitReport().fileValue(junitReport.toFile());
+        task.runCheck();
+        String originalReport = Files.readString(junitReport);
+        Files.delete(junitReport);
+        Thread.sleep(20);
+        Files.writeString(junitReport, originalReport);
+
+        task.getJunit().set(false);
+        task.runCheck();
+
+        assertEquals(originalReport, Files.readString(junitReport));
+    }
+
+    @Test
+    void runCheckRejectsOtherTaskInternalStatePath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(projectRoot.resolve(".gradle/crap-java/other-task/primary-output.path").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
     }
 
     @Test

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -8,12 +8,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -350,6 +353,25 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void movedOutputDoesNotDeleteCurrentJunitReportAtPreviousOutputPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path sharedReport = projectRoot.resolve("shared-report.xml");
+        Files.writeString(sharedReport, "<testsuites tests=\"0\"/>");
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        rememberOwnedReport(
+                projectRoot.resolve(".gradle/crap-java/root/crap-java-check/primary-output.path"),
+                sharedReport
+        );
+
+        invokeCleanupStaleReports(task, null, sharedReport);
+
+        assertTrue(Files.exists(sharedReport));
+    }
+
+    @Test
     void invalidReportPathDoesNotDeleteRememberedJunitSidecar() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
@@ -424,6 +446,22 @@ class CrapJavaGradlePluginTest {
         GradleException exception = assertThrows(GradleException.class, task::runCheck);
 
         assertTrue(exception.getMessage().contains("output must not point to a crap-java internal task file"));
+    }
+
+    @Test
+    void runCheckRejectsRootReportPath() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path root = projectRoot.getRoot();
+        assumeTrue(root != null, "Filesystem root is unavailable");
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getOutput().fileValue(root.toFile());
+
+        GradleException exception = assertThrows(GradleException.class, task::runCheck);
+
+        assertTrue(exception.getMessage().contains("output must not point to a filesystem root"));
     }
 
     @Test
@@ -681,6 +719,34 @@ class CrapJavaGradlePluginTest {
             assumeTrue(false, "Directory symbolic links are unavailable: " + exception.getMessage());
             return link;
         }
+    }
+
+    private void rememberOwnedReport(Path statePath, Path reportPath) throws Exception {
+        Files.createDirectories(statePath.getParent());
+        Path ownerPath = statePath.resolveSibling("primary-output.owner");
+        Files.createLink(ownerPath, reportPath);
+        Files.writeString(statePath, reportPath + "\n" + ownership(reportPath) + "\n");
+    }
+
+    private String ownership(Path reportPath) throws Exception {
+        BasicFileAttributes attributes = Files.readAttributes(reportPath, BasicFileAttributes.class);
+        return "link\t"
+                + attributes.lastModifiedTime().to(TimeUnit.NANOSECONDS) + "\t"
+                + attributes.size();
+    }
+
+    private void invokeCleanupStaleReports(
+            CrapJavaCheckTask task,
+            Path currentOutputPath,
+            Path currentJunitReportPath
+    ) throws Exception {
+        Method cleanup = CrapJavaCheckTask.class.getDeclaredMethod(
+                "cleanupStaleReports",
+                Path.class,
+                Path.class
+        );
+        cleanup.setAccessible(true);
+        cleanup.invoke(task, currentOutputPath, currentJunitReportPath);
     }
 
     private boolean isCaseInsensitiveFileSystem(Path directory) throws Exception {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -413,6 +413,67 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void invalidFormatDoesNotDeleteRememberedOutput() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path output = projectRoot.resolve("outside-report.json");
+        CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
+        firstTask.getFormat().set("json");
+        firstTask.getOutput().fileValue(output.toFile());
+        firstTask.runCheck();
+        assertTrue(Files.exists(output));
+
+        CrapJavaCheckTask secondTask = newCheckTask(projectRoot);
+        secondTask.getFormat().set("invalid");
+
+        GradleException exception = assertThrows(GradleException.class, secondTask::runCheck);
+
+        assertTrue(exception.getMessage().contains("Unknown report format: invalid"));
+        assertTrue(Files.exists(output));
+    }
+
+    @Test
+    void invalidThresholdDoesNotDeleteRememberedOutput() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path output = projectRoot.resolve("outside-report.json");
+        CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
+        firstTask.getFormat().set("json");
+        firstTask.getOutput().fileValue(output.toFile());
+        firstTask.runCheck();
+        assertTrue(Files.exists(output));
+
+        CrapJavaCheckTask secondTask = newCheckTask(projectRoot);
+        secondTask.getThreshold().set(0.0);
+
+        GradleException exception = assertThrows(GradleException.class, secondTask::runCheck);
+
+        assertTrue(exception.getMessage().contains("Threshold must be a finite number greater than 0"));
+        assertTrue(Files.exists(output));
+    }
+
+    @Test
+    void aliasedFutureReportPathCollisionDoesNotDeleteRememberedOutput() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Path output = projectRoot.resolve("outside-report.json");
+        CrapJavaCheckTask firstTask = newCheckTask(projectRoot);
+        firstTask.getFormat().set("json");
+        firstTask.getOutput().fileValue(output.toFile());
+        firstTask.runCheck();
+        assertTrue(Files.exists(output));
+
+        Path reportDirectory = projectRoot.resolve("reports");
+        Files.createDirectories(reportDirectory);
+        Path reportAlias = createDirectorySymlinkOrSkip(projectRoot.resolve("reports-alias"), reportDirectory);
+        CrapJavaCheckTask secondTask = newCheckTask(projectRoot);
+        secondTask.getOutput().fileValue(reportDirectory.resolve("collision.xml").toFile());
+        secondTask.getJunitReport().fileValue(reportAlias.resolve("collision.xml").toFile());
+
+        GradleException exception = assertThrows(GradleException.class, secondTask::runCheck);
+
+        assertTrue(exception.getMessage().contains("output and junitReport must not point to the same file"));
+        assertTrue(Files.exists(output));
+    }
+
+    @Test
     void runCheckRejectsOtherTaskInternalStatePath() throws Exception {
         Path projectRoot = tempDir.toRealPath();
         Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
@@ -739,6 +800,14 @@ class CrapJavaGradlePluginTest {
             assumeTrue(false, "Directory symbolic links are unavailable: " + exception.getMessage());
             return link;
         }
+    }
+
+    private CrapJavaCheckTask newCheckTask(Path projectRoot) {
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        return task;
     }
 
     private void rememberOwnedReport(Path statePath, Path reportPath) throws Exception {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -36,7 +36,14 @@ class CrapJavaGradlePluginTest {
         assertEquals("Runs the crap-java CRAP metric gate.", checkTask.getDescription());
         assertEquals(8.0, extension.getThreshold().get());
         assertFalse(extension.getAgent().get());
+        assertEquals("none", extension.getFormat().get());
+        assertFalse(extension.getFailuresOnly().get());
+        assertFalse(extension.getOmitRedundancy().get());
+        assertFalse(extension.getOutput().isPresent());
         assertTrue(extension.getJunit().get());
+        assertTrue(extension.getJunitReport().get().getAsFile().toPath().normalize().toString()
+                .replace('\\', '/')
+                .endsWith("build/reports/crap-java/TEST-crap-java.xml"));
         assertEquals(8.0, checkTask.getThreshold().get());
         assertEquals("none", checkTask.getFormat().get());
         assertFalse(checkTask.getAgent().get());
@@ -52,6 +59,7 @@ class CrapJavaGradlePluginTest {
         assertTrue(checkTask.getJunitReport().get().getAsFile().toPath().normalize().toString()
                 .replace('\\', '/')
                 .endsWith("build/reports/crap-java/TEST-crap-java.xml"));
+        assertTrue(checkTask.getJunitReportOutput().isPresent());
         assertNotNull(project.getTasks().findByName("jacocoTestReport"));
     }
 
@@ -94,6 +102,7 @@ class CrapJavaGradlePluginTest {
         assertEquals(output.normalize(), checkTask.getOutput().get().getAsFile().toPath().normalize());
         assertFalse(checkTask.getJunit().get());
         assertEquals(junitReport.normalize(), checkTask.getJunitReport().get().getAsFile().toPath().normalize());
+        assertFalse(checkTask.getJunitReportOutput().isPresent());
     }
 
     @Test
@@ -105,24 +114,41 @@ class CrapJavaGradlePluginTest {
         project.getExtensions().getByType(CrapJavaExtension.class).getAgent().set(true);
 
         CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
+        CrapJavaExtension extension = project.getExtensions().getByType(CrapJavaExtension.class);
 
+        assertEquals("toon", extension.getFormat().get());
+        assertTrue(extension.getFailuresOnly().get());
+        assertTrue(extension.getOmitRedundancy().get());
         assertEquals("toon", checkTask.getFormat().get());
         assertTrue(checkTask.getFailuresOnly().get());
         assertTrue(checkTask.getOmitRedundancy().get());
     }
 
     @Test
-    void taskAgentComposesPrimaryDefaultsWhenControlsAreUnset() {
+    void configuredTaskReportControlsOverrideExtensionDefaults() {
         Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
 
         project.getPluginManager().apply("java");
         project.getPluginManager().apply(CrapJavaGradlePlugin.class);
         CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
+        Path output = tempDir.resolve("build/reports/crap-java/task-report.json");
+        Path junitReport = tempDir.resolve("build/reports/crap-java/task-junit.xml");
         checkTask.getAgent().set(true);
+        checkTask.getFormat().set("json");
+        checkTask.getFailuresOnly().set(false);
+        checkTask.getOmitRedundancy().set(true);
+        checkTask.getOutput().fileValue(output.toFile());
+        checkTask.getJunit().set(false);
+        checkTask.getJunitReport().fileValue(junitReport.toFile());
 
-        assertEquals("toon", checkTask.getFormat().get());
-        assertTrue(checkTask.getFailuresOnly().get());
+        assertEquals("json", checkTask.getFormat().get());
+        assertTrue(checkTask.getAgent().get());
+        assertFalse(checkTask.getFailuresOnly().get());
         assertTrue(checkTask.getOmitRedundancy().get());
+        assertEquals(output.normalize(), checkTask.getOutput().get().getAsFile().toPath().normalize());
+        assertFalse(checkTask.getJunit().get());
+        assertEquals(junitReport.normalize(), checkTask.getJunitReport().get().getAsFile().toPath().normalize());
+        assertFalse(checkTask.getJunitReportOutput().isPresent());
     }
 
     @Test

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -250,6 +250,28 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void disabledCustomTaskDoesNotDeleteBuiltInTaskSidecar() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path builtInJunit = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        Path customJunit = projectRoot.resolve("build/reports/crap-java/custom-crap-java-check/TEST-crap-java.xml");
+        Files.createDirectories(builtInJunit.getParent());
+        Files.createDirectories(customJunit.getParent());
+        Files.writeString(builtInJunit, "<testsuites tests=\"1\"/>");
+        Files.writeString(customJunit, "<testsuites tests=\"2\"/>");
+
+        CrapJavaCheckTask task = project.getTasks().register("custom-crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getModuleCoverageReports().set(Map.of());
+        task.getJunit().set(false);
+
+        task.runCheck();
+
+        assertTrue(Files.exists(builtInJunit));
+        assertFalse(Files.exists(customJunit));
+    }
+
+    @Test
     void rootModuleMatchesEverySourcePath() {
         assertTrue(CrapJavaCheckTask.matchesModulePath("app/src/main/java/demo/Sample.java", "."));
     }

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -158,6 +158,21 @@ class CrapJavaGradlePluginTest {
     }
 
     @Test
+    void taskAgentFalseOverridesExtensionAgentComposedDefaults() {
+        Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+
+        project.getPluginManager().apply("java");
+        project.getPluginManager().apply(CrapJavaGradlePlugin.class);
+        project.getExtensions().getByType(CrapJavaExtension.class).getAgent().set(true);
+        CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
+        checkTask.getAgent().set(false);
+
+        assertEquals("none", checkTask.getFormat().get());
+        assertFalse(checkTask.getFailuresOnly().get());
+        assertFalse(checkTask.getOmitRedundancy().get());
+    }
+
+    @Test
     void configuredTaskReportControlsOverrideExtensionDefaults() {
         Project project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -120,7 +120,7 @@ class CrapJavaGradlePluginTest {
         assertTrue(checkTask.getJunit().get());
         assertTrue(checkTask.getJunitReport().get().getAsFile().toPath().normalize().toString()
                 .replace('\\', '/')
-                .endsWith("build/reports/crap-java/TEST-crap-java.xml"));
+                .endsWith("build/reports/crap-java/custom-crap-java-check/TEST-crap-java.xml"));
         assertTrue(checkTask.getJunitReportOutput().isPresent());
     }
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/GradleLoggingPrintStreamsTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/GradleLoggingPrintStreamsTest.java
@@ -1,0 +1,93 @@
+package media.barney.crap.gradle;
+
+import org.gradle.api.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintStream;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GradleLoggingPrintStreamsTest {
+
+    @Test
+    void standardOutLogsCompleteLinesAndFlushesTrailingLine() {
+        List<String> lifecycle = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+
+        try (PrintStream stream = GradleLoggingPrintStreams.standardOut(logger(lifecycle, warnings))) {
+            stream.print("alpha");
+            stream.write('\r');
+            stream.write('\n');
+            stream.print("beta");
+            stream.flush();
+            stream.flush();
+        }
+
+        assertEquals(List.of("alpha", "beta"), lifecycle);
+        assertEquals(List.of(), warnings);
+    }
+
+    @Test
+    void standardErrLogsWarnings() {
+        List<String> lifecycle = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+
+        try (PrintStream stream = GradleLoggingPrintStreams.standardErr(logger(lifecycle, warnings))) {
+            stream.println("problem");
+        }
+
+        assertEquals(List.of(), lifecycle);
+        assertEquals(List.of("problem"), warnings);
+    }
+
+    private static Logger logger(List<String> lifecycle, List<String> warnings) {
+        return (Logger) Proxy.newProxyInstance(
+                Logger.class.getClassLoader(),
+                new Class<?>[]{Logger.class},
+                (proxy, method, args) -> {
+                    if (args != null && args.length == 1 && args[0] instanceof String message) {
+                        if ("lifecycle".equals(method.getName())) {
+                            lifecycle.add(message);
+                            return null;
+                        }
+                        if ("warn".equals(method.getName())) {
+                            warnings.add(message);
+                            return null;
+                        }
+                    }
+                    return defaultValue(method.getReturnType());
+                }
+        );
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive() || void.class.equals(returnType)) {
+            return null;
+        }
+        if (boolean.class.equals(returnType)) {
+            return false;
+        }
+        if (char.class.equals(returnType)) {
+            return '\0';
+        }
+        if (byte.class.equals(returnType)) {
+            return (byte) 0;
+        }
+        if (short.class.equals(returnType)) {
+            return (short) 0;
+        }
+        if (int.class.equals(returnType)) {
+            return 0;
+        }
+        if (long.class.equals(returnType)) {
+            return 0L;
+        }
+        if (float.class.equals(returnType)) {
+            return 0.0f;
+        }
+        return 0.0d;
+    }
+}


### PR DESCRIPTION
## Summary

- add Gradle extension/task controls for primary report format, agent mode, filtering, redundancy omission, output, JUnit enablement, and JUnit report path
- default Gradle primary output to `none` while keeping the JUnit sidecar enabled at the existing default path
- add a core resolved-module report-options overload so Gradle keeps its current pre-resolved multi-module coverage behavior
- cover extension/task defaults, configured report controls, agent composition, and full JUnit sidecar behavior

Closes #89.

## Validation

- `mvn -B -pl core package`
- `gradle-plugin/gradlew.bat test --no-daemon`
- `mvn -B verify`