### PR TITLE
Make boolean CLI option values strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ coverage input used for each CRAP score (`instruction`, `branch`, or `N/A`).
 `--agent` is a composite shortcut for `--format toon --failures-only
 --omit-redundancy` when those settings are not overridden explicitly.
 `--failures-only` and `--omit-redundancy` affect only the primary report.
+Assigned boolean CLI values must be lowercase `true` or `false`; bare boolean flags mean `true`.
 `--junit-report <path>` always writes the complete unfiltered JUnit XML sidecar,
 and it can be combined with any primary format, including `none`.
 

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -2,7 +2,6 @@ package media.barney.crap.core;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import org.jspecify.annotations.Nullable;
 
 final class CliArgumentsParser {
@@ -177,7 +176,7 @@ final class CliArgumentsParser {
         if (arg.equals(option)) {
             return true;
         }
-        String value = arg.substring(option.length() + 1).toLowerCase(Locale.ROOT);
+        String value = arg.substring(option.length() + 1);
         if ("true".equals(value)) {
             return true;
         }

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -142,13 +142,9 @@ class CliArgumentsParserTest {
     void failuresOnlyFlagAcceptsExplicitBooleanAssignments() {
         CliArguments enabled = CliArgumentsParser.parse(new String[]{"--failures-only=true", "--changed"});
         CliArguments disabled = CliArgumentsParser.parse(new String[]{"--failures-only=false", "--changed"});
-        CliArguments enabledUppercase = CliArgumentsParser.parse(new String[]{"--failures-only=TRUE", "--changed"});
-        CliArguments disabledUppercase = CliArgumentsParser.parse(new String[]{"--failures-only=FALSE", "--changed"});
 
         assertTrue(enabled.failuresOnly());
         assertFalse(disabled.failuresOnly());
-        assertTrue(enabledUppercase.failuresOnly());
-        assertFalse(disabledUppercase.failuresOnly());
     }
 
     @Test
@@ -157,6 +153,12 @@ class CliArgumentsParserTest {
                 () -> CliArgumentsParser.parse(new String[]{"--failures-only=yes", "--changed"}));
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--failures-only=", "--changed"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--failures-only=TRUE", "--changed"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--failures-only=False", "--changed"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--failures-only=FALSE", "--changed"}));
     }
 
     @Test
@@ -177,13 +179,9 @@ class CliArgumentsParserTest {
     void omitRedundancyFlagAcceptsExplicitBooleanAssignments() {
         CliArguments enabled = CliArgumentsParser.parse(new String[]{"--omit-redundancy=true", "--changed"});
         CliArguments disabled = CliArgumentsParser.parse(new String[]{"--omit-redundancy=false", "--changed"});
-        CliArguments enabledUppercase = CliArgumentsParser.parse(new String[]{"--omit-redundancy=TRUE", "--changed"});
-        CliArguments disabledUppercase = CliArgumentsParser.parse(new String[]{"--omit-redundancy=FALSE", "--changed"});
 
         assertTrue(enabled.omitRedundancy());
         assertFalse(disabled.omitRedundancy());
-        assertTrue(enabledUppercase.omitRedundancy());
-        assertFalse(disabledUppercase.omitRedundancy());
     }
 
     @Test
@@ -192,6 +190,12 @@ class CliArgumentsParserTest {
                 () -> CliArgumentsParser.parse(new String[]{"--omit-redundancy=yes", "--changed"}));
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--omit-redundancy=", "--changed"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--omit-redundancy=TRUE", "--changed"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--omit-redundancy=False", "--changed"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--omit-redundancy=FALSE", "--changed"}));
     }
 
     @Test


### PR DESCRIPTION
Closes #98

## Summary
- reject mixed-case or uppercase assigned boolean CLI values
- keep bare boolean flags and lowercase `=true` / `=false` assignments working
- document lowercase-only assigned boolean values

## Validation
- `mvn -B -pl core -Dtest=CliArgumentsParserTest test`
- `mvn -B -pl cli -am package`
- `mvn -B cognitive-java:check`