### PR TITLE
Fix #96 primary src semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,10 @@ The CLI writes only the requested primary report format to stdout unless
 `--format none` when you only want the exit status or a JUnit sidecar.
 
 Machine-readable primary reports include top-level `status` (`passed` or
-`failed`) and `threshold` values, plus method-level `coverageKind` values
-identifying the coverage input used for each CRAP score (`instruction`,
-`branch`, or `N/A`).
+`failed`) and `threshold` values. Method entries use compact fields `status`,
+`crap`, `cc`, `cov`, `covKind`, `method`, `src`, `lineStart`, and `lineEnd`.
+`src` is the project-relative source file path. `coverageKind` identifies the
+coverage input used for each CRAP score (`instruction`, `branch`, or `N/A`).
 
 `--agent` is a composite shortcut for `--format toon --failures-only
 --omit-redundancy` when those settings are not overridden explicitly.

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -75,7 +75,7 @@ final class ReportFormatter {
     private static List<TableColumn> methodTextColumns() {
         return List.of(
                 new TableColumn("Method", Alignment.LEFT, CrapReport.MethodReport::methodName),
-                new TableColumn("Class", Alignment.LEFT, CrapReport.MethodReport::className),
+                new TableColumn("Src", Alignment.LEFT, CrapReport.MethodReport::sourcePath),
                 new TableColumn("CC", Alignment.RIGHT, method -> Integer.toString(method.complexity())),
                 new TableColumn("Cov%", Alignment.RIGHT, method -> formatCoverage(method.coveragePercent())),
                 new TableColumn("CovKind", Alignment.LEFT, CrapReport.MethodReport::coverageKind),
@@ -182,7 +182,7 @@ final class ReportFormatter {
                 method.coveragePercent(),
                 method.coverageKind(),
                 method.methodName(),
-                method.className(),
+                method.sourcePath(),
                 method.startLine(),
                 method.endLine()
         );
@@ -296,7 +296,7 @@ final class ReportFormatter {
         sorted.sort(Comparator
                 .comparing((CrapReport.MethodReport e) -> e.crapScore() == null)
                 .thenComparing(e -> e.crapScore() == null ? 0.0 : -e.crapScore())
-                .thenComparing(CrapReport.MethodReport::className)
+                .thenComparing(CrapReport.MethodReport::sourcePath)
                 .thenComparing(CrapReport.MethodReport::methodName)
                 .thenComparingInt(CrapReport.MethodReport::startLine));
         return sorted;

--- a/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
@@ -169,7 +169,7 @@ class CliApplicationTest {
 
         assertEquals(0, exit);
         assertEquals(List.of(moduleRoot), directories);
-        assertTrue(utf8(out).contains("mutate4java.Sample"));
+        assertTrue(utf8(out).contains("tools/mutate4java/src/mutate4java/Sample.java"));
         assertFalse(utf8(err).contains("Warning: JaCoCo XML not found"));
     }
 
@@ -219,7 +219,7 @@ class CliApplicationTest {
         assertEquals(0, exit);
         assertEquals(List.of(tempDir), directories);
         assertEquals(List.of(List.of("gradle", "--no-daemon", "-q", ":apps:demo:test", ":apps:demo:jacocoTestReport")), commands);
-        assertTrue(utf8(out).contains("demo.Sample"));
+        assertTrue(utf8(out).contains("apps/demo/src/main/java/demo/Sample.java"));
         assertFalse(utf8(err).contains("Warning: JaCoCo XML not found"));
     }
 

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -810,8 +810,8 @@ class MainTest {
         );
 
         assertEquals(0, exit);
-        assertTrue(utf8(out).contains("demo.app.AppSample"));
-        assertTrue(utf8(out).contains("demo.lib.LibSample"));
+        assertTrue(utf8(out).contains("app/src/main/java/demo/app/AppSample.java"));
+        assertTrue(utf8(out).contains("lib/src/main/java/demo/lib/LibSample.java"));
         assertEquals("", utf8(err));
     }
 

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -50,7 +50,7 @@ class ReportFormatterTest {
         String passed = lines.get(headerIndex + 3);
 
         assertTrue(failed.contains("veryLongMethodNameForWideColumn"));
-        assertTrue(failed.contains("demo.really.LongClassNameForWideColumn"));
+        assertTrue(failed.contains("src/main/java/demo/Sample.java"));
         assertEquals(header.length(), separator.length());
         assertEquals(header.length(), failed.length());
         assertEquals(header.length(), passed.length());
@@ -79,7 +79,7 @@ class ReportFormatterTest {
                       "cov": 10.0,
                       "covKind": "instruction",
                       "method": "danger",
-                      "src": "demo.Sample",
+                      "src": "src/main/java/demo/Sample.java",
                       "lineStart": 4,
                       "lineEnd": 6
                     },
@@ -90,7 +90,7 @@ class ReportFormatterTest {
                       "cov": null,
                       "covKind": "N/A",
                       "method": "unknown",
-                      "src": "demo.Sample",
+                      "src": "src/main/java/demo/Sample.java",
                       "lineStart": 20,
                       "lineEnd": 22
                     }
@@ -111,8 +111,8 @@ class ReportFormatterTest {
         assertTrue(report.contains("status: passed"));
         assertTrue(report.contains("threshold: 8"));
         assertTrue(report.contains("methods[2]{status,crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
-        assertTrue(report.contains("passed,4.5,3,85,instruction,foo,demo.Sample,4,6"));
-        assertTrue(report.contains("skipped,null,2,null,N/A,bar,demo.Sample,9,11"));
+        assertTrue(report.contains("passed,4.5,3,85,instruction,foo,src/main/java/demo/Sample.java,4,6"));
+        assertTrue(report.contains("skipped,null,2,null,N/A,bar,src/main/java/demo/Sample.java,9,11"));
     }
 
     @Test
@@ -143,7 +143,7 @@ class ReportFormatterTest {
                       "cov": 10.0,
                       "covKind": "instruction",
                       "method": "danger",
-                      "src": "demo.Sample",
+                      "src": "src/main/java/demo/Sample.java",
                       "lineStart": 4,
                       "lineEnd": 6
                     }
@@ -174,7 +174,7 @@ class ReportFormatterTest {
                       "cov": 10.0,
                       "covKind": "instruction",
                       "method": "danger",
-                      "src": "demo.Sample",
+                      "src": "src/main/java/demo/Sample.java",
                       "lineStart": 4,
                       "lineEnd": 6
                     }
@@ -238,7 +238,7 @@ class ReportFormatterTest {
                       "cov": 10.0,
                       "covKind": "instruction",
                       "method": "danger",
-                      "src": "demo.Sample",
+                      "src": "src/main/java/demo/Sample.java",
                       "lineStart": 4,
                       "lineEnd": 6
                     },
@@ -248,7 +248,7 @@ class ReportFormatterTest {
                       "cov": null,
                       "covKind": "N/A",
                       "method": "unknown",
-                      "src": "demo.Sample",
+                      "src": "src/main/java/demo/Sample.java",
                       "lineStart": 20,
                       "lineEnd": 22
                     }
@@ -269,8 +269,8 @@ class ReportFormatterTest {
         assertTrue(report.contains("status: passed"));
         assertTrue(report.contains("threshold: 8"));
         assertTrue(report.contains("methods[2]{crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
-        assertTrue(report.contains("4.5,3,85,instruction,foo,demo.Sample,4,6"));
-        assertTrue(report.contains("null,2,null,N/A,bar,demo.Sample,9,11"));
+        assertTrue(report.contains("4.5,3,85,instruction,foo,src/main/java/demo/Sample.java,4,6"));
+        assertTrue(report.contains("null,2,null,N/A,bar,src/main/java/demo/Sample.java,9,11"));
         assertFalse(report.contains("methods[2]{status,"));
     }
 
@@ -316,7 +316,7 @@ class ReportFormatterTest {
         assertTrue(report.contains("status: failed"));
         assertTrue(report.contains("threshold: 8"));
         assertTrue(report.contains("methods[1]{crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
-        assertTrue(report.contains("9.645,5,10,instruction,danger,demo.Sample,4,6"));
+        assertTrue(report.contains("9.645,5,10,instruction,danger,src/main/java/demo/Sample.java,4,6"));
     }
 
     @Test
@@ -429,7 +429,7 @@ class ReportFormatterTest {
     private static int tableHeaderIndex(List<String> lines, String firstColumn) {
         for (int index = 0; index < lines.size(); index++) {
             String line = lines.get(index);
-            if (line.startsWith(firstColumn) && line.contains("Class") && line.contains("CovKind")) {
+            if (line.startsWith(firstColumn) && line.contains("Src") && line.contains("CovKind")) {
                 return index;
             }
         }


### PR DESCRIPTION
## Summary

- Change the Java primary report `src` field to use the project-relative source path.
- Update text, JSON, and TOON formatter expectations around the compact primary schema.
- Document the compact primary fields and Java coverage kind values.

Closes #96