### PR TITLE
Fix #97 GitLab JUnit XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,14 @@ lenient even for hard gates. The warning recommends `8.0` for hard gates,
 targeting `6.0` during implementation, and using the `8.0` default when in
 doubt.
 
-The JUnit XML format exposes each analyzed method as a testcase. Methods with
-CRAP scores over the configured threshold fail, methods with unavailable
-coverage are skipped, and the testsuite properties include the global
-threshold. Testcase properties include the score, complexity, coverage percent,
-coverage kind, source path, and line range.
+The JUnit XML format exposes each analyzed method as a testcase and is shaped
+for GitLab's Tests tab. Testcases use the project-relative source path for
+`classname` and `file`, use `method:lineStart` as the testcase `name`, and
+write `time="0"`. Methods with CRAP scores over the configured threshold fail,
+methods with unavailable coverage are skipped, and failure/skipped element text
+includes CRAP score, threshold, coverage kind, source path, and line range.
+Custom properties remain for tools that read them, but GitLab-visible details do
+not rely on properties.
 
 ## Distribution
 

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -219,14 +219,14 @@ final class ReportFormatter {
                                                double threshold,
                                                boolean omitRedundancy) {
         return new JunitTestCase(
-                method.className(),
+                method.sourcePath(),
                 testcaseName(method),
                 method.sourcePath(),
                 method.startLine(),
                 "0",
                 junitProperties(method, omitRedundancy),
                 junitFailure(method, threshold),
-                junitSkipped(method)
+                junitSkipped(method, threshold)
         );
     }
 
@@ -255,16 +255,16 @@ final class ReportFormatter {
         }
         String message = "CRAP threshold exceeded: "
                 + formatDisplayNumber(method.crapScore()) + " > " + formatDisplayNumber(threshold);
-        return new JunitFailure(message, "crap-java.threshold", message);
+        return new JunitFailure(message, "crap-java.threshold", junitDiagnosticText(method, threshold));
     }
 
-    private static @Nullable JunitSkipped junitSkipped(CrapReport.MethodReport method) {
+    private static @Nullable JunitSkipped junitSkipped(CrapReport.MethodReport method, double threshold) {
         if (method.status() != MethodStatus.SKIPPED) {
             return null;
         }
         return new JunitSkipped(
                 "CRAP score unavailable",
-                "Coverage data unavailable for " + method.className() + "#" + method.methodName()
+                junitDiagnosticText(method, threshold)
         );
     }
 
@@ -285,10 +285,18 @@ final class ReportFormatter {
     }
 
     private static String testcaseName(CrapReport.MethodReport method) {
-        return method.status().value().toUpperCase(Locale.ROOT)
-                + " " + method.methodName()
-                + ":" + method.startLine()
-                + " CRAP " + formatDisplayNumber(method.crapScore());
+        return method.methodName() + ":" + method.startLine();
+    }
+
+    private static String junitDiagnosticText(CrapReport.MethodReport method, double threshold) {
+        return String.join("\n",
+                "CRAP score: " + formatDisplayNumber(method.crapScore()),
+                "Threshold: " + formatDisplayNumber(threshold),
+                "Coverage: " + formatCoverage(method.coveragePercent()) + " (" + method.coverageKind() + ")",
+                "Source: " + method.sourcePath() + ":" + method.startLine() + "-" + method.endLine(),
+                "Method: " + method.methodName(),
+                "Complexity: " + method.complexity()
+        );
     }
 
     private static List<CrapReport.MethodReport> sortedMethods(List<CrapReport.MethodReport> entries) {

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -256,9 +256,9 @@ class MainTest {
         assertEquals(2, exit);
         assertEquals("", utf8(out));
         assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
-        assertTrue(junit.contains("FAILED danger"));
-        assertTrue(junit.contains("PASSED safe"));
-        assertTrue(junit.contains("SKIPPED unknown"));
+        assertTrue(junit.contains("name=\"danger:4\""));
+        assertTrue(junit.contains("name=\"safe:14\""));
+        assertTrue(junit.contains("name=\"unknown:18\""));
     }
 
     @Test
@@ -321,9 +321,9 @@ class MainTest {
         assertFalse(primary.contains("\"method\": \"safe\""));
         assertFalse(primary.contains("\"method\": \"unknown\""));
         assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
-        assertTrue(junit.contains("FAILED danger"));
-        assertTrue(junit.contains("PASSED safe"));
-        assertTrue(junit.contains("SKIPPED unknown"));
+        assertTrue(junit.contains("name=\"danger:4\""));
+        assertTrue(junit.contains("name=\"safe:14\""));
+        assertTrue(junit.contains("name=\"unknown:18\""));
     }
 
     @Test
@@ -390,9 +390,9 @@ class MainTest {
         assertFalse(primary.contains("\"method\": \"safe\""));
         assertFalse(primary.contains("\"method\": \"unknown\""));
         assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
-        assertTrue(junit.contains("FAILED danger"));
-        assertTrue(junit.contains("PASSED safe"));
-        assertTrue(junit.contains("SKIPPED unknown"));
+        assertTrue(junit.contains("name=\"danger:4\""));
+        assertTrue(junit.contains("name=\"safe:14\""));
+        assertTrue(junit.contains("name=\"unknown:18\""));
     }
 
     @Test
@@ -463,9 +463,9 @@ class MainTest {
         assertTrue(primary.contains("\"method\": \"danger\""));
         assertFalse(primary.contains("\"method\": \"safe\""));
         assertFalse(primary.contains("\"method\": \"unknown\""));
-        assertTrue(junit.contains("FAILED danger"));
-        assertTrue(junit.contains("PASSED safe"));
-        assertTrue(junit.contains("SKIPPED unknown"));
+        assertTrue(junit.contains("name=\"danger:4\""));
+        assertTrue(junit.contains("name=\"safe:14\""));
+        assertTrue(junit.contains("name=\"unknown:18\""));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -214,10 +214,10 @@ class ReportFormatterTest {
         assertEquals("1", root.getAttribute("tests"));
         assertEquals("1", root.getAttribute("failures"));
         assertEquals("0", root.getAttribute("skipped"));
-        assertTrue(report.contains("FAILED danger"));
+        assertTrue(report.contains("<testcase classname=\"src/main/java/demo/Sample.java\" name=\"danger:4\""));
         assertTrue(report.contains("<property name=\"threshold\" value=\"8.0\"/>"));
-        assertFalse(report.contains("PASSED safe"));
-        assertFalse(report.contains("SKIPPED unknown"));
+        assertFalse(report.contains("name=\"safe:9\""));
+        assertFalse(report.contains("name=\"unknown:20\""));
     }
 
     @Test
@@ -375,13 +375,21 @@ class ReportFormatterTest {
         assertTrue(report.contains("    <property name=\"threshold\" value=\"8.0\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"instruction\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"N/A\"/>"));
-        assertTrue(report.contains("<testcase classname=\"demo.Sample\" name=\"FAILED danger:4 CRAP 9.6\""));
-        assertTrue(report.contains("<testcase classname=\"demo.Sample\" name=\"SKIPPED unknown:20 CRAP N/A\""));
+        assertTrue(report.contains("<testcase classname=\"src/main/java/demo/Sample.java\" name=\"danger:4\""));
+        assertTrue(report.contains("<testcase classname=\"src/main/java/demo/Sample.java\" name=\"unknown:20\""));
+        assertTrue(report.contains("file=\"src/main/java/demo/Sample.java\""));
+        assertTrue(report.contains("time=\"0\""));
         assertEquals("CRAP threshold exceeded: 9.6 > 8.0", failure.getAttribute("message"));
         assertEquals("crap-java.threshold", failure.getAttribute("type"));
-        assertEquals("CRAP threshold exceeded: 9.6 > 8.0", failure.getTextContent());
+        assertTrue(failure.getTextContent().contains("CRAP score: 9.6"));
+        assertTrue(failure.getTextContent().contains("Threshold: 8.0"));
+        assertTrue(failure.getTextContent().contains("Coverage: 10.0% (instruction)"));
+        assertTrue(failure.getTextContent().contains("Source: src/main/java/demo/Sample.java:4-6"));
         assertEquals("CRAP score unavailable", skipped.getAttribute("message"));
-        assertEquals("Coverage data unavailable for demo.Sample#unknown", skipped.getTextContent());
+        assertTrue(skipped.getTextContent().contains("CRAP score: N/A"));
+        assertTrue(skipped.getTextContent().contains("Threshold: 8.0"));
+        assertTrue(skipped.getTextContent().contains("Coverage: N/A (N/A)"));
+        assertTrue(skipped.getTextContent().contains("Source: src/main/java/demo/Sample.java:20-22"));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -209,15 +209,19 @@ class ReportFormatterTest {
                 metric("unknown", "demo.Sample", 20, 2, null, null)
         ), ReportFormat.JUNIT, true, false);
 
-        Element root = parseXml(report).getDocumentElement();
+        Document document = parseXml(report);
+        Element root = document.getDocumentElement();
+        Element danger = testcaseByName(document, "danger:4");
 
         assertEquals("1", root.getAttribute("tests"));
         assertEquals("1", root.getAttribute("failures"));
         assertEquals("0", root.getAttribute("skipped"));
-        assertTrue(report.contains("<testcase classname=\"src/main/java/demo/Sample.java\" name=\"danger:4\""));
+        assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("classname"));
+        assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("file"));
+        assertEquals("0", danger.getAttribute("time"));
         assertTrue(report.contains("<property name=\"threshold\" value=\"8.0\"/>"));
-        assertFalse(report.contains("name=\"safe:9\""));
-        assertFalse(report.contains("name=\"unknown:20\""));
+        assertFalse(hasTestcase(document, "safe:9"));
+        assertFalse(hasTestcase(document, "unknown:20"));
     }
 
     @Test
@@ -365,6 +369,8 @@ class ReportFormatterTest {
         Element root = document.getDocumentElement();
         Element failure = (Element) document.getElementsByTagName("failure").item(0);
         Element skipped = (Element) document.getElementsByTagName("skipped").item(0);
+        Element danger = testcaseByName(document, "danger:4");
+        Element unknown = testcaseByName(document, "unknown:20");
 
         assertEquals("testsuites", root.getNodeName());
         assertEquals("2", root.getAttribute("tests"));
@@ -375,10 +381,12 @@ class ReportFormatterTest {
         assertTrue(report.contains("    <property name=\"threshold\" value=\"8.0\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"instruction\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"N/A\"/>"));
-        assertTrue(report.contains("<testcase classname=\"src/main/java/demo/Sample.java\" name=\"danger:4\""));
-        assertTrue(report.contains("<testcase classname=\"src/main/java/demo/Sample.java\" name=\"unknown:20\""));
-        assertTrue(report.contains("file=\"src/main/java/demo/Sample.java\""));
-        assertTrue(report.contains("time=\"0\""));
+        assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("classname"));
+        assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("file"));
+        assertEquals("0", danger.getAttribute("time"));
+        assertEquals("src/main/java/demo/Sample.java", unknown.getAttribute("classname"));
+        assertEquals("src/main/java/demo/Sample.java", unknown.getAttribute("file"));
+        assertEquals("0", unknown.getAttribute("time"));
         assertEquals("CRAP threshold exceeded: 9.6 > 8.0", failure.getAttribute("message"));
         assertEquals("crap-java.threshold", failure.getAttribute("type"));
         assertTrue(failure.getTextContent().contains("CRAP score: 9.6"));
@@ -460,6 +468,28 @@ class ReportFormatterTest {
             }
         }
         throw new AssertionError("Missing XML property: " + name);
+    }
+
+    private static boolean hasTestcase(Document document, String name) {
+        NodeList testcases = document.getElementsByTagName("testcase");
+        for (int index = 0; index < testcases.getLength(); index++) {
+            Element testcase = (Element) testcases.item(index);
+            if (name.equals(testcase.getAttribute("name"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Element testcaseByName(Document document, String name) {
+        NodeList testcases = document.getElementsByTagName("testcase");
+        for (int index = 0; index < testcases.getLength(); index++) {
+            Element testcase = (Element) testcases.item(index);
+            if (name.equals(testcase.getAttribute("name"))) {
+                return testcase;
+            }
+        }
+        throw new AssertionError("Missing XML testcase: " + name);
     }
 
     private static MethodMetrics metric(String method,


### PR DESCRIPTION
## Summary

- Align JUnit testcase `classname`, `name`, and failure/skipped body content with the GitLab-oriented contract.
- Keep the existing `<testsuites>` wrapper and complete sidecar behavior.
- Document the GitLab-facing JUnit XML fields.

Closes #97