### PR TITLE
Add generated source exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ mvn verify -DcrapJava.excludeClasses='.*MapperImpl$' -DcrapJava.excludeAnnotatio
 mvn verify -DcrapJava.useDefaultExclusions=false
 ```
 
+In comma-separated Maven properties, escape a literal comma as `\,`, for
+example `-DcrapJava.excludeClasses='demo.Name{1\,3}$'`.
+
 Defaults: `crapJava.format=none`, `crapJava.agent=false`, and
 `crapJava.junit=true`. `crapJava.agent=true` switches the default primary report
 to TOON and defaults `crapJava.failuresOnly` and `crapJava.omitRedundancy` to

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ java -jar cli/target/crap-java-cli-0.5.0.jar
 --agent               Apply AI-agent defaults: `toon`, failures only, omit redundancy
 --failures-only[=true|false]  Only include failing methods in the primary report
 --omit-redundancy[=true|false]  Omit redundant method fields from the primary report
+--exclude <glob>     Exclude source paths by normalized relative glob; repeatable
+--exclude-class <regex>  Exclude fully-qualified class names by regex; repeatable
+--exclude-annotation <name>  Exclude classes by annotation name; repeatable
+--use-default-exclusions[=true|false]  Enable built-in generated-code exclusions (`true` by default)
 --output <path>       Write the selected output format to a file instead of stdout
 --junit-report <path> Also write a JUnit XML report for CI test-report UIs
 --threshold <number>  Override the CRAP threshold (`8.0` by default)
@@ -134,6 +138,7 @@ java -jar cli/target/crap-java-cli-0.5.0.jar --agent
 java -jar cli/target/crap-java-cli-0.5.0.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
 java -jar cli/target/crap-java-cli-0.5.0.jar --junit-report target/crap-java/TEST-crap-java.xml
 java -jar cli/target/crap-java-cli-0.5.0.jar --threshold 6
+java -jar cli/target/crap-java-cli-0.5.0.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
 java -jar cli/target/crap-java-cli-0.5.0.jar --build-tool maven module-a/src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.5.0.jar src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.5.0.jar module-a module-b
@@ -148,6 +153,23 @@ Machine-readable primary reports include top-level `status` (`passed` or
 `crap`, `cc`, `cov`, `covKind`, `method`, `src`, `lineStart`, and `lineEnd`.
 `src` is the project-relative source file path. `coverageKind` identifies the
 coverage input used for each CRAP score (`instruction`, `branch`, or `N/A`).
+Full primary reports also include exclusion audit counts when any source was
+considered; optimized primary reports produced through `--agent` omit that audit
+detail by default to stay focused on actionable failures. The JUnit sidecar
+keeps the complete exclusion audit.
+
+Built-in exclusions are conservative and generated-code focused. They exclude
+source files under any directory segment containing `generated`, source files
+under `**/src/main/java-gen/**`, and classes annotated with any annotation whose
+simple name is `Generated` regardless of package. Default class-name regexes
+are `(^|.*\.)generated(\..*)?`, `(^|.*\.)gen(\..*)?`,
+`(^|.*\.)[^.]*MapperImpl$`, `(^|.*\.)Dagger[^.]*$`,
+`(^|.*\.)Hilt_[^.]*$`, and `(^|.*\.)AutoValue_[^.]*$`.
+The defaults intentionally do not exclude handwritten-looking parser/listener/
+visitor classes, `Immutable*` classes, QueryDSL metamodels, vendor trees,
+examples, migrations, bootstrap/configuration classes, or operational scripts.
+User exclusions compose with those defaults unless
+`--use-default-exclusions=false` is set.
 
 `--agent` is a composite shortcut for `--format toon --failures-only
 --omit-redundancy` when those settings are not overridden explicitly.
@@ -213,6 +235,10 @@ crapJava {
     output.set(layout.buildDirectory.file("reports/crap-java/report.json"))
     junit.set(true)
     junitReport.set(layout.buildDirectory.file("reports/crap-java/custom-junit.xml"))
+    excludes.set(listOf("module-a/**"))
+    excludeClasses.set(listOf(".*MapperImpl$"))
+    excludeAnnotations.set(listOf("Generated"))
+    useDefaultExclusions.set(true)
 }
 ```
 
@@ -311,12 +337,19 @@ mvn verify -DcrapJava.failuresOnly=false -DcrapJava.omitRedundancy=true
 mvn verify -DcrapJava.junit=false
 mvn verify -DcrapJava.junitReport=target/custom-crap-java.xml
 mvn verify -DcrapJava.threshold=6.0
+mvn verify -DcrapJava.excludes='module-a/**,**/custom-generated/**'
+mvn verify -DcrapJava.excludeClasses='.*MapperImpl$' -DcrapJava.excludeAnnotations=Generated
+mvn verify -DcrapJava.useDefaultExclusions=false
 ```
 
 Defaults: `crapJava.format=none`, `crapJava.agent=false`, and
 `crapJava.junit=true`. `crapJava.agent=true` switches the default primary report
 to TOON and defaults `crapJava.failuresOnly` and `crapJava.omitRedundancy` to
 `true` unless they are supplied explicitly.
+
+Equivalent XML configuration is available through `<excludes>`,
+`<excludeClasses>`, `<excludeAnnotations>`, and
+`<useDefaultExclusions>`.
 
 Override the JUnit XML path with:
 

--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -41,17 +41,28 @@ final class CliApplication {
         CliArguments parsed = parse.arguments();
         try {
             Main.writeThresholdWarning(err, parsed.threshold());
-            List<Path> filesToAnalyze = filesForMode(parsed);
+            SourceExclusionAudit.Builder audit = SourceExclusionAudit.builder();
+            SourceExclusionMatcher exclusions = SourceExclusionMatcher.create(projectRoot, parsed.exclusionOptions());
+            List<Path> filesToAnalyze = SourceExclusionMatcher.filterFiles(
+                    filesForMode(parsed),
+                    exclusions,
+                    audit
+            );
             if (filesToAnalyze.isEmpty()) {
-                CrapReport report = CrapReport.from(List.of(), parsed.threshold());
+                CrapReport report = CrapReport.from(List.of(), parsed.threshold(), audit.build());
                 ReportPublisher.publish(report, reportOptions(parsed), out);
                 return 0;
             }
 
-            List<MethodMetrics> metrics = analyzeByModule(filesToAnalyze, parsed.buildToolSelection());
+            List<MethodMetrics> metrics = analyzeByModule(
+                    filesToAnalyze,
+                    parsed.buildToolSelection(),
+                    exclusions,
+                    audit
+            );
             metrics.sort(Comparator.comparing(MethodMetrics::crapScore,
                     Comparator.nullsLast(Comparator.reverseOrder())));
-            CrapReport report = CrapReport.from(metrics, parsed.threshold());
+            CrapReport report = CrapReport.from(metrics, parsed.threshold(), audit.build());
             ReportPublisher.publish(report, reportOptions(parsed), out);
 
             double max = Main.maxCrap(metrics);
@@ -67,7 +78,9 @@ final class CliApplication {
     }
 
     private List<MethodMetrics> analyzeByModule(List<Path> filesToAnalyze,
-                                                BuildToolSelection buildToolSelection) throws Exception {
+                                                BuildToolSelection buildToolSelection,
+                                                SourceExclusionMatcher exclusions,
+                                                SourceExclusionAudit.Builder audit) throws Exception {
         List<MethodMetrics> metrics = new ArrayList<>();
         for (Map.Entry<ProjectModule, List<Path>> entry : groupByModule(filesToAnalyze, buildToolSelection).entrySet()) {
             ProjectModule module = entry.getKey();
@@ -78,7 +91,7 @@ final class CliApplication {
             if (!Files.exists(jacocoXml)) {
                 err.println("Warning: JaCoCo XML not found at " + jacocoXml + ". Coverage will be N/A.");
             }
-            metrics.addAll(CrapAnalyzer.analyze(projectRoot, entry.getValue(), jacocoXml));
+            metrics.addAll(CrapAnalyzer.analyze(projectRoot, entry.getValue(), jacocoXml, exclusions, audit));
         }
         return metrics;
     }
@@ -117,7 +130,8 @@ final class CliApplication {
                 parsed.failuresOnly(),
                 parsed.omitRedundancy(),
                 outputPath(parsed.outputPath()),
-                outputPath(parsed.junitReportPath())
+                outputPath(parsed.junitReportPath()),
+                !parsed.agent()
         );
     }
 

--- a/core/src/main/java/media/barney/crap/core/CliArguments.java
+++ b/core/src/main/java/media/barney/crap/core/CliArguments.java
@@ -13,7 +13,32 @@ record CliArguments(
         boolean omitRedundancy,
         @Nullable String outputPath,
         @Nullable String junitReportPath,
-        List<String> fileArgs
+        List<String> fileArgs,
+        SourceExclusionOptions exclusionOptions
 ) {
+    CliArguments(CliMode mode,
+                 BuildToolSelection buildToolSelection,
+                 ReportFormat reportFormat,
+                 double threshold,
+                 boolean agent,
+                 boolean failuresOnly,
+                 boolean omitRedundancy,
+                 @Nullable String outputPath,
+                 @Nullable String junitReportPath,
+                 List<String> fileArgs) {
+        this(
+                mode,
+                buildToolSelection,
+                reportFormat,
+                threshold,
+                agent,
+                failuresOnly,
+                omitRedundancy,
+                outputPath,
+                junitReportPath,
+                fileArgs,
+                SourceExclusionOptions.defaults()
+        );
+    }
 }
 

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -37,7 +37,8 @@ final class CliArgumentsParser {
                     state.omitRedundancy,
                     state.outputPath,
                     state.junitReportPath,
-                    List.of()
+                    List.of(),
+                    state.exclusionOptions
             );
         }
         boolean changed = state.changed;
@@ -54,7 +55,8 @@ final class CliArgumentsParser {
                     state.omitRedundancy,
                     state.outputPath,
                     state.junitReportPath,
-                    List.of()
+                    List.of(),
+                    state.exclusionOptions
             );
         }
         if (values.isEmpty()) {
@@ -68,7 +70,8 @@ final class CliArgumentsParser {
                     state.omitRedundancy,
                     state.outputPath,
                     state.junitReportPath,
-                    List.of()
+                    List.of(),
+                    state.exclusionOptions
             );
         }
         return new CliArguments(
@@ -81,7 +84,8 @@ final class CliArgumentsParser {
                 state.omitRedundancy,
                 state.outputPath,
                 state.junitReportPath,
-                List.copyOf(values)
+                List.copyOf(values),
+                state.exclusionOptions
         );
     }
 
@@ -126,6 +130,15 @@ final class CliArgumentsParser {
             state.omitRedundancySeen = true;
             return index;
         }
+        if (isBooleanOption(arg, "--use-default-exclusions")) {
+            state.useDefaultExclusions = parseBooleanOption(
+                    arg,
+                    "--use-default-exclusions",
+                    state.useDefaultExclusionsSeen
+            );
+            state.useDefaultExclusionsSeen = true;
+            return index;
+        }
         return parseValuedOption(args, index, state, arg);
     }
 
@@ -153,6 +166,18 @@ final class CliArgumentsParser {
         if ("--threshold".equals(arg)) {
             state.threshold = parseThreshold(args, index, state.thresholdSeen);
             state.thresholdSeen = true;
+            return index + 1;
+        }
+        if ("--exclude".equals(arg)) {
+            state.excludes.add(parseListOption(args, index, "--exclude", "a glob"));
+            return index + 1;
+        }
+        if ("--exclude-class".equals(arg)) {
+            state.excludeClasses.add(parseListOption(args, index, "--exclude-class", "a regex"));
+            return index + 1;
+        }
+        if ("--exclude-annotation".equals(arg)) {
+            state.excludeAnnotations.add(parseListOption(args, index, "--exclude-annotation", "an annotation name"));
             return index + 1;
         }
         throw new IllegalArgumentException("Unknown option: " + arg);
@@ -230,6 +255,17 @@ final class CliArgumentsParser {
         }
     }
 
+    private static String parseListOption(String[] args, int index, String option, String valueDescription) {
+        if (index + 1 >= args.length) {
+            throw new IllegalArgumentException(option + " requires " + valueDescription);
+        }
+        String value = args[index + 1].trim();
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException(option + " requires " + valueDescription);
+        }
+        return value;
+    }
+
     private static void ensureChangedIsNotCombined(boolean changed, List<String> values) {
         if (changed && !values.isEmpty()) {
             throw new IllegalArgumentException("--changed cannot be combined with file arguments");
@@ -246,6 +282,7 @@ final class CliArgumentsParser {
                               boolean omitRedundancy,
                               @Nullable String outputPath,
                               @Nullable String junitReportPath,
+                              SourceExclusionOptions exclusionOptions,
                               List<String> fileArgs) {
     }
 
@@ -264,6 +301,11 @@ final class CliArgumentsParser {
         private boolean failuresOnlySeen;
         private boolean omitRedundancy;
         private boolean omitRedundancySeen;
+        private boolean useDefaultExclusions = true;
+        private boolean useDefaultExclusionsSeen;
+        private final List<String> excludes = new ArrayList<>();
+        private final List<String> excludeClasses = new ArrayList<>();
+        private final List<String> excludeAnnotations = new ArrayList<>();
         private @Nullable String outputPath;
         private boolean outputPathSeen;
         private @Nullable String junitReportPath;
@@ -284,6 +326,12 @@ final class CliArgumentsParser {
                     effectiveOmitRedundancy,
                     outputPath,
                     junitReportPath,
+                    new SourceExclusionOptions(
+                            excludes,
+                            excludeClasses,
+                            excludeAnnotations,
+                            useDefaultExclusions
+                    ),
                     values
             );
         }

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -143,44 +143,76 @@ final class CliArgumentsParser {
     }
 
     private static int parseValuedOption(String[] args, int index, ParseStateBuilder state, String arg) {
-        if ("--build-tool".equals(arg)) {
-            state.buildToolSelection = parseBuildTool(args, index, state.buildToolSeen);
-            state.buildToolSeen = true;
-            return index + 1;
-        }
-        if ("--format".equals(arg)) {
-            state.reportFormat = parseReportFormat(args, index, state.reportFormatSeen);
-            state.reportFormatSeen = true;
-            return index + 1;
-        }
-        if ("--output".equals(arg)) {
-            state.outputPath = parsePathOption(args, index, state.outputPathSeen, "--output");
-            state.outputPathSeen = true;
-            return index + 1;
-        }
-        if ("--junit-report".equals(arg)) {
-            state.junitReportPath = parsePathOption(args, index, state.junitReportPathSeen, "--junit-report");
-            state.junitReportPathSeen = true;
-            return index + 1;
-        }
-        if ("--threshold".equals(arg)) {
-            state.threshold = parseThreshold(args, index, state.thresholdSeen);
-            state.thresholdSeen = true;
-            return index + 1;
-        }
-        if ("--exclude".equals(arg)) {
-            state.excludes.add(parseListOption(args, index, "--exclude", "a glob"));
-            return index + 1;
-        }
-        if ("--exclude-class".equals(arg)) {
-            state.excludeClasses.add(parseListOption(args, index, "--exclude-class", "a regex"));
-            return index + 1;
-        }
-        if ("--exclude-annotation".equals(arg)) {
-            state.excludeAnnotations.add(parseListOption(args, index, "--exclude-annotation", "an annotation name"));
+        if (parseBuildToolOption(args, index, state, arg)
+                || parseReportFormatOption(args, index, state, arg)
+                || parseOutputOption(args, index, state, arg)
+                || parseJunitReportOption(args, index, state, arg)
+                || parseThresholdOption(args, index, state, arg)
+                || parseExclusionOption(args, index, state, arg)) {
             return index + 1;
         }
         throw new IllegalArgumentException("Unknown option: " + arg);
+    }
+
+    private static boolean parseBuildToolOption(String[] args, int index, ParseStateBuilder state, String arg) {
+        if ("--build-tool".equals(arg)) {
+            state.buildToolSelection = parseBuildTool(args, index, state.buildToolSeen);
+            state.buildToolSeen = true;
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean parseReportFormatOption(String[] args, int index, ParseStateBuilder state, String arg) {
+        if ("--format".equals(arg)) {
+            state.reportFormat = parseReportFormat(args, index, state.reportFormatSeen);
+            state.reportFormatSeen = true;
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean parseOutputOption(String[] args, int index, ParseStateBuilder state, String arg) {
+        if ("--output".equals(arg)) {
+            state.outputPath = parsePathOption(args, index, state.outputPathSeen, "--output");
+            state.outputPathSeen = true;
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean parseJunitReportOption(String[] args, int index, ParseStateBuilder state, String arg) {
+        if ("--junit-report".equals(arg)) {
+            state.junitReportPath = parsePathOption(args, index, state.junitReportPathSeen, "--junit-report");
+            state.junitReportPathSeen = true;
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean parseThresholdOption(String[] args, int index, ParseStateBuilder state, String arg) {
+        if ("--threshold".equals(arg)) {
+            state.threshold = parseThreshold(args, index, state.thresholdSeen);
+            state.thresholdSeen = true;
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean parseExclusionOption(String[] args, int index, ParseStateBuilder state, String arg) {
+        if ("--exclude".equals(arg)) {
+            state.excludes.add(parseListOption(args, index, "--exclude", "a glob"));
+            return true;
+        }
+        if ("--exclude-class".equals(arg)) {
+            state.excludeClasses.add(parseListOption(args, index, "--exclude-class", "a regex"));
+            return true;
+        }
+        if ("--exclude-annotation".equals(arg)) {
+            state.excludeAnnotations.add(parseListOption(args, index, "--exclude-annotation", "an annotation name"));
+            return true;
+        }
+        return false;
     }
 
     private static boolean parseAgent(boolean agentSeen) {

--- a/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
+++ b/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
@@ -5,8 +5,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
@@ -19,40 +22,104 @@ final class CrapAnalyzer {
     }
 
     static List<MethodMetrics> analyze(Path projectRoot, List<Path> changedFiles, Path jacocoXml) throws IOException {
+        return analyze(
+                projectRoot,
+                changedFiles,
+                jacocoXml,
+                SourceExclusionMatcher.create(projectRoot, SourceExclusionOptions.defaults()),
+                SourceExclusionAudit.builder()
+        );
+    }
+
+    static List<MethodMetrics> analyze(Path projectRoot,
+                                       List<Path> changedFiles,
+                                       Path jacocoXml,
+                                       SourceExclusionMatcher exclusions,
+                                       SourceExclusionAudit.Builder audit) throws IOException {
         Map<String, CoverageData> coverageMap = JacocoCoverageParser.parse(jacocoXml);
         List<MethodMetrics> metrics = new ArrayList<>();
+        Set<String> excludedClasses = new LinkedHashSet<>();
         Path normalizedProjectRoot = projectRoot.toAbsolutePath().normalize();
 
         for (Path file : changedFiles) {
-            if (!Files.exists(file)) {
-                continue;
-            }
-            Path normalizedFile = file.toAbsolutePath().normalize();
-            String source = Files.readString(file);
-            String primaryClassName = classNameFromSource(file, source);
-            List<MethodDescriptor> methods = JavaMethodParser.parse(primaryClassName, source);
-            for (MethodDescriptor method : methods) {
-                EffectiveCoverage coverage = lookupCoverage(coverageMap, method.className(), method.name(), method.startLine());
-                Double coveragePercent = coverage == null ? null : coverage.percent();
-                String coverageKind = coverage == null ? CoverageData.UNAVAILABLE_KIND : coverage.kind();
-                Double crap = CrapScore.calculate(method.complexity(), coveragePercent);
-                metrics.add(new MethodMetrics(
-                        method.name(),
-                        method.className(),
-                        sourcePath(normalizedProjectRoot, normalizedFile),
-                        method.startLine(),
-                        method.endLine(),
-                        method.complexity(),
-                        coveragePercent,
-                        coverageKind,
-                        crap
-                ));
-            }
+            analyzeFile(
+                    file,
+                    normalizedProjectRoot,
+                    coverageMap,
+                    exclusions,
+                    audit,
+                    excludedClasses,
+                    metrics
+            );
         }
 
         metrics.sort(Comparator.comparing(MethodMetrics::crapScore,
                 Comparator.nullsLast(Comparator.reverseOrder())));
         return metrics;
+    }
+
+    private static void analyzeFile(Path file,
+                                    Path projectRoot,
+                                    Map<String, CoverageData> coverageMap,
+                                    SourceExclusionMatcher exclusions,
+                                    SourceExclusionAudit.Builder audit,
+                                    Set<String> excludedClasses,
+                                    List<MethodMetrics> metrics) throws IOException {
+        if (!Files.exists(file)) {
+            return;
+        }
+        Path normalizedFile = file.toAbsolutePath().normalize();
+        String source = Files.readString(file);
+        String primaryClassName = classNameFromSource(file, source);
+        for (MethodDescriptor method : JavaMethodParser.parse(primaryClassName, source)) {
+            addMetricIfIncluded(method, projectRoot, normalizedFile, coverageMap, exclusions, audit, excludedClasses, metrics);
+        }
+    }
+
+    private static void addMetricIfIncluded(MethodDescriptor method,
+                                            Path projectRoot,
+                                            Path file,
+                                            Map<String, CoverageData> coverageMap,
+                                            SourceExclusionMatcher exclusions,
+                                            SourceExclusionAudit.Builder audit,
+                                            Set<String> excludedClasses,
+                                            List<MethodMetrics> metrics) {
+        Optional<String> classExclusion = exclusions.classExclusionReason(method.className(), method.classAnnotations());
+        if (classExclusion.isPresent()) {
+            recordExcludedClass(method, classExclusion.get(), audit, excludedClasses);
+            return;
+        }
+        metrics.add(methodMetric(method, projectRoot, file, coverageMap));
+    }
+
+    private static void recordExcludedClass(MethodDescriptor method,
+                                            String reason,
+                                            SourceExclusionAudit.Builder audit,
+                                            Set<String> excludedClasses) {
+        if (excludedClasses.add(method.className())) {
+            audit.recordExcludedClass(reason);
+        }
+    }
+
+    private static MethodMetrics methodMetric(MethodDescriptor method,
+                                              Path projectRoot,
+                                              Path file,
+                                              Map<String, CoverageData> coverageMap) {
+        EffectiveCoverage coverage = lookupCoverage(coverageMap, method.className(), method.name(), method.startLine());
+        Double coveragePercent = coverage == null ? null : coverage.percent();
+        String coverageKind = coverage == null ? CoverageData.UNAVAILABLE_KIND : coverage.kind();
+        Double crap = CrapScore.calculate(method.complexity(), coveragePercent);
+        return new MethodMetrics(
+                method.name(),
+                method.className(),
+                sourcePath(projectRoot, file),
+                method.startLine(),
+                method.endLine(),
+                method.complexity(),
+                coveragePercent,
+                coverageKind,
+                crap
+        );
     }
 
     private static String sourcePath(Path projectRoot, Path file) {

--- a/core/src/main/java/media/barney/crap/core/CrapReport.java
+++ b/core/src/main/java/media/barney/crap/core/CrapReport.java
@@ -6,14 +6,23 @@ import org.jspecify.annotations.Nullable;
 record CrapReport(
         String status,
         double threshold,
-        List<MethodReport> methods
+        List<MethodReport> methods,
+        SourceExclusionAudit exclusions
 ) {
+    CrapReport(String status, double threshold, List<MethodReport> methods) {
+        this(status, threshold, methods, SourceExclusionAudit.empty());
+    }
+
     static CrapReport from(List<MethodMetrics> metrics, double threshold) {
+        return from(metrics, threshold, SourceExclusionAudit.empty());
+    }
+
+    static CrapReport from(List<MethodMetrics> metrics, double threshold, SourceExclusionAudit exclusions) {
         double validatedThreshold = Thresholds.validate(threshold);
         List<MethodReport> methods = metrics.stream()
                 .map(metric -> MethodReport.from(metric, validatedThreshold))
                 .toList();
-        return new CrapReport(status(methods), validatedThreshold, methods);
+        return new CrapReport(status(methods), validatedThreshold, methods, exclusions);
     }
 
     private static String status(List<MethodReport> methods) {

--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -151,9 +151,10 @@ final class JavaMethodParser {
         }
 
         private List<String> currentClassAnnotations() {
-            return enclosingClassAnnotations.stream()
-                    .flatMap(List::stream)
-                    .toList();
+            if (enclosingClassAnnotations.isEmpty()) {
+                return List.of();
+            }
+            return enclosingClassAnnotations.get(enclosingClassAnnotations.size() - 1);
         }
     }
 

--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -83,6 +83,7 @@ final class JavaMethodParser {
         private final SourcePositions positions;
         private final List<MethodDescriptor> methods;
         private final List<String> enclosingClassNames = new ArrayList<>();
+        private final List<List<String>> enclosingClassAnnotations = new ArrayList<>();
 
         private MethodScanner(CompilationUnitTree unit,
                               SourcePositions positions,
@@ -100,9 +101,11 @@ final class JavaMethodParser {
                 return null;
             }
             enclosingClassNames.add(simpleName);
+            enclosingClassAnnotations.add(classAnnotations(node));
             try {
                 return super.visitClass(node, null);
             } finally {
+                enclosingClassAnnotations.remove(enclosingClassAnnotations.size() - 1);
                 enclosingClassNames.remove(enclosingClassNames.size() - 1);
             }
         }
@@ -118,8 +121,21 @@ final class JavaMethodParser {
             int startLine = lineNumber(start);
             int endLine = lineNumber(Math.decrementExact((int) bodyEndExclusive));
             int complexity = ComplexityCounter.count(node);
-            methods.add(new MethodDescriptor(currentClassName(), node.getName().toString(), startLine, endLine, complexity));
+            methods.add(new MethodDescriptor(
+                    currentClassName(),
+                    node.getName().toString(),
+                    startLine,
+                    endLine,
+                    complexity,
+                    currentClassAnnotations()
+            ));
             return null;
+        }
+
+        private static List<String> classAnnotations(ClassTree node) {
+            return node.getModifiers().getAnnotations().stream()
+                    .map(annotation -> annotation.getAnnotationType().toString())
+                    .toList();
         }
 
         private int lineNumber(long position) {
@@ -132,6 +148,12 @@ final class JavaMethodParser {
                 return simpleName;
             }
             return packageName + "." + simpleName;
+        }
+
+        private List<String> currentClassAnnotations() {
+            return enclosingClassAnnotations.stream()
+                    .flatMap(List::stream)
+                    .toList();
         }
     }
 

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -35,7 +35,8 @@ public final class Main {
                 out,
                 err,
                 ReportOptions.textWithOptionalJunit(null),
-                DEFAULT_THRESHOLD
+                DEFAULT_THRESHOLD,
+                SourceExclusionOptions.defaults()
         );
     }
 
@@ -59,7 +60,8 @@ public final class Main {
                 out,
                 err,
                 ReportOptions.textWithOptionalJunit(junitReportPath),
-                threshold
+                threshold,
+                SourceExclusionOptions.defaults()
         );
     }
 
@@ -73,6 +75,34 @@ public final class Main {
                                               @Nullable Path outputPath,
                                               @Nullable Path junitReportPath,
                                               double threshold) throws Exception {
+        return runWithExistingCoverage(
+                modules,
+                reportRoot,
+                out,
+                err,
+                reportFormat,
+                false,
+                failuresOnly,
+                omitRedundancy,
+                outputPath,
+                junitReportPath,
+                threshold,
+                SourceExclusionOptions.defaults()
+        );
+    }
+
+    public static int runWithExistingCoverage(List<ResolvedCoverageModule> modules,
+                                              Path reportRoot,
+                                              PrintStream out,
+                                              PrintStream err,
+                                              String reportFormat,
+                                              boolean agent,
+                                              boolean failuresOnly,
+                                              boolean omitRedundancy,
+                                              @Nullable Path outputPath,
+                                              @Nullable Path junitReportPath,
+                                              double threshold,
+                                              SourceExclusionOptions exclusionOptions) throws Exception {
         Path normalizedReportRoot = reportRoot.toAbsolutePath().normalize();
         return runResolvedModules(
                 modules,
@@ -82,11 +112,13 @@ public final class Main {
                 reportOptionsRelativeToRoot(
                         normalizedReportRoot,
                         reportFormat,
+                        agent,
                         failuresOnly,
                         omitRedundancy,
                         outputPath,
                         junitReportPath),
-                threshold
+                threshold,
+                exclusionOptions
         );
     }
 
@@ -116,21 +148,25 @@ public final class Main {
                                           PrintStream out,
                                           PrintStream err,
                                           ReportOptions reportOptions,
-                                          double threshold) throws Exception {
+                                          double threshold,
+                                          SourceExclusionOptions exclusionOptions) throws Exception {
         Thresholds.validate(threshold);
         writeThresholdWarning(err, threshold);
         List<MethodMetrics> metrics = new ArrayList<>();
+        SourceExclusionAudit.Builder audit = SourceExclusionAudit.builder();
+        SourceExclusionMatcher exclusions = SourceExclusionMatcher.create(reportRoot, exclusionOptions);
         for (ResolvedCoverageModule module : modules) {
-            if (module.sourceFiles().isEmpty()) {
+            List<Path> includedSources = SourceExclusionMatcher.filterFiles(module.sourceFiles(), exclusions, audit);
+            if (includedSources.isEmpty()) {
                 continue;
             }
             if (!Files.exists(module.coverageReport())) {
                 err.println("Warning: JaCoCo XML not found at " + module.coverageReport() + ". Coverage will be N/A.");
             }
-            metrics.addAll(CrapAnalyzer.analyze(reportRoot, module.sourceFiles(), module.coverageReport()));
+            metrics.addAll(CrapAnalyzer.analyze(reportRoot, includedSources, module.coverageReport(), exclusions, audit));
         }
 
-        CrapReport report = CrapReport.from(metrics, threshold);
+        CrapReport report = CrapReport.from(metrics, threshold, audit.build());
         ReportPublisher.publish(report, reportOptions, out);
 
         double max = Main.maxCrap(metrics);
@@ -152,6 +188,10 @@ public final class Main {
                   crap-java --agent                       Apply AI-agent defaults: toon, failures only, omit redundancy
                   crap-java --failures-only[=true|false]  Only include failing methods in the primary report
                   crap-java --omit-redundancy[=true|false]  Omit redundant method fields from the primary report
+                  crap-java --exclude '**/generated/**'    Exclude source paths by glob, repeatable
+                  crap-java --exclude-class '.*MapperImpl' Exclude fully-qualified class names by regex, repeatable
+                  crap-java --exclude-annotation Generated Exclude classes by annotation simple or qualified name, repeatable
+                  crap-java --use-default-exclusions[=true|false]  Enable generated-code defaults (default: true)
                   crap-java --output report.toon          Write the selected report format to a file
                   crap-java --junit-report report.xml     Also write a JUnit XML report for CI
                   crap-java --threshold 6                 Override the CRAP threshold (default: 8.0)
@@ -177,6 +217,7 @@ public final class Main {
 
     private static ReportOptions reportOptionsRelativeToRoot(Path root,
                                                              String reportFormat,
+                                                             boolean agent,
                                                              boolean failuresOnly,
                                                              boolean omitRedundancy,
                                                              @Nullable Path outputPath,
@@ -186,7 +227,8 @@ public final class Main {
                 failuresOnly,
                 omitRedundancy,
                 normalize(root, outputPath),
-                normalize(root, junitReportPath)
+                normalize(root, junitReportPath),
+                !agent
         );
     }
 

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -189,7 +189,7 @@ public final class Main {
                   crap-java --failures-only[=true|false]  Only include failing methods in the primary report
                   crap-java --omit-redundancy[=true|false]  Omit redundant method fields from the primary report
                   crap-java --exclude '**/generated/**'    Exclude source paths by glob, repeatable
-                  crap-java --exclude-class '.*MapperImpl' Exclude fully-qualified class names by regex, repeatable
+                  crap-java --exclude-class '.*MapperImpl$' Exclude fully-qualified class names by regex, repeatable
                   crap-java --exclude-annotation Generated Exclude classes by annotation simple or qualified name, repeatable
                   crap-java --use-default-exclusions[=true|false]  Enable generated-code defaults (default: true)
                   crap-java --output report.toon          Write the selected report format to a file

--- a/core/src/main/java/media/barney/crap/core/MethodDescriptor.java
+++ b/core/src/main/java/media/barney/crap/core/MethodDescriptor.java
@@ -1,11 +1,21 @@
 package media.barney.crap.core;
 
+import java.util.List;
+
 record MethodDescriptor(
         String className,
         String name,
         int startLine,
         int endLine,
-        int complexity
+        int complexity,
+        List<String> classAnnotations
 ) {
+    MethodDescriptor {
+        classAnnotations = List.copyOf(classAnnotations);
+    }
+
+    MethodDescriptor(String className, String name, int startLine, int endLine, int complexity) {
+        this(className, name, startLine, endLine, complexity, List.of());
+    }
 }
 

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -38,31 +38,59 @@ final class ReportFormatter {
     }
 
     static String format(CrapReport report, ReportFormat format, boolean failuresOnly, boolean omitRedundancy) {
+        return format(report, format, failuresOnly, omitRedundancy, true);
+    }
+
+    static String format(CrapReport report,
+                         ReportFormat format,
+                         boolean failuresOnly,
+                         boolean omitRedundancy,
+                         boolean includeExclusionAudit) {
         if (format == ReportFormat.NONE) {
             return "";
         }
-        return formatFull(failuresOnly ? failuresOnly(report) : report, format, omitRedundancy);
+        return formatFull(failuresOnly ? failuresOnly(report) : report, format, omitRedundancy, includeExclusionAudit);
     }
 
-    private static String formatFull(CrapReport report, ReportFormat format, boolean omitRedundancy) {
+    private static String formatFull(CrapReport report,
+                                     ReportFormat format,
+                                     boolean omitRedundancy,
+                                     boolean includeExclusionAudit) {
         return switch (format) {
-            case TOON -> JToon.encodeJson(formatJson(report, omitRedundancy));
-            case JSON -> formatJson(report, omitRedundancy);
-            case TEXT -> formatText(report, omitRedundancy);
-            case JUNIT -> formatJunit(report, omitRedundancy);
+            case TOON -> JToon.encodeJson(formatJson(report, omitRedundancy, includeExclusionAudit));
+            case JSON -> formatJson(report, omitRedundancy, includeExclusionAudit);
+            case TEXT -> formatText(report, omitRedundancy, includeExclusionAudit);
+            case JUNIT -> formatJunit(report, omitRedundancy, includeExclusionAudit);
             case NONE -> "";
         };
     }
 
-    private static String formatText(CrapReport report, boolean omitRedundancy) {
+    private static String formatText(CrapReport report, boolean omitRedundancy, boolean includeExclusionAudit) {
         List<CrapReport.MethodReport> sorted = sortedMethods(report.methods());
         StringBuilder builder = new StringBuilder();
         builder.append("CRAP Report\n");
         builder.append("===========\n");
         builder.append("Status: ").append(report.status()).append('\n');
         builder.append("Threshold: ").append(formatDisplayNumber(report.threshold())).append('\n');
+        if (includeExclusionAudit && hasExclusionAudit(report.exclusions())) {
+            appendExclusionAudit(builder, report.exclusions());
+        }
         appendMethodTable(builder, omitRedundancy ? methodTextColumns() : fullTextColumns(), sorted);
         return builder.toString();
+    }
+
+    private static void appendExclusionAudit(StringBuilder builder, SourceExclusionAudit audit) {
+        builder.append("Exclusions:\n");
+        builder.append("  Candidate files: ").append(audit.candidateFiles()).append('\n');
+        builder.append("  Analyzed files: ").append(audit.analyzedFiles()).append('\n');
+        builder.append("  Excluded files: ").append(audit.excludedFileCount()).append('\n');
+        for (SourceExclusionAudit.ExclusionCount count : audit.excludedFiles()) {
+            builder.append("    ").append(count.reason()).append(": ").append(count.count()).append('\n');
+        }
+        builder.append("  Excluded classes: ").append(audit.excludedClassCount()).append('\n');
+        for (SourceExclusionAudit.ExclusionCount count : audit.excludedClasses()) {
+            builder.append("    ").append(count.reason()).append(": ").append(count.count()).append('\n');
+        }
     }
 
     private static List<TableColumn> fullTextColumns() {
@@ -146,12 +174,12 @@ final class ReportFormatter {
         builder.append('\n');
     }
 
-    private static String formatJson(CrapReport report, boolean omitRedundancy) {
-        return writeJson(jsonReport(report, omitRedundancy));
+    private static String formatJson(CrapReport report, boolean omitRedundancy, boolean includeExclusionAudit) {
+        return writeJson(jsonReport(report, omitRedundancy, includeExclusionAudit));
     }
 
-    private static String formatJunit(CrapReport report, boolean omitRedundancy) {
-        return writeXml(junitTestSuites(report, omitRedundancy));
+    private static String formatJunit(CrapReport report, boolean omitRedundancy, boolean includeExclusionAudit) {
+        return writeXml(junitTestSuites(report, omitRedundancy, includeExclusionAudit));
     }
 
     private static int countStatus(List<CrapReport.MethodReport> methods, MethodStatus status) {
@@ -164,13 +192,25 @@ final class ReportFormatter {
         return count;
     }
 
-    private static JsonReport jsonReport(CrapReport report, boolean omitRedundancy) {
+    private static JsonReport jsonReport(CrapReport report, boolean omitRedundancy, boolean includeExclusionAudit) {
         return new JsonReport(
                 report.status(),
                 report.threshold(),
+                includeExclusionAudit && hasExclusionAudit(report.exclusions()) ? jsonExclusions(report.exclusions()) : null,
                 sortedMethods(report.methods()).stream()
                         .map(method -> jsonMethod(method, omitRedundancy))
                         .toList()
+        );
+    }
+
+    private static JsonExclusions jsonExclusions(SourceExclusionAudit audit) {
+        return new JsonExclusions(
+                audit.candidateFiles(),
+                audit.analyzedFiles(),
+                audit.excludedFileCount(),
+                audit.excludedClassCount(),
+                audit.excludedFiles(),
+                audit.excludedClasses()
         );
     }
 
@@ -196,7 +236,9 @@ final class ReportFormatter {
         }
     }
 
-    private static JunitTestSuites junitTestSuites(CrapReport report, boolean omitRedundancy) {
+    private static JunitTestSuites junitTestSuites(CrapReport report,
+                                                   boolean omitRedundancy,
+                                                   boolean includeExclusionAudit) {
         List<CrapReport.MethodReport> methods = sortedMethods(report.methods());
         int failed = countStatus(methods, MethodStatus.FAILED);
         int skipped = countStatus(methods, MethodStatus.SKIPPED);
@@ -207,7 +249,7 @@ final class ReportFormatter {
                 0,
                 skipped,
                 "0",
-                new JunitProperties(List.of(new JunitProperty("threshold", number(report.threshold())))),
+                new JunitProperties(junitSuiteProperties(report, includeExclusionAudit)),
                 methods.stream()
                         .map(method -> junitTestCase(method, report.threshold(), omitRedundancy))
                         .toList()
@@ -228,6 +270,29 @@ final class ReportFormatter {
                 junitFailure(method, threshold),
                 junitSkipped(method, threshold)
         );
+    }
+
+    private static List<JunitProperty> junitSuiteProperties(CrapReport report, boolean includeExclusionAudit) {
+        List<JunitProperty> properties = new ArrayList<>();
+        properties.add(new JunitProperty("threshold", number(report.threshold())));
+        if (includeExclusionAudit && hasExclusionAudit(report.exclusions())) {
+            SourceExclusionAudit audit = report.exclusions();
+            properties.add(new JunitProperty("exclusion.candidateFiles", Integer.toString(audit.candidateFiles())));
+            properties.add(new JunitProperty("exclusion.analyzedFiles", Integer.toString(audit.analyzedFiles())));
+            properties.add(new JunitProperty("exclusion.excludedFiles", Integer.toString(audit.excludedFileCount())));
+            properties.add(new JunitProperty("exclusion.excludedClasses", Integer.toString(audit.excludedClassCount())));
+            addCountProperties(properties, "exclusion.file", audit.excludedFiles());
+            addCountProperties(properties, "exclusion.class", audit.excludedClasses());
+        }
+        return properties;
+    }
+
+    private static void addCountProperties(List<JunitProperty> properties,
+                                           String prefix,
+                                           List<SourceExclusionAudit.ExclusionCount> counts) {
+        for (SourceExclusionAudit.ExclusionCount count : counts) {
+            properties.add(new JunitProperty(prefix + "." + count.reason(), Integer.toString(count.count())));
+        }
     }
 
     private static JunitProperties junitProperties(CrapReport.MethodReport method, boolean omitRedundancy) {
@@ -314,7 +379,14 @@ final class ReportFormatter {
         List<CrapReport.MethodReport> failedMethods = report.methods().stream()
                 .filter(method -> method.status() == MethodStatus.FAILED)
                 .toList();
-        return new CrapReport(report.status(), report.threshold(), failedMethods);
+        return new CrapReport(report.status(), report.threshold(), failedMethods, report.exclusions());
+    }
+
+    private static boolean hasExclusionAudit(SourceExclusionAudit audit) {
+        return audit.candidateFiles() != 0
+                || audit.analyzedFiles() != 0
+                || audit.excludedFileCount() != 0
+                || audit.excludedClassCount() != 0;
     }
 
     private static String formatCoverage(@Nullable Double coverage) {
@@ -342,7 +414,19 @@ final class ReportFormatter {
     private record JsonReport(
             String status,
             double threshold,
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            @Nullable JsonExclusions exclusions,
             List<JsonMethod> methods
+    ) {
+    }
+
+    private record JsonExclusions(
+            int candidateFiles,
+            int analyzedFiles,
+            int excludedFiles,
+            int excludedClasses,
+            List<SourceExclusionAudit.ExclusionCount> excludedFileReasons,
+            List<SourceExclusionAudit.ExclusionCount> excludedClassReasons
     ) {
     }
 

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -13,8 +13,17 @@ record ReportOptions(
         boolean failuresOnly,
         boolean omitRedundancy,
         @Nullable Path outputPath,
-        @Nullable Path junitReportPath
+        @Nullable Path junitReportPath,
+        boolean includeExclusionAudit
 ) {
+    ReportOptions(ReportFormat format,
+                  boolean failuresOnly,
+                  boolean omitRedundancy,
+                  @Nullable Path outputPath,
+                  @Nullable Path junitReportPath) {
+        this(format, failuresOnly, omitRedundancy, outputPath, junitReportPath, true);
+    }
+
     ReportOptions {
         outputPath = normalize(outputPath);
         junitReportPath = normalize(junitReportPath);
@@ -26,7 +35,7 @@ record ReportOptions(
     }
 
     static ReportOptions textWithOptionalJunit(@Nullable Path junitReportPath) {
-        return new ReportOptions(ReportFormat.TEXT, false, false, null, junitReportPath);
+        return new ReportOptions(ReportFormat.TEXT, false, false, null, junitReportPath, true);
     }
 
     private static @Nullable Path normalize(@Nullable Path path) {

--- a/core/src/main/java/media/barney/crap/core/ReportPublisher.java
+++ b/core/src/main/java/media/barney/crap/core/ReportPublisher.java
@@ -23,7 +23,8 @@ final class ReportPublisher {
                 report,
                 options.format(),
                 options.failuresOnly(),
-                options.omitRedundancy()
+                options.omitRedundancy(),
+                options.includeExclusionAudit()
         );
         if (options.outputPath() == null) {
             out.print(content);

--- a/core/src/main/java/media/barney/crap/core/SourceExclusionAudit.java
+++ b/core/src/main/java/media/barney/crap/core/SourceExclusionAudit.java
@@ -1,0 +1,81 @@
+package media.barney.crap.core;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+record SourceExclusionAudit(
+        int candidateFiles,
+        int analyzedFiles,
+        List<ExclusionCount> excludedFiles,
+        List<ExclusionCount> excludedClasses
+) {
+    SourceExclusionAudit {
+        excludedFiles = List.copyOf(excludedFiles);
+        excludedClasses = List.copyOf(excludedClasses);
+    }
+
+    static SourceExclusionAudit empty() {
+        return new SourceExclusionAudit(0, 0, List.of(), List.of());
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    int excludedFileCount() {
+        return excludedFiles.stream().mapToInt(ExclusionCount::count).sum();
+    }
+
+    int excludedClassCount() {
+        return excludedClasses.stream().mapToInt(ExclusionCount::count).sum();
+    }
+
+    record ExclusionCount(String reason, int count) {
+    }
+
+    static final class Builder {
+        private int candidateFiles;
+        private int analyzedFiles;
+        private final Map<String, Integer> excludedFiles = new LinkedHashMap<>();
+        private final Map<String, Integer> excludedClasses = new LinkedHashMap<>();
+
+        void recordCandidateFile() {
+            candidateFiles++;
+        }
+
+        void recordAnalyzedFile() {
+            analyzedFiles++;
+        }
+
+        void recordExcludedFile(String reason) {
+            increment(excludedFiles, reason);
+        }
+
+        void recordExcludedClass(String reason) {
+            increment(excludedClasses, reason);
+        }
+
+        SourceExclusionAudit build() {
+            return new SourceExclusionAudit(
+                    candidateFiles,
+                    analyzedFiles,
+                    counts(excludedFiles),
+                    counts(excludedClasses)
+            );
+        }
+
+        private static void increment(Map<String, Integer> counts, String reason) {
+            counts.merge(reason, 1, Integer::sum);
+        }
+
+        private static List<ExclusionCount> counts(Map<String, Integer> counts) {
+            List<ExclusionCount> result = new ArrayList<>();
+            for (Map.Entry<String, Integer> entry : counts.entrySet()) {
+                result.add(new ExclusionCount(entry.getKey(), entry.getValue()));
+            }
+            return result;
+        }
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/SourceExclusionMatcher.java
+++ b/core/src/main/java/media/barney/crap/core/SourceExclusionMatcher.java
@@ -1,0 +1,246 @@
+package media.barney.crap.core;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+final class SourceExclusionMatcher {
+
+    private static final List<String> DEFAULT_CLASS_REGEXES = List.of(
+            "(^|.*\\.)generated(\\..*)?",
+            "(^|.*\\.)gen(\\..*)?",
+            "(^|.*\\.)[^.]*MapperImpl$",
+            "(^|.*\\.)Dagger[^.]*$",
+            "(^|.*\\.)Hilt_[^.]*$",
+            "(^|.*\\.)AutoValue_[^.]*$"
+    );
+    private static final String DEFAULT_GENERATED_ANNOTATION = "Generated";
+
+    private final Path projectRoot;
+    private final boolean useDefaultExclusions;
+    private final List<GlobRule> userPathRules;
+    private final List<RegexRule> defaultClassRules;
+    private final List<RegexRule> userClassRules;
+    private final List<String> defaultAnnotationNames;
+    private final List<String> userAnnotationNames;
+
+    private SourceExclusionMatcher(Path projectRoot,
+                                   SourceExclusionOptions options) {
+        this.projectRoot = projectRoot.toAbsolutePath().normalize();
+        this.useDefaultExclusions = options.useDefaultExclusions();
+        this.userPathRules = options.excludes().stream()
+                .map(pattern -> new GlobRule(pattern, globToRegex(pattern)))
+                .toList();
+        this.defaultClassRules = useDefaultExclusions
+                ? DEFAULT_CLASS_REGEXES.stream().map(pattern -> regexRule(pattern, true)).toList()
+                : List.of();
+        this.userClassRules = options.excludeClasses().stream()
+                .map(pattern -> regexRule(pattern, false))
+                .toList();
+        this.defaultAnnotationNames = useDefaultExclusions ? List.of(DEFAULT_GENERATED_ANNOTATION) : List.of();
+        this.userAnnotationNames = List.copyOf(options.excludeAnnotations());
+    }
+
+    static SourceExclusionMatcher create(Path projectRoot, SourceExclusionOptions options) {
+        return new SourceExclusionMatcher(projectRoot, options);
+    }
+
+    Optional<String> pathExclusionReason(Path file) {
+        String relativePath = normalizedRelativePath(file);
+        if (useDefaultExclusions && isUnderGeneratedDirectory(relativePath)) {
+            return Optional.of("default:path:generated-directory");
+        }
+        if (useDefaultExclusions && isUnderSrcMainJavaGen(relativePath)) {
+            return Optional.of("default:path:src-main-java-gen");
+        }
+        for (GlobRule rule : userPathRules) {
+            if (rule.pattern().matcher(relativePath).matches()) {
+                return Optional.of("user:path:" + rule.glob());
+            }
+        }
+        return Optional.empty();
+    }
+
+    Optional<String> classExclusionReason(String className, List<String> annotationNames) {
+        return classRegexExclusionReason(className)
+                .or(() -> annotationExclusionReason(annotationNames));
+    }
+
+    private Optional<String> classRegexExclusionReason(String className) {
+        for (RegexRule rule : defaultClassRules) {
+            if (rule.pattern().matcher(className).matches()) {
+                return Optional.of(rule.reason());
+            }
+        }
+        for (RegexRule rule : userClassRules) {
+            if (rule.pattern().matcher(className).matches()) {
+                return Optional.of(rule.reason());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> annotationExclusionReason(List<String> annotationNames) {
+        for (String annotationName : annotationNames) {
+            Optional<String> reason = annotationExclusionReason(annotationName, defaultAnnotationNames, "default");
+            if (reason.isPresent()) {
+                return reason;
+            }
+            reason = annotationExclusionReason(annotationName, userAnnotationNames, "user");
+            if (reason.isPresent()) {
+                return reason;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> annotationExclusionReason(String annotationName,
+                                                             List<String> excludedNames,
+                                                             String origin) {
+        for (String excludedName : excludedNames) {
+            if (matchesAnnotation(annotationName, excludedName)) {
+                return Optional.of(origin + ":annotation:" + excludedName);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String normalizedRelativePath(Path file) {
+        Path normalized = file.toAbsolutePath().normalize();
+        Path path = normalized.startsWith(projectRoot) ? projectRoot.relativize(normalized) : normalized;
+        return path.normalize().toString().replace('\\', '/');
+    }
+
+    private static boolean isUnderGeneratedDirectory(String normalizedPath) {
+        int lastSeparator = normalizedPath.lastIndexOf('/');
+        if (lastSeparator < 0) {
+            return false;
+        }
+        int segmentStart = 0;
+        while (segmentStart < lastSeparator) {
+            int segmentEnd = normalizedPath.indexOf('/', segmentStart);
+            if (segmentEnd < 0 || segmentEnd > lastSeparator) {
+                segmentEnd = lastSeparator;
+            }
+            if (normalizedPath.substring(segmentStart, segmentEnd).contains("generated")) {
+                return true;
+            }
+            segmentStart = segmentEnd + 1;
+        }
+        return false;
+    }
+
+    private static boolean isUnderSrcMainJavaGen(String normalizedPath) {
+        String marker = "src/main/java-gen/";
+        return normalizedPath.startsWith(marker) || normalizedPath.contains("/" + marker);
+    }
+
+    private static boolean matchesAnnotation(String annotationName, String excludedName) {
+        if (excludedName.contains(".")) {
+            return annotationName.equals(excludedName);
+        }
+        return simpleName(annotationName).equals(excludedName);
+    }
+
+    private static String simpleName(String name) {
+        int separator = name.lastIndexOf('.');
+        return separator < 0 ? name : name.substring(separator + 1);
+    }
+
+    private static RegexRule regexRule(String pattern, boolean defaultRule) {
+        try {
+            return new RegexRule(
+                    pattern,
+                    Pattern.compile(pattern),
+                    (defaultRule ? "default:class:" : "user:class:") + pattern
+            );
+        } catch (PatternSyntaxException ex) {
+            throw new IllegalArgumentException("Invalid exclude-class regex: " + pattern, ex);
+        }
+    }
+
+    private static Pattern globToRegex(String glob) {
+        String normalized = normalizeGlob(glob);
+        StringBuilder regex = new StringBuilder("^");
+        for (int index = 0; index < normalized.length(); index++) {
+            index = appendGlobToken(regex, normalized, index);
+        }
+        regex.append('$');
+        return Pattern.compile(regex.toString());
+    }
+
+    private static int appendGlobToken(StringBuilder regex, String glob, int index) {
+        char current = glob.charAt(index);
+        if (current == '*') {
+            return appendStarGlobToken(regex, glob, index);
+        }
+        if (current == '?') {
+            regex.append("[^/]");
+            return index;
+        }
+        appendRegexLiteral(regex, current);
+        return index;
+    }
+
+    private static int appendStarGlobToken(StringBuilder regex, String glob, int index) {
+        if (index + 1 >= glob.length() || glob.charAt(index + 1) != '*') {
+            regex.append("[^/]*");
+            return index;
+        }
+        if (index + 2 < glob.length() && glob.charAt(index + 2) == '/') {
+            regex.append("(?:.*/)?");
+            return index + 2;
+        }
+        regex.append(".*");
+        return index + 1;
+    }
+
+    private static String normalizeGlob(String glob) {
+        String normalized = glob.trim().replace('\\', '/');
+        while (normalized.startsWith("./")) {
+            normalized = normalized.substring(2);
+        }
+        return normalized;
+    }
+
+    private static void appendRegexLiteral(StringBuilder regex, char current) {
+        if ("\\.[]{}()+-^$|".indexOf(current) >= 0) {
+            regex.append('\\');
+        }
+        regex.append(current);
+    }
+
+    static List<Path> filterFiles(Path projectRoot,
+                                  List<Path> files,
+                                  SourceExclusionOptions options,
+                                  SourceExclusionAudit.Builder audit) {
+        SourceExclusionMatcher matcher = create(projectRoot, options);
+        return filterFiles(files, matcher, audit);
+    }
+
+    static List<Path> filterFiles(List<Path> files,
+                                  SourceExclusionMatcher matcher,
+                                  SourceExclusionAudit.Builder audit) {
+        List<Path> included = new ArrayList<>();
+        for (Path file : files) {
+            audit.recordCandidateFile();
+            Optional<String> reason = matcher.pathExclusionReason(file);
+            if (reason.isPresent()) {
+                audit.recordExcludedFile(reason.get());
+                continue;
+            }
+            audit.recordAnalyzedFile();
+            included.add(file);
+        }
+        return included;
+    }
+
+    private record GlobRule(String glob, Pattern pattern) {
+    }
+
+    private record RegexRule(String regex, Pattern pattern, String reason) {
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/SourceExclusionMatcher.java
+++ b/core/src/main/java/media/barney/crap/core/SourceExclusionMatcher.java
@@ -139,10 +139,7 @@ final class SourceExclusionMatcher {
     }
 
     private static boolean matchesAnnotation(String annotationName, String excludedName) {
-        if (excludedName.contains(".")) {
-            return annotationName.equals(excludedName);
-        }
-        return simpleName(annotationName).equals(excludedName);
+        return annotationName.equals(excludedName) || simpleName(annotationName).equals(simpleName(excludedName));
     }
 
     private static String simpleName(String name) {

--- a/core/src/main/java/media/barney/crap/core/SourceExclusionOptions.java
+++ b/core/src/main/java/media/barney/crap/core/SourceExclusionOptions.java
@@ -1,0 +1,29 @@
+package media.barney.crap.core;
+
+import java.util.List;
+import java.util.Objects;
+
+public record SourceExclusionOptions(
+        List<String> excludes,
+        List<String> excludeClasses,
+        List<String> excludeAnnotations,
+        boolean useDefaultExclusions
+) {
+    public SourceExclusionOptions {
+        excludes = normalized(excludes);
+        excludeClasses = normalized(excludeClasses);
+        excludeAnnotations = normalized(excludeAnnotations);
+    }
+
+    public static SourceExclusionOptions defaults() {
+        return new SourceExclusionOptions(List.of(), List.of(), List.of(), true);
+    }
+
+    private static List<String> normalized(List<String> values) {
+        return values.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .toList();
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/SourceExclusionOptions.java
+++ b/core/src/main/java/media/barney/crap/core/SourceExclusionOptions.java
@@ -20,6 +20,9 @@ public record SourceExclusionOptions(
     }
 
     private static List<String> normalized(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
         return values.stream()
                 .filter(Objects::nonNull)
                 .map(String::trim)

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -73,6 +73,23 @@ class CliArgumentsParserTest {
     }
 
     @Test
+    void sourceExclusionOptionsAreParsed() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{
+                "--exclude", "module-a/**",
+                "--exclude", "**/generated/**",
+                "--exclude-class", ".*MapperImpl$",
+                "--exclude-annotation", "Generated",
+                "--use-default-exclusions=false",
+                "--changed"
+        });
+
+        assertEquals(List.of("module-a/**", "**/generated/**"), args.exclusionOptions().excludes());
+        assertEquals(List.of(".*MapperImpl$"), args.exclusionOptions().excludeClasses());
+        assertEquals(List.of("Generated"), args.exclusionOptions().excludeAnnotations());
+        assertFalse(args.exclusionOptions().useDefaultExclusions());
+    }
+
+    @Test
     void agentModeDefaultsToToon() {
         CliArguments args = CliArgumentsParser.parse(new String[]{"--agent", "--changed"});
 
@@ -286,6 +303,18 @@ class CliArgumentsParserTest {
     void junitReportCanOnlyBeProvidedOnce() {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--junit-report", "one.xml", "--junit-report", "two.xml"}));
+    }
+
+    @Test
+    void sourceExclusionOptionsRequireValues() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--exclude"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--exclude-class"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--exclude-annotation"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--use-default-exclusions=maybe"}));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
+++ b/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
@@ -177,6 +177,63 @@ class CrapAnalyzerTest {
     }
 
     @Test
+    void generatedAnnotationExclusionDoesNotApplyOuterAnnotationsToNestedClasses() throws IOException {
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Outer.java");
+        Files.writeString(source, """
+                package demo;
+
+                @interface Generated {
+                }
+
+                @Generated
+                class Outer {
+                    int outer() {
+                        return 1;
+                    }
+
+                    static class Inner {
+                        int inner() {
+                            return 2;
+                        }
+                    }
+                }
+                """);
+
+        Path jacoco = tempDir.resolve("jacoco.xml");
+        Files.writeString(jacoco, """
+                <report>
+                  <package name="demo">
+                    <class name="demo/Outer" sourcefilename="Outer.java">
+                      <method name="outer" desc="()I" line="8">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                    <class name="demo/Outer$Inner" sourcefilename="Outer.java">
+                      <method name="inner" desc="()I" line="13">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+        SourceExclusionAudit.Builder audit = SourceExclusionAudit.builder();
+
+        List<MethodMetrics> result = CrapAnalyzer.analyze(
+                tempDir,
+                List.of(source),
+                jacoco,
+                SourceExclusionMatcher.create(tempDir, SourceExclusionOptions.defaults()),
+                audit
+        );
+
+        assertEquals(List.of("inner"), result.stream().map(MethodMetrics::methodName).toList());
+        assertEquals("demo.Outer$Inner", result.get(0).className());
+        assertEquals(1, audit.build().excludedClassCount());
+    }
+
+    @Test
     void usesSimpleClassNameWhenSourceHasNoPackage() {
         String className = CrapAnalyzer.classNameFromSource(
                 Path.of("src/main/java/Sample.java"),

--- a/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
+++ b/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
@@ -143,6 +143,40 @@ class CrapAnalyzerTest {
     }
 
     @Test
+    void excludesClassesAnnotatedWithGeneratedSimpleNameFromAnyPackage() throws IOException {
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+
+                @javax.annotation.processing.Generated("tool")
+                class Sample {
+                    int alpha(boolean a) {
+                        if (a) {
+                            return 1;
+                        }
+                        return 0;
+                    }
+                }
+                """);
+
+        Path jacoco = tempDir.resolve("jacoco.xml");
+        Files.writeString(jacoco, "<report/>");
+        SourceExclusionAudit.Builder audit = SourceExclusionAudit.builder();
+        List<MethodMetrics> result = CrapAnalyzer.analyze(
+                tempDir,
+                List.of(source),
+                jacoco,
+                SourceExclusionMatcher.create(tempDir, SourceExclusionOptions.defaults()),
+                audit
+        );
+
+        assertEquals(List.of(), result);
+        assertEquals(1, audit.build().excludedClassCount());
+    }
+
+    @Test
     void usesSimpleClassNameWhenSourceHasNoPackage() {
         String className = CrapAnalyzer.classNameFromSource(
                 Path.of("src/main/java/Sample.java"),

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -438,6 +438,48 @@ class ReportFormatterTest {
         assertEquals("amp&apos'quote\"lt<gt>", propertyValue(parseXml(junit), "methodName"));
     }
 
+    @Test
+    void fullReportsCanIncludeExclusionAudit() throws Exception {
+        CrapReport report = CrapReport.from(
+                List.of(metric("safe", "demo.Sample", 4, 1, 100.0, 1.0)),
+                Main.DEFAULT_THRESHOLD,
+                new SourceExclusionAudit(
+                        2,
+                        1,
+                        List.of(new SourceExclusionAudit.ExclusionCount("default:path:generated-directory", 1)),
+                        List.of(new SourceExclusionAudit.ExclusionCount("default:annotation:Generated", 1))
+                )
+        );
+
+        String json = ReportFormatter.format(report, ReportFormat.JSON);
+        String text = ReportFormatter.format(report, ReportFormat.TEXT);
+        String junit = ReportFormatter.format(report, ReportFormat.JUNIT);
+
+        assertTrue(json.contains("\"exclusions\""));
+        assertTrue(json.contains("\"excludedFiles\": 1"));
+        assertTrue(text.contains("Exclusions:"));
+        assertEquals("1", propertyValue(parseXml(junit), "exclusion.excludedFiles"));
+        assertEquals("1", propertyValue(parseXml(junit), "exclusion.excludedClasses"));
+    }
+
+    @Test
+    void optimizedPrimaryReportsCanOmitExclusionAudit() {
+        CrapReport report = CrapReport.from(
+                List.of(metric("danger", "demo.Sample", 4, 5, 10.0, 9.645)),
+                Main.DEFAULT_THRESHOLD,
+                new SourceExclusionAudit(
+                        2,
+                        1,
+                        List.of(new SourceExclusionAudit.ExclusionCount("default:path:generated-directory", 1)),
+                        List.of()
+                )
+        );
+
+        String json = ReportFormatter.format(report, ReportFormat.JSON, true, true, false);
+
+        assertFalse(json.contains("\"exclusions\""));
+    }
+
     private static CrapReport report(MethodMetrics... metrics) {
         return CrapReport.from(List.of(metrics), Main.DEFAULT_THRESHOLD);
     }

--- a/core/src/test/java/media/barney/crap/core/SourceExclusionIntegrationTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceExclusionIntegrationTest.java
@@ -1,0 +1,135 @@
+package media.barney.crap.core;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SourceExclusionIntegrationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void defaultGeneratedPathExclusionsPreventThresholdFailures() throws Exception {
+        Path source = writeGeneratedSource();
+        Path jacoco = writeZeroCoverageReport();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacoco, List.of(source))),
+                tempDir,
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8),
+                "json",
+                false,
+                false,
+                false,
+                null,
+                null,
+                1.0,
+                SourceExclusionOptions.defaults()
+        );
+
+        String report = out.toString(StandardCharsets.UTF_8);
+        assertEquals(0, exit);
+        assertTrue(report.contains("\"excludedFiles\": 1"));
+        assertFalse(report.contains("\"method\": \"alpha\""));
+    }
+
+    @Test
+    void disabledDefaultsAllowGeneratedSourcesToFailThresholds() throws Exception {
+        Path source = writeGeneratedSource();
+        Path jacoco = writeZeroCoverageReport();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacoco, List.of(source))),
+                tempDir,
+                new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8),
+                "none",
+                false,
+                false,
+                false,
+                null,
+                null,
+                1.0,
+                new SourceExclusionOptions(List.of(), List.of(), List.of(), false)
+        );
+
+        assertEquals(2, exit);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("CRAP threshold exceeded"));
+    }
+
+    @Test
+    void agentPrimaryReportOmitsExclusionAuditWhileJunitSidecarKeepsIt() throws Exception {
+        Path source = writeGeneratedSource();
+        Path jacoco = writeZeroCoverageReport();
+        Path junit = tempDir.resolve("target/crap-java/TEST-crap-java.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        int exit = Main.runWithExistingCoverage(
+                List.of(new Main.ResolvedCoverageModule(tempDir, jacoco, List.of(source))),
+                tempDir,
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8),
+                "json",
+                true,
+                true,
+                true,
+                null,
+                junit,
+                1.0,
+                SourceExclusionOptions.defaults()
+        );
+
+        assertEquals(0, exit);
+        assertFalse(out.toString(StandardCharsets.UTF_8).contains("\"exclusions\""));
+        assertTrue(Files.readString(junit).contains("exclusion.excludedFiles"));
+    }
+
+    private Path writeGeneratedSource() throws Exception {
+        Path source = tempDir.resolve("src/main/java/demo/generated/Sample.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package demo.generated;
+
+                class Sample {
+                    int alpha(boolean a) {
+                        if (a) {
+                            return 1;
+                        }
+                        return 0;
+                    }
+                }
+                """);
+        return source;
+    }
+
+    private Path writeZeroCoverageReport() throws Exception {
+        Path jacoco = tempDir.resolve("jacoco.xml");
+        Files.writeString(jacoco, """
+                <report>
+                  <package name="demo/generated">
+                    <class name="demo/generated/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="(Z)I" line="4">
+                        <counter type="INSTRUCTION" missed="4" covered="0"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+        return jacoco;
+    }
+}

--- a/core/src/test/java/media/barney/crap/core/SourceExclusionMatcherTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceExclusionMatcherTest.java
@@ -72,6 +72,29 @@ class SourceExclusionMatcherTest {
     }
 
     @Test
+    void userGlobExclusionsSupportDoubleStarSingleStarAndQuestionMark() {
+        Path numbered = tempDir.resolve("module/src/main/java/demo/Sample1.java");
+        Path named = tempDir.resolve("module/src/main/java/demo/SampleName.java");
+        Path nested = tempDir.resolve("module/src/main/java/demo/nested/Sample2.java");
+        SourceExclusionAudit.Builder audit = SourceExclusionAudit.builder();
+
+        List<Path> included = SourceExclusionMatcher.filterFiles(
+                tempDir,
+                List.of(numbered, named, nested),
+                new SourceExclusionOptions(
+                        List.of("**/demo/Sample?.java", "**/demo/*.java"),
+                        List.of(),
+                        List.of(),
+                        false
+                ),
+                audit
+        );
+
+        assertEquals(List.of(nested), included);
+        assertEquals(2, audit.build().excludedFileCount());
+    }
+
+    @Test
     void defaultClassRegexesAreGeneratedFocused() {
         SourceExclusionMatcher matcher = SourceExclusionMatcher.create(tempDir, SourceExclusionOptions.defaults());
 

--- a/core/src/test/java/media/barney/crap/core/SourceExclusionMatcherTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceExclusionMatcherTest.java
@@ -1,0 +1,98 @@
+package media.barney.crap.core;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SourceExclusionMatcherTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void defaultPathExclusionsMatchGeneratedDirectorySegmentsAndJavaGen() {
+        Path generated = tempDir.resolve("src/main/java/demo/generated/Sample.java");
+        Path generatedSources = tempDir.resolve("module/src/main/generated-sources/demo/Sample.java");
+        Path javaGen = tempDir.resolve("module/src/main/java-gen/demo/Sample.java");
+        Path handwritten = tempDir.resolve("src/main/java/demo/GeneratedName.java");
+        SourceExclusionAudit.Builder audit = SourceExclusionAudit.builder();
+
+        List<Path> included = SourceExclusionMatcher.filterFiles(
+                tempDir,
+                List.of(generated, generatedSources, javaGen, handwritten),
+                SourceExclusionOptions.defaults(),
+                audit
+        );
+
+        SourceExclusionAudit result = audit.build();
+        assertEquals(List.of(handwritten), included);
+        assertEquals(4, result.candidateFiles());
+        assertEquals(1, result.analyzedFiles());
+        assertEquals(3, result.excludedFileCount());
+    }
+
+    @Test
+    void disabledDefaultsKeepGeneratedPathsUnlessUserGlobMatches() {
+        Path generated = tempDir.resolve("src/main/java/demo/generated/Sample.java");
+        Path javaGen = tempDir.resolve("src/main/java-gen/demo/Sample.java");
+        SourceExclusionAudit.Builder audit = SourceExclusionAudit.builder();
+
+        List<Path> included = SourceExclusionMatcher.filterFiles(
+                tempDir,
+                List.of(generated, javaGen),
+                new SourceExclusionOptions(List.of(), List.of(), List.of(), false),
+                audit
+        );
+
+        assertEquals(List.of(generated, javaGen), included);
+        assertEquals(0, audit.build().excludedFileCount());
+    }
+
+    @Test
+    void userGlobExclusionsUseNormalizedRelativePaths() {
+        Path moduleSource = tempDir.resolve("module-a/src/main/java/demo/Sample.java");
+        Path otherSource = tempDir.resolve("module-b/src/main/java/demo/Sample.java");
+        SourceExclusionAudit.Builder audit = SourceExclusionAudit.builder();
+
+        List<Path> included = SourceExclusionMatcher.filterFiles(
+                tempDir,
+                List.of(moduleSource, otherSource),
+                new SourceExclusionOptions(List.of("module-a/**"), List.of(), List.of(), false),
+                audit
+        );
+
+        assertEquals(List.of(otherSource), included);
+        assertEquals(1, audit.build().excludedFileCount());
+    }
+
+    @Test
+    void defaultClassRegexesAreGeneratedFocused() {
+        SourceExclusionMatcher matcher = SourceExclusionMatcher.create(tempDir, SourceExclusionOptions.defaults());
+
+        assertTrue(matcher.classExclusionReason("demo.generated.Sample", List.of()).isPresent());
+        assertTrue(matcher.classExclusionReason("demo.SampleMapperImpl", List.of()).isPresent());
+        assertTrue(matcher.classExclusionReason("demo.DaggerComponent", List.of()).isPresent());
+        assertTrue(matcher.classExclusionReason("demo.Hilt_Service", List.of()).isPresent());
+        assertTrue(matcher.classExclusionReason("demo.AutoValue_User", List.of()).isPresent());
+        assertFalse(matcher.classExclusionReason("demo.QueryParser", List.of()).isPresent());
+        assertFalse(matcher.classExclusionReason("demo.BaseListener", List.of()).isPresent());
+        assertFalse(matcher.classExclusionReason("demo.ImmutableUser", List.of()).isPresent());
+    }
+
+    @Test
+    void generatedAnnotationDefaultMatchesSimpleNameFromAnyPackage() {
+        SourceExclusionMatcher matcher = SourceExclusionMatcher.create(tempDir, SourceExclusionOptions.defaults());
+
+        assertTrue(matcher.classExclusionReason("demo.Sample", List.of("Generated")).isPresent());
+        assertTrue(matcher.classExclusionReason("demo.Sample", List.of("javax.annotation.Generated")).isPresent());
+        assertTrue(matcher.classExclusionReason("demo.Sample", List.of("jakarta.annotation.Generated")).isPresent());
+        assertTrue(matcher.classExclusionReason("demo.Sample", List.of("com.acme.Generated")).isPresent());
+        assertFalse(matcher.classExclusionReason("demo.Sample", List.of("com.acme.GeneratedValue")).isPresent());
+    }
+}

--- a/core/src/test/java/media/barney/crap/core/SourceExclusionMatcherTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceExclusionMatcherTest.java
@@ -16,6 +16,18 @@ class SourceExclusionMatcherTest {
     Path tempDir;
 
     @Test
+    void sourceExclusionOptionsTreatNullListsAsEmpty() throws ReflectiveOperationException {
+        SourceExclusionOptions options = SourceExclusionOptions.class
+                .getDeclaredConstructor(List.class, List.class, List.class, boolean.class)
+                .newInstance(null, null, null, true);
+
+        assertEquals(List.of(), options.excludes());
+        assertEquals(List.of(), options.excludeClasses());
+        assertEquals(List.of(), options.excludeAnnotations());
+        assertTrue(options.useDefaultExclusions());
+    }
+
+    @Test
     void defaultPathExclusionsMatchGeneratedDirectorySegmentsAndJavaGen() {
         Path generated = tempDir.resolve("src/main/java/demo/generated/Sample.java");
         Path generatedSources = tempDir.resolve("module/src/main/generated-sources/demo/Sample.java");

--- a/core/src/test/java/media/barney/crap/core/SourceExclusionMatcherTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceExclusionMatcherTest.java
@@ -130,4 +130,14 @@ class SourceExclusionMatcherTest {
         assertTrue(matcher.classExclusionReason("demo.Sample", List.of("com.acme.Generated")).isPresent());
         assertFalse(matcher.classExclusionReason("demo.Sample", List.of("com.acme.GeneratedValue")).isPresent());
     }
+
+    @Test
+    void userQualifiedAnnotationMatchesCapturedSimpleName() {
+        SourceExclusionMatcher matcher = SourceExclusionMatcher.create(
+                tempDir,
+                new SourceExclusionOptions(List.of(), List.of(), List.of("com.acme.Generated"), false)
+        );
+
+        assertTrue(matcher.classExclusionReason("demo.Sample", List.of("Generated")).isPresent());
+    }
 }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -1,6 +1,7 @@
 package media.barney.crap.gradle;
 
 import media.barney.crap.core.Main;
+import media.barney.crap.core.SourceExclusionOptions;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -10,6 +11,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
@@ -90,6 +92,10 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         getOmitRedundancy().convention(getAgent());
         getJunit().convention(true);
         getJunitReport().convention(defaultJunitReport);
+        getExcludes().convention(List.of());
+        getExcludeClasses().convention(List.of());
+        getExcludeAnnotations().convention(List.of());
+        getUseDefaultExclusions().convention(true);
     }
 
     @Internal
@@ -131,6 +137,18 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     @Internal
     public abstract RegularFileProperty getJunitReport();
+
+    @Input
+    public abstract ListProperty<String> getExcludes();
+
+    @Input
+    public abstract ListProperty<String> getExcludeClasses();
+
+    @Input
+    public abstract ListProperty<String> getExcludeAnnotations();
+
+    @Input
+    public abstract Property<Boolean> getUseDefaultExclusions();
 
     @Input
     @Optional
@@ -213,11 +231,18 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                         out,
                         err,
                         getFormat().get(),
+                        getAgent().get(),
                         getFailuresOnly().get(),
                         getOmitRedundancy().get(),
                         configuredOutputPath,
                         configuredJunitReportPath,
-                        getThreshold().get()
+                        getThreshold().get(),
+                        new SourceExclusionOptions(
+                                getExcludes().get(),
+                                getExcludeClasses().get(),
+                                getExcludeAnnotations().get(),
+                                getUseDefaultExclusions().get()
+                        )
                 );
             } catch (Exception exception) {
                 rememberChangedReportState(

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaExtension.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaExtension.java
@@ -1,6 +1,7 @@
 package media.barney.crap.gradle;
 
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 public abstract class CrapJavaExtension {
@@ -20,4 +21,12 @@ public abstract class CrapJavaExtension {
     public abstract Property<Boolean> getJunit();
 
     public abstract RegularFileProperty getJunitReport();
+
+    public abstract ListProperty<String> getExcludes();
+
+    public abstract ListProperty<String> getExcludeClasses();
+
+    public abstract ListProperty<String> getExcludeAnnotations();
+
+    public abstract Property<Boolean> getUseDefaultExclusions();
 }

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
@@ -29,6 +29,10 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
         extension.getJunit().convention(true);
         extension.getJunitReport().convention(project.getLayout().getBuildDirectory()
                 .file("reports/crap-java/TEST-crap-java.xml"));
+        extension.getExcludes().convention(List.of());
+        extension.getExcludeClasses().convention(List.of());
+        extension.getExcludeAnnotations().convention(List.of());
+        extension.getUseDefaultExclusions().convention(true);
 
         TaskProvider<CrapJavaCheckTask> checkTask = project.getTasks().register(
                 "crap-java-check",
@@ -45,6 +49,10 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
                     task.getOutput().convention(extension.getOutput());
                     task.getJunit().convention(extension.getJunit());
                     task.getJunitReport().convention(extension.getJunitReport());
+                    task.getExcludes().convention(extension.getExcludes());
+                    task.getExcludeClasses().convention(extension.getExcludeClasses());
+                    task.getExcludeAnnotations().convention(extension.getExcludeAnnotations());
+                    task.getUseDefaultExclusions().convention(extension.getUseDefaultExclusions());
                 }
         );
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -55,6 +55,10 @@ class CrapJavaGradlePluginTest {
         assertTrue(extension.getJunitReport().get().getAsFile().toPath().normalize().toString()
                 .replace('\\', '/')
                 .endsWith("build/reports/crap-java/TEST-crap-java.xml"));
+        assertEquals(List.of(), extension.getExcludes().get());
+        assertEquals(List.of(), extension.getExcludeClasses().get());
+        assertEquals(List.of(), extension.getExcludeAnnotations().get());
+        assertTrue(extension.getUseDefaultExclusions().get());
         assertEquals(8.0, checkTask.getThreshold().get());
         assertEquals("none", checkTask.getFormat().get());
         assertFalse(checkTask.getAgent().get());
@@ -70,6 +74,10 @@ class CrapJavaGradlePluginTest {
         assertTrue(checkTask.getJunitReport().get().getAsFile().toPath().normalize().toString()
                 .replace('\\', '/')
                 .endsWith("build/reports/crap-java/TEST-crap-java.xml"));
+        assertEquals(List.of(), checkTask.getExcludes().get());
+        assertEquals(List.of(), checkTask.getExcludeClasses().get());
+        assertEquals(List.of(), checkTask.getExcludeAnnotations().get());
+        assertTrue(checkTask.getUseDefaultExclusions().get());
         assertTrue(checkTask.getJunitReportOutput().isPresent());
         assertNotNull(project.getTasks().findByName("jacocoTestReport"));
     }
@@ -103,6 +111,10 @@ class CrapJavaGradlePluginTest {
         extension.getOutput().fileValue(output.toFile());
         extension.getJunit().set(false);
         extension.getJunitReport().fileValue(junitReport.toFile());
+        extension.getExcludes().set(List.of("module-a/**"));
+        extension.getExcludeClasses().set(List.of(".*MapperImpl$"));
+        extension.getExcludeAnnotations().set(List.of("Generated"));
+        extension.getUseDefaultExclusions().set(false);
 
         CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
 
@@ -113,6 +125,10 @@ class CrapJavaGradlePluginTest {
         assertEquals(output.normalize(), checkTask.getOutput().get().getAsFile().toPath().normalize());
         assertFalse(checkTask.getJunit().get());
         assertEquals(junitReport.normalize(), checkTask.getJunitReport().get().getAsFile().toPath().normalize());
+        assertEquals(List.of("module-a/**"), checkTask.getExcludes().get());
+        assertEquals(List.of(".*MapperImpl$"), checkTask.getExcludeClasses().get());
+        assertEquals(List.of("Generated"), checkTask.getExcludeAnnotations().get());
+        assertFalse(checkTask.getUseDefaultExclusions().get());
         assertFalse(checkTask.getJunitReportOutput().isPresent());
     }
 
@@ -132,6 +148,10 @@ class CrapJavaGradlePluginTest {
         assertTrue(checkTask.getJunitReport().get().getAsFile().toPath().normalize().toString()
                 .replace('\\', '/')
                 .endsWith("build/reports/crap-java/custom-crap-java-check/TEST-crap-java.xml"));
+        assertEquals(List.of(), checkTask.getExcludes().get());
+        assertEquals(List.of(), checkTask.getExcludeClasses().get());
+        assertEquals(List.of(), checkTask.getExcludeAnnotations().get());
+        assertTrue(checkTask.getUseDefaultExclusions().get());
         assertTrue(checkTask.getJunitReportOutput().isPresent());
     }
 
@@ -258,6 +278,58 @@ class CrapJavaGradlePluginTest {
 
         assertTrue(Files.exists(jacocoXml));
         assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
+    }
+
+    @Test
+    void runCheckAppliesConfiguredSourceExclusions() throws Exception {
+        Path projectRoot = tempDir.toRealPath();
+        Project project = ProjectBuilder.builder().withProjectDir(projectRoot.toFile()).build();
+        Path source = projectRoot.resolve("src/main/java/demo/Sample.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int alpha(boolean a) {
+                        if (a) {
+                            return 1;
+                        }
+                        return 0;
+                    }
+                }
+                """);
+        Path jacocoXml = projectRoot.resolve("build/reports/jacoco/test/jacocoTestReport.xml");
+        Files.createDirectories(jacocoXml.getParent());
+        Files.writeString(jacocoXml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="(Z)I" line="4">
+                        <counter type="INSTRUCTION" missed="4" covered="0"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        CrapJavaCheckTask task = project.getTasks().register("crap-java-check", CrapJavaCheckTask.class).get();
+        task.getAnalysisRoot().fileValue(projectRoot.toFile());
+        task.getAnalysisSources().from(source);
+        task.getCoverageReports().from(jacocoXml);
+        task.getModuleCoverageReports().put(".", "build/reports/jacoco/test/jacocoTestReport.xml");
+        task.getThreshold().set(1.0);
+        task.getFormat().set("none");
+        task.getAgent().set(false);
+        task.getFailuresOnly().set(false);
+        task.getOmitRedundancy().set(false);
+        task.getUseDefaultExclusions().set(false);
+        task.getExcludes().set(List.of("src/main/java/demo/**"));
+        Path junitReport = projectRoot.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        task.getJunitReport().fileValue(junitReport.toFile());
+
+        task.runCheck();
+
+        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"0\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
     }
 
     @Test

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -165,11 +165,32 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         if (propertyValue == null) {
             return List.of();
         }
-        return List.of(propertyValue.split(",")).stream()
+        return splitEscapedCommaValues(propertyValue).stream()
                 .filter(Objects::nonNull)
                 .map(String::trim)
                 .filter(value -> !value.isEmpty())
                 .toList();
+    }
+
+    private static List<String> splitEscapedCommaValues(String propertyValue) {
+        List<String> values = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        for (int index = 0; index < propertyValue.length(); index++) {
+            char character = propertyValue.charAt(index);
+            if (character == '\\' && index + 1 < propertyValue.length() && propertyValue.charAt(index + 1) == ',') {
+                current.append(',');
+                index++;
+                continue;
+            }
+            if (character == ',') {
+                values.add(current.toString());
+                current.setLength(0);
+                continue;
+            }
+            current.append(character);
+        }
+        values.add(current.toString());
+        return values;
     }
 
     private static List<String> configuredListValues(List<String> values) {

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -55,6 +55,18 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     @Parameter(property = "crapJava.threshold", defaultValue = "8.0")
     private double threshold = Main.DEFAULT_THRESHOLD;
 
+    @Parameter(property = "crapJava.excludes")
+    private List<String> excludes = new ArrayList<>();
+
+    @Parameter(property = "crapJava.excludeClasses")
+    private List<String> excludeClasses = new ArrayList<>();
+
+    @Parameter(property = "crapJava.excludeAnnotations")
+    private List<String> excludeAnnotations = new ArrayList<>();
+
+    @Parameter(property = "crapJava.useDefaultExclusions", defaultValue = "true")
+    private boolean useDefaultExclusions = true;
+
     public CrapJavaCheckMojo() {
         this((useExistingCoverage, args, projectRoot, out, err) -> useExistingCoverage
                 ? Main.runWithExistingCoverage(args, projectRoot, out, err)
@@ -107,6 +119,12 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         if (omitRedundancy != null) {
             args.add("--omit-redundancy=" + omitRedundancy);
         }
+        addRepeated(args, "--exclude", excludes);
+        addRepeated(args, "--exclude-class", excludeClasses);
+        addRepeated(args, "--exclude-annotation", excludeAnnotations);
+        if (!useDefaultExclusions) {
+            args.add("--use-default-exclusions=false");
+        }
         if (output != null) {
             args.add("--output");
             args.add(configuredPath(executionRoot, output).toString());
@@ -118,6 +136,25 @@ public class CrapJavaCheckMojo extends AbstractMojo {
             args.add(junitReportPath(executionRoot).toString());
         }
         return args.toArray(String[]::new);
+    }
+
+    private static void addRepeated(List<String> args, String option, List<String> values) {
+        for (String value : configuredValues(values)) {
+            args.add(option);
+            args.add(value);
+        }
+    }
+
+    private static List<String> configuredValues(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(Objects::nonNull)
+                .flatMap(value -> List.of(value.split(",")).stream())
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .toList();
     }
 
     private Path junitReportPath(Path executionRoot) {

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -55,14 +55,23 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     @Parameter(property = "crapJava.threshold", defaultValue = "8.0")
     private double threshold = Main.DEFAULT_THRESHOLD;
 
-    @Parameter(property = "crapJava.excludes")
+    @Parameter
     private List<String> excludes = new ArrayList<>();
 
-    @Parameter(property = "crapJava.excludeClasses")
+    @Parameter(property = "crapJava.excludes")
+    private @Nullable String excludesProperty;
+
+    @Parameter
     private List<String> excludeClasses = new ArrayList<>();
 
-    @Parameter(property = "crapJava.excludeAnnotations")
+    @Parameter(property = "crapJava.excludeClasses")
+    private @Nullable String excludeClassesProperty;
+
+    @Parameter
     private List<String> excludeAnnotations = new ArrayList<>();
+
+    @Parameter(property = "crapJava.excludeAnnotations")
+    private @Nullable String excludeAnnotationsProperty;
 
     @Parameter(property = "crapJava.useDefaultExclusions", defaultValue = "true")
     private boolean useDefaultExclusions = true;
@@ -119,9 +128,9 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         if (omitRedundancy != null) {
             args.add("--omit-redundancy=" + omitRedundancy);
         }
-        addRepeated(args, "--exclude", excludes);
-        addRepeated(args, "--exclude-class", excludeClasses);
-        addRepeated(args, "--exclude-annotation", excludeAnnotations);
+        addRepeated(args, "--exclude", excludesProperty, excludes);
+        addRepeated(args, "--exclude-class", excludeClassesProperty, excludeClasses);
+        addRepeated(args, "--exclude-annotation", excludeAnnotationsProperty, excludeAnnotations);
         if (!useDefaultExclusions) {
             args.add("--use-default-exclusions=false");
         }
@@ -138,20 +147,37 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         return args.toArray(String[]::new);
     }
 
-    private static void addRepeated(List<String> args, String option, List<String> values) {
-        for (String value : configuredValues(values)) {
+    private static void addRepeated(List<String> args, String option, @Nullable String propertyValue, List<String> values) {
+        for (String value : configuredValues(propertyValue, values)) {
             args.add(option);
             args.add(value);
         }
     }
 
-    private static List<String> configuredValues(List<String> values) {
+    private static List<String> configuredValues(@Nullable String propertyValue, List<String> values) {
+        List<String> configured = new ArrayList<>();
+        configured.addAll(commaSeparatedPropertyValues(propertyValue));
+        configured.addAll(configuredListValues(values));
+        return configured;
+    }
+
+    private static List<String> commaSeparatedPropertyValues(@Nullable String propertyValue) {
+        if (propertyValue == null) {
+            return List.of();
+        }
+        return List.of(propertyValue.split(",")).stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .toList();
+    }
+
+    private static List<String> configuredListValues(List<String> values) {
         if (values == null) {
             return List.of();
         }
         return values.stream()
                 .filter(Objects::nonNull)
-                .flatMap(value -> List.of(value.split(",")).stream())
                 .map(String::trim)
                 .filter(value -> !value.isEmpty())
                 .toList();

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -122,6 +122,43 @@ class CrapJavaCheckMojoTest {
     }
 
     @Test
+    void usesConfiguredExclusionControls() throws Exception {
+        Path root = tempDir.resolve("root");
+        writeCoverageReport(root);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        setField(mojo, "session", session(List.of(project(root, "root")), root));
+        setField(mojo, "project", project(root, "root"));
+        setField(mojo, "excludes", List.of("module-a/**, module-b/**", "**/custom/**"));
+        setField(mojo, "excludeClasses", List.of(".*MapperImpl$"));
+        setField(mojo, "excludeAnnotations", List.of("Generated"));
+        setField(mojo, "useDefaultExclusions", false);
+
+        mojo.execute();
+
+        assertEquals(List.of(
+                "--format",
+                "none",
+                "--exclude",
+                "module-a/**",
+                "--exclude",
+                "module-b/**",
+                "--exclude",
+                "**/custom/**",
+                "--exclude-class",
+                ".*MapperImpl$",
+                "--exclude-annotation",
+                "Generated",
+                "--use-default-exclusions=false",
+                "--threshold",
+                "8.0",
+                "--junit-report",
+                root.resolve("target/crap-java/TEST-crap-java.xml").toString()
+        ), List.of(runner.args));
+    }
+
+    @Test
     void disablesJunitReport() throws Exception {
         Path root = tempDir.resolve("root");
         writeCoverageReport(root);

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -132,8 +132,8 @@ class CrapJavaCheckMojoTest {
         setField(mojo, "project", project(root, "root"));
         setField(mojo, "excludesProperty", "module-a/**, module-b/**");
         setField(mojo, "excludes", List.of("**/custom/**"));
-        setField(mojo, "excludeClassesProperty", ".*MapperImpl$");
-        setField(mojo, "excludeClasses", List.of("demo.Name{1,3}$"));
+        setField(mojo, "excludeClassesProperty", ".*MapperImpl$, demo.Name{1\\,3}$, demo.\\d+$");
+        setField(mojo, "excludeClasses", List.of("demo.Other{1,3}$"));
         setField(mojo, "excludeAnnotationsProperty", "Generated");
         setField(mojo, "excludeAnnotations", List.of("com.acme.Generated"));
         setField(mojo, "useDefaultExclusions", false);
@@ -153,6 +153,10 @@ class CrapJavaCheckMojoTest {
                 ".*MapperImpl$",
                 "--exclude-class",
                 "demo.Name{1,3}$",
+                "--exclude-class",
+                "demo.\\d+$",
+                "--exclude-class",
+                "demo.Other{1,3}$",
                 "--exclude-annotation",
                 "Generated",
                 "--exclude-annotation",

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -130,9 +130,12 @@ class CrapJavaCheckMojoTest {
         CrapJavaCheckMojo mojo = mojo(runner);
         setField(mojo, "session", session(List.of(project(root, "root")), root));
         setField(mojo, "project", project(root, "root"));
-        setField(mojo, "excludes", List.of("module-a/**, module-b/**", "**/custom/**"));
-        setField(mojo, "excludeClasses", List.of(".*MapperImpl$"));
-        setField(mojo, "excludeAnnotations", List.of("Generated"));
+        setField(mojo, "excludesProperty", "module-a/**, module-b/**");
+        setField(mojo, "excludes", List.of("**/custom/**"));
+        setField(mojo, "excludeClassesProperty", ".*MapperImpl$");
+        setField(mojo, "excludeClasses", List.of("demo.Name{1,3}$"));
+        setField(mojo, "excludeAnnotationsProperty", "Generated");
+        setField(mojo, "excludeAnnotations", List.of("com.acme.Generated"));
         setField(mojo, "useDefaultExclusions", false);
 
         mojo.execute();
@@ -148,8 +151,12 @@ class CrapJavaCheckMojoTest {
                 "**/custom/**",
                 "--exclude-class",
                 ".*MapperImpl$",
+                "--exclude-class",
+                "demo.Name{1,3}$",
                 "--exclude-annotation",
                 "Generated",
+                "--exclude-annotation",
+                "com.acme.Generated",
                 "--use-default-exclusions=false",
                 "--threshold",
                 "8.0",


### PR DESCRIPTION
## Summary
- add source exclusion configuration for CLI, Maven plugin, and Gradle plugin
- exclude generated paths, Generated annotations, and generated class-name patterns before CRAP threshold evaluation
- add exclusion audit visibility to full reports and JUnit sidecars while keeping agent primary reports compact

Closes #95

## Verification
- `mvn -pl core -DskipITs test`
- `mvn -pl maven-plugin -am test`
- `mvn verify`
- `gradle-plugin/.\gradlew.bat test --no-daemon --console=plain`