### PR TITLE
Add timeout for changed-file git status

### DIFF
--- a/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
@@ -80,16 +80,17 @@ final class ChangedFileDetector {
     private static int waitFor(Process process,
                                List<String> command,
                                Duration timeout) throws InterruptedException {
-        if (process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+        if (process.waitFor(timeout.toNanos(), TimeUnit.NANOSECONDS)) {
             return process.exitValue();
         }
+        String commandText = String.join(" ", command);
         process.destroyForcibly();
         if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
             throw new IllegalStateException(
-                    "git status timed out after " + timeout + " and could not be terminated within "
-                            + TERMINATION_TIMEOUT + ": " + String.join(" ", command));
+                    "Changed-file detection command timed out after " + timeout
+                            + " and could not be terminated within " + TERMINATION_TIMEOUT + ": " + commandText);
         }
-        throw new IllegalStateException("git status timed out after " + timeout + ": " + String.join(" ", command));
+        throw new IllegalStateException("Changed-file detection command timed out after " + timeout + ": " + commandText);
     }
 
     private static OutputReader readOutput(InputStream input) {
@@ -191,6 +192,11 @@ final class ChangedFileDetector {
                 // Nothing useful can be done while already failing the git status call.
             }
             thread.interrupt();
+            try {
+                thread.join(TERMINATION_TIMEOUT.toMillis());
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
@@ -1,14 +1,12 @@
 package media.barney.crap.core;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.Nullable;
 
@@ -34,9 +32,16 @@ final class ChangedFileDetector {
                 .start();
 
         process.getOutputStream().close();
-        CompletableFuture<byte[]> outputFuture = readOutput(process);
-        int exit = waitFor(process, command, timeout);
-        byte[] outputBytes = outputBytes(outputFuture);
+        OutputReader outputReader = readOutput(process.getInputStream());
+        int exit;
+        byte[] outputBytes;
+        try {
+            exit = waitFor(process, command, timeout);
+            outputBytes = outputReader.bytes();
+        } catch (IOException | InterruptedException | RuntimeException ex) {
+            outputReader.close();
+            throw ex;
+        }
         String output = new String(outputBytes, StandardCharsets.UTF_8);
         if (exit != 0) {
             throw new IllegalStateException("git status failed: " + output);
@@ -72,16 +77,6 @@ final class ChangedFileDetector {
         return command;
     }
 
-    private static CompletableFuture<byte[]> readOutput(Process process) {
-        return CompletableFuture.supplyAsync(() -> {
-            try (var input = process.getInputStream()) {
-                return input.readAllBytes();
-            } catch (IOException ex) {
-                throw new UncheckedIOException(ex);
-            }
-        });
-    }
-
     private static int waitFor(Process process,
                                List<String> command,
                                Duration timeout) throws InterruptedException {
@@ -97,30 +92,10 @@ final class ChangedFileDetector {
         throw new IllegalStateException("git status timed out after " + timeout + ": " + String.join(" ", command));
     }
 
-    private static byte[] outputBytes(CompletableFuture<byte[]> outputFuture) throws IOException, InterruptedException {
-        try {
-            return outputFuture.get();
-        } catch (ExecutionException ex) {
-            throw outputException(ex.getCause());
-        }
-    }
-
-    private static IOException outputException(@Nullable Throwable cause) {
-        if (cause instanceof UncheckedIOException io) {
-            return uncheckedIoCause(io);
-        }
-        return wrappedOutputException(cause);
-    }
-
-    private static IOException uncheckedIoCause(UncheckedIOException error) {
-        @Nullable IOException cause = error.getCause();
-        return cause == null ? new IOException("Unable to read git status output", error) : cause;
-    }
-
-    private static IOException wrappedOutputException(@Nullable Throwable cause) {
-        return cause == null
-                ? new IOException("Unable to read git status output")
-                : new IOException("Unable to read git status output", cause);
+    private static OutputReader readOutput(InputStream input) {
+        OutputReader reader = new OutputReader(input);
+        reader.start();
+        return reader;
     }
 
     static List<Path> changedJavaFilesUnderSourceRoots(Path projectRoot) throws IOException, InterruptedException {
@@ -174,6 +149,48 @@ final class ChangedFileDetector {
                 return false;
             }
             return "??".equals(status) || status.charAt(0) != ' ' || status.charAt(1) != ' ';
+        }
+    }
+
+    private static final class OutputReader {
+        private final InputStream input;
+        private final Thread thread;
+        private byte[] output = new byte[0];
+        private @Nullable IOException failure;
+
+        private OutputReader(InputStream input) {
+            this.input = input;
+            this.thread = new Thread(this::read, "crap-java-git-status-output");
+            this.thread.setDaemon(true);
+        }
+
+        private void start() {
+            thread.start();
+        }
+
+        private void read() {
+            try (input) {
+                output = input.readAllBytes();
+            } catch (IOException ex) {
+                failure = ex;
+            }
+        }
+
+        private byte[] bytes() throws IOException, InterruptedException {
+            thread.join();
+            if (failure != null) {
+                throw new IOException("Unable to read git status output", failure);
+            }
+            return output;
+        }
+
+        private void close() {
+            try {
+                input.close();
+            } catch (IOException ex) {
+                // Nothing useful can be done while already failing the git status call.
+            }
+            thread.interrupt();
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
@@ -101,12 +101,26 @@ final class ChangedFileDetector {
         try {
             return outputFuture.get();
         } catch (ExecutionException ex) {
-            Throwable cause = ex.getCause();
-            if (cause instanceof UncheckedIOException io) {
-                throw io.getCause();
-            }
-            throw new IOException("Unable to read git status output", cause);
+            throw outputException(ex.getCause());
         }
+    }
+
+    private static IOException outputException(@Nullable Throwable cause) {
+        if (cause instanceof UncheckedIOException io) {
+            return uncheckedIoCause(io);
+        }
+        return wrappedOutputException(cause);
+    }
+
+    private static IOException uncheckedIoCause(UncheckedIOException error) {
+        @Nullable IOException cause = error.getCause();
+        return cause == null ? new IOException("Unable to read git status output", error) : cause;
+    }
+
+    private static IOException wrappedOutputException(@Nullable Throwable cause) {
+        return cause == null
+                ? new IOException("Unable to read git status output")
+                : new IOException("Unable to read git status output", cause);
     }
 
     static List<Path> changedJavaFilesUnderSourceRoots(Path projectRoot) throws IOException, InterruptedException {

--- a/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
@@ -1,24 +1,42 @@
 package media.barney.crap.core;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.Nullable;
 
 final class ChangedFileDetector {
+
+    private static final Duration GIT_STATUS_TIMEOUT = Duration.ofMinutes(10);
+    private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
+    private static final List<String> GIT_COMMAND = List.of("git");
 
     private ChangedFileDetector() {
     }
 
     static List<Path> changedJavaFiles(Path projectRoot) throws IOException, InterruptedException {
-        Process process = new ProcessBuilder("git", "-C", projectRoot.toString(), "status", "--porcelain=v1", "-z", "--untracked-files=all")
+        return changedJavaFiles(projectRoot, GIT_COMMAND, GIT_STATUS_TIMEOUT);
+    }
+
+    static List<Path> changedJavaFiles(Path projectRoot,
+                                       List<String> gitCommand,
+                                       Duration timeout) throws IOException, InterruptedException {
+        List<String> command = gitStatusCommand(projectRoot, gitCommand);
+        Process process = new ProcessBuilder(command)
                 .redirectErrorStream(true)
                 .start();
 
-        byte[] outputBytes = process.getInputStream().readAllBytes();
-        int exit = process.waitFor();
+        process.getOutputStream().close();
+        CompletableFuture<byte[]> outputFuture = readOutput(process);
+        int exit = waitFor(process, command, timeout);
+        byte[] outputBytes = outputBytes(outputFuture);
         String output = new String(outputBytes, StandardCharsets.UTF_8);
         if (exit != 0) {
             throw new IllegalStateException("git status failed: " + output);
@@ -41,6 +59,54 @@ final class ChangedFileDetector {
         }
         files.sort(Path::compareTo);
         return files;
+    }
+
+    private static List<String> gitStatusCommand(Path projectRoot, List<String> gitCommand) {
+        List<String> command = new ArrayList<>(gitCommand);
+        command.add("-C");
+        command.add(projectRoot.toString());
+        command.add("status");
+        command.add("--porcelain=v1");
+        command.add("-z");
+        command.add("--untracked-files=all");
+        return command;
+    }
+
+    private static CompletableFuture<byte[]> readOutput(Process process) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (var input = process.getInputStream()) {
+                return input.readAllBytes();
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+        });
+    }
+
+    private static int waitFor(Process process,
+                               List<String> command,
+                               Duration timeout) throws InterruptedException {
+        if (process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            return process.exitValue();
+        }
+        process.destroyForcibly();
+        if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+            throw new IllegalStateException(
+                    "git status timed out after " + timeout + " and could not be terminated within "
+                            + TERMINATION_TIMEOUT + ": " + String.join(" ", command));
+        }
+        throw new IllegalStateException("git status timed out after " + timeout + ": " + String.join(" ", command));
+    }
+
+    private static byte[] outputBytes(CompletableFuture<byte[]> outputFuture) throws IOException, InterruptedException {
+        try {
+            return outputFuture.get();
+        } catch (ExecutionException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof UncheckedIOException io) {
+                throw io.getCause();
+            }
+            throw new IOException("Unable to read git status output", cause);
+        }
     }
 
     static List<Path> changedJavaFilesUnderSourceRoots(Path projectRoot) throws IOException, InterruptedException {

--- a/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
@@ -177,7 +177,7 @@ final class ChangedFileDetector {
             }
             thread.interrupt();
             try {
-                thread.join(Duration.ofSeconds(5).toMillis());
+                thread.join(ProcessTimeout.CLEANUP_TIMEOUT.toMillis());
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
             }

--- a/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
@@ -7,13 +7,11 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.Nullable;
 
 final class ChangedFileDetector {
 
     private static final Duration GIT_STATUS_TIMEOUT = Duration.ofMinutes(10);
-    private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
     private static final List<String> GIT_COMMAND = List.of("git");
 
     private ChangedFileDetector() {
@@ -27,6 +25,7 @@ final class ChangedFileDetector {
                                        List<String> gitCommand,
                                        Duration timeout) throws IOException, InterruptedException {
         List<String> command = gitStatusCommand(projectRoot, gitCommand);
+        ProcessTimeout.validate(timeout);
         Process process = new ProcessBuilder(command)
                 .redirectErrorStream(true)
                 .start();
@@ -36,7 +35,7 @@ final class ChangedFileDetector {
         int exit;
         byte[] outputBytes;
         try {
-            exit = waitFor(process, command, timeout);
+            exit = ProcessTimeout.waitForOrTerminate(process, command, timeout, "Changed-file detection command");
             outputBytes = outputReader.bytes();
         } catch (IOException | InterruptedException | RuntimeException ex) {
             outputReader.close();
@@ -75,22 +74,6 @@ final class ChangedFileDetector {
         command.add("-z");
         command.add("--untracked-files=all");
         return command;
-    }
-
-    private static int waitFor(Process process,
-                               List<String> command,
-                               Duration timeout) throws InterruptedException {
-        if (process.waitFor(timeout.toNanos(), TimeUnit.NANOSECONDS)) {
-            return process.exitValue();
-        }
-        String commandText = String.join(" ", command);
-        process.destroyForcibly();
-        if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
-            throw new IllegalStateException(
-                    "Changed-file detection command timed out after " + timeout
-                            + " and could not be terminated within " + TERMINATION_TIMEOUT + ": " + commandText);
-        }
-        throw new IllegalStateException("Changed-file detection command timed out after " + timeout + ": " + commandText);
     }
 
     private static OutputReader readOutput(InputStream input) {
@@ -193,7 +176,7 @@ final class ChangedFileDetector {
             }
             thread.interrupt();
             try {
-                thread.join(TERMINATION_TIMEOUT.toMillis());
+                thread.join(Duration.ofSeconds(5).toMillis());
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
             }

--- a/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
@@ -43,7 +43,8 @@ final class ChangedFileDetector {
         }
         String output = new String(outputBytes, StandardCharsets.UTF_8);
         if (exit != 0) {
-            throw new IllegalStateException("git status failed: " + output);
+            throw new IllegalStateException(
+                    "Changed-file detection command failed (" + String.join(" ", command) + "): " + output);
         }
 
         List<Path> files = new ArrayList<>();

--- a/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
@@ -5,11 +5,8 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 final class ProcessCommandExecutor implements CommandExecutor {
-
-    private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
 
     private final Duration timeout;
     private final PrintStream processOutput;
@@ -29,24 +26,17 @@ final class ProcessCommandExecutor implements CommandExecutor {
 
     @Override
     public int run(List<String> command, Path directory) throws Exception {
+        ProcessTimeout.validate(timeout);
         Process process = new ProcessBuilder(command)
                 .directory(directory.toFile())
                 .start();
         process.getOutputStream().close();
         Thread stdout = pipe(process.getInputStream());
         Thread stderr = pipe(process.getErrorStream());
-        if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
-            process.destroyForcibly();
-            if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
-                throw new IllegalStateException(
-                        "Command timed out after " + timeout + " and could not be terminated within "
-                                + TERMINATION_TIMEOUT + ": " + String.join(" ", command));
-            }
-            throw new IllegalStateException("Command timed out after " + timeout + ": " + String.join(" ", command));
-        }
+        int exit = ProcessTimeout.waitForOrTerminate(process, command, timeout, "Command");
         stdout.join();
         stderr.join();
-        return process.exitValue();
+        return exit;
     }
 
     private Thread pipe(InputStream input) {

--- a/core/src/main/java/media/barney/crap/core/ProcessTimeout.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessTimeout.java
@@ -1,0 +1,45 @@
+package media.barney.crap.core;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+final class ProcessTimeout {
+
+    private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
+
+    private ProcessTimeout() {
+    }
+
+    static void validate(Duration timeout) {
+        timeoutNanos(timeout);
+    }
+
+    static int waitForOrTerminate(Process process,
+                                  List<String> command,
+                                  Duration timeout,
+                                  String commandDescription) throws InterruptedException {
+        long timeoutNanos = timeoutNanos(timeout);
+        if (process.waitFor(timeoutNanos, TimeUnit.NANOSECONDS)) {
+            return process.exitValue();
+        }
+        String commandText = String.join(" ", command);
+        process.destroyForcibly();
+        if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+            throw new IllegalStateException(commandDescription + " timed out after " + timeout
+                    + " and could not be terminated within " + TERMINATION_TIMEOUT + ": " + commandText);
+        }
+        throw new IllegalStateException(commandDescription + " timed out after " + timeout + ": " + commandText);
+    }
+
+    private static long timeoutNanos(Duration timeout) {
+        if (timeout.isZero() || timeout.isNegative()) {
+            throw new IllegalArgumentException("Command timeout must be positive: " + timeout);
+        }
+        try {
+            return timeout.toNanos();
+        } catch (ArithmeticException ex) {
+            throw new IllegalArgumentException("Command timeout is too large: " + timeout, ex);
+        }
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/ProcessTimeout.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessTimeout.java
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit;
 
 final class ProcessTimeout {
 
-    private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
+    static final Duration CLEANUP_TIMEOUT = Duration.ofSeconds(5);
 
     private ProcessTimeout() {
     }
@@ -26,15 +26,15 @@ final class ProcessTimeout {
             }
             String commandText = String.join(" ", command);
             process.destroyForcibly();
-            if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+            if (!process.waitFor(CLEANUP_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
                 throw new IllegalStateException(commandDescription + " timed out after " + timeout
-                        + " and could not be terminated within " + TERMINATION_TIMEOUT + ": " + commandText);
+                        + " and could not be terminated within " + CLEANUP_TIMEOUT + ": " + commandText);
             }
             throw new IllegalStateException(commandDescription + " timed out after " + timeout + ": " + commandText);
         } catch (InterruptedException ex) {
             process.destroyForcibly();
             try {
-                process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                process.waitFor(CLEANUP_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             } catch (InterruptedException cleanupFailure) {
                 ex.addSuppressed(cleanupFailure);
             }

--- a/core/src/main/java/media/barney/crap/core/ProcessTimeout.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessTimeout.java
@@ -20,16 +20,27 @@ final class ProcessTimeout {
                                   Duration timeout,
                                   String commandDescription) throws InterruptedException {
         long timeoutNanos = timeoutNanos(timeout);
-        if (process.waitFor(timeoutNanos, TimeUnit.NANOSECONDS)) {
-            return process.exitValue();
+        try {
+            if (process.waitFor(timeoutNanos, TimeUnit.NANOSECONDS)) {
+                return process.exitValue();
+            }
+            String commandText = String.join(" ", command);
+            process.destroyForcibly();
+            if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException(commandDescription + " timed out after " + timeout
+                        + " and could not be terminated within " + TERMINATION_TIMEOUT + ": " + commandText);
+            }
+            throw new IllegalStateException(commandDescription + " timed out after " + timeout + ": " + commandText);
+        } catch (InterruptedException ex) {
+            process.destroyForcibly();
+            try {
+                process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException cleanupFailure) {
+                ex.addSuppressed(cleanupFailure);
+            }
+            Thread.currentThread().interrupt();
+            throw ex;
         }
-        String commandText = String.join(" ", command);
-        process.destroyForcibly();
-        if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
-            throw new IllegalStateException(commandDescription + " timed out after " + timeout
-                    + " and could not be terminated within " + TERMINATION_TIMEOUT + ": " + commandText);
-        }
-        throw new IllegalStateException(commandDescription + " timed out after " + timeout + ": " + commandText);
     }
 
     private static long timeoutNanos(Duration timeout) {

--- a/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
@@ -163,7 +163,8 @@ class ChangedFileDetectorTest {
                         Duration.ofMillis(100)
                 ));
 
-        assertTrue(Objects.requireNonNull(error.getMessage()).contains("git status timed out after PT0.1S"));
+        assertTrue(Objects.requireNonNull(error.getMessage())
+                .contains("Changed-file detection command timed out after PT0.1S"));
     }
 
     private static void run(Path dir, String... command) throws IOException, InterruptedException {
@@ -195,7 +196,7 @@ class ChangedFileDetectorTest {
 
     public static final class SleepingGit {
         public static void main(String[] args) throws InterruptedException {
-            Thread.sleep(Duration.ofSeconds(30).toMillis());
+            Thread.sleep(Duration.ofSeconds(5).toMillis());
         }
     }
 }

--- a/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
@@ -187,7 +187,9 @@ class ChangedFileDetectorTest {
     }
 
     private static String javaExecutable() {
-        String executable = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win") ? "java.exe" : "java";
+        String executable = System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
+                ? "java.exe"
+                : "java";
         return Path.of(System.getProperty("java.home"), "bin", executable).toString();
     }
 

--- a/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -187,19 +186,7 @@ class ChangedFileDetectorTest {
     }
 
     private static List<String> javaSleepingGitCommand() {
-        return List.of(
-                javaExecutable(),
-                "-cp",
-                System.getProperty("java.class.path"),
-                SleepingGit.class.getName()
-        );
-    }
-
-    private static String javaExecutable() {
-        String executable = System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
-                ? "java.exe"
-                : "java";
-        return Path.of(System.getProperty("java.home"), "bin", executable).toString();
+        return TestJavaCommand.command(SleepingGit.class);
     }
 
     public static final class SleepingGit {

--- a/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
@@ -7,7 +7,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -152,6 +154,18 @@ class ChangedFileDetectorTest {
         assertEquals(List.of(renamed), changed);
     }
 
+    @Test
+    void timesOutHungGitStatus() {
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> ChangedFileDetector.changedJavaFiles(
+                        tempDir,
+                        javaSleepingGitCommand(),
+                        Duration.ofMillis(100)
+                ));
+
+        assertTrue(Objects.requireNonNull(error.getMessage()).contains("git status timed out after PT0.1S"));
+    }
+
     private static void run(Path dir, String... command) throws IOException, InterruptedException {
         Process process = new ProcessBuilder(command)
                 .directory(dir.toFile())
@@ -160,6 +174,26 @@ class ChangedFileDetectorTest {
         if (process.waitFor() != 0) {
             String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
             throw new IllegalStateException(output);
+        }
+    }
+
+    private static List<String> javaSleepingGitCommand() {
+        return List.of(
+                javaExecutable(),
+                "-cp",
+                System.getProperty("java.class.path"),
+                SleepingGit.class.getName()
+        );
+    }
+
+    private static String javaExecutable() {
+        String executable = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win") ? "java.exe" : "java";
+        return Path.of(System.getProperty("java.home"), "bin", executable).toString();
+    }
+
+    public static final class SleepingGit {
+        public static void main(String[] args) throws InterruptedException {
+            Thread.sleep(Duration.ofSeconds(30).toMillis());
         }
     }
 }

--- a/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
@@ -167,6 +167,14 @@ class ChangedFileDetectorTest {
                 .contains("Changed-file detection command timed out after PT0.1S"));
     }
 
+    @Test
+    void rejectsNonPositiveGitStatusTimeout() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> ChangedFileDetector.changedJavaFiles(tempDir, javaSleepingGitCommand(), Duration.ZERO));
+
+        assertTrue(Objects.requireNonNull(error.getMessage()).contains("Command timeout must be positive"));
+    }
+
     private static void run(Path dir, String... command) throws IOException, InterruptedException {
         Process process = new ProcessBuilder(command)
                 .directory(dir.toFile())

--- a/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
@@ -106,19 +106,7 @@ class ProcessCommandExecutorTest {
     }
 
     private static List<String> largeOutputCommand() {
-        return List.of(
-                javaExecutable(),
-                "-cp",
-                System.getProperty("java.class.path"),
-                LargeOutput.class.getName()
-        );
-    }
-
-    private static String javaExecutable() {
-        String executable = System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
-                ? "java.exe"
-                : "java";
-        return Path.of(System.getProperty("java.home"), "bin", executable).toString();
+        return TestJavaCommand.command(LargeOutput.class);
     }
 
     public static final class LargeOutput {

--- a/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
@@ -38,6 +38,16 @@ class ProcessCommandExecutorTest {
         assertTrue(message.contains(String.join(" ", sleepCommand())));
     }
 
+    @Test
+    void rejectsNonPositiveTimeouts() {
+        ProcessCommandExecutor executor = new ProcessCommandExecutor(Duration.ZERO);
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> executor.run(sleepCommand(), tempDir));
+
+        assertTrue(Objects.requireNonNull(error.getMessage()).contains("Command timeout must be positive"));
+    }
+
     private static List<String> exitCommand(int exitCode) {
         if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
             return List.of("cmd", "/c", "exit " + exitCode);

--- a/core/src/test/java/media/barney/crap/core/ProcessTimeoutTest.java
+++ b/core/src/test/java/media/barney/crap/core/ProcessTimeoutTest.java
@@ -1,0 +1,86 @@
+package media.barney.crap.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProcessTimeoutTest {
+
+    @Test
+    void destroysProcessWhenWaitIsInterrupted() {
+        InterruptingProcess process = new InterruptingProcess();
+
+        try {
+            assertThrows(InterruptedException.class, () -> ProcessTimeout.waitForOrTerminate(
+                    process,
+                    List.of("git", "status"),
+                    Duration.ofSeconds(5),
+                    "Changed-file detection command"
+            ));
+
+            assertTrue(process.destroyed);
+            assertEquals(2, process.timedWaitCalls);
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    private static final class InterruptingProcess extends Process {
+        private int timedWaitCalls;
+        private boolean destroyed;
+
+        @Override
+        public OutputStream getOutputStream() {
+            return OutputStream.nullOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public int waitFor() {
+            return 0;
+        }
+
+        @Override
+        public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+            timedWaitCalls++;
+            if (timedWaitCalls == 1) {
+                throw new InterruptedException("test interruption");
+            }
+            return true;
+        }
+
+        @Override
+        public int exitValue() {
+            return 0;
+        }
+
+        @Override
+        public void destroy() {
+            destroyed = true;
+        }
+
+        @Override
+        public Process destroyForcibly() {
+            destroyed = true;
+            return this;
+        }
+    }
+}

--- a/core/src/test/java/media/barney/crap/core/TestJavaCommand.java
+++ b/core/src/test/java/media/barney/crap/core/TestJavaCommand.java
@@ -1,0 +1,27 @@
+package media.barney.crap.core;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+final class TestJavaCommand {
+
+    private TestJavaCommand() {
+    }
+
+    static List<String> command(Class<?> mainClass) {
+        return List.of(
+                executable(),
+                "-cp",
+                System.getProperty("java.class.path"),
+                mainClass.getName()
+        );
+    }
+
+    private static String executable() {
+        String executable = System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
+                ? "java.exe"
+                : "java";
+        return Path.of(System.getProperty("java.home"), "bin", executable).toString();
+    }
+}


### PR DESCRIPTION
Closes #112

## Classification
Valid AI-review finding. `ChangedFileDetector` started `git status` directly and could block indefinitely while reading process output or waiting for process exit.

## Summary
- add a 10-minute timeout around the `git status --porcelain` process used for changed-file detection
- read combined git output asynchronously so output capture cannot block timeout enforcement
- forcibly terminate a timed-out git process and report the command in the error message
- add a regression test using a sleeper Java process as a fake git command

## Verification
- mvn -pl core test
- mvn verify