### PR TITLE
Surface coverage command failure details

### DIFF
--- a/core/src/main/java/media/barney/crap/core/CommandExecutor.java
+++ b/core/src/main/java/media/barney/crap/core/CommandExecutor.java
@@ -5,5 +5,9 @@ import java.util.List;
 
 interface CommandExecutor {
     int run(List<String> command, Path directory) throws Exception;
+
+    default CommandResult runWithResult(List<String> command, Path directory) throws Exception {
+        return CommandResult.exitCode(run(command, directory));
+    }
 }
 

--- a/core/src/main/java/media/barney/crap/core/CommandResult.java
+++ b/core/src/main/java/media/barney/crap/core/CommandResult.java
@@ -1,0 +1,8 @@
+package media.barney.crap.core;
+
+record CommandResult(int exitCode, String stdout, String stderr) {
+
+    static CommandResult exitCode(int exitCode) {
+        return new CommandResult(exitCode, "", "");
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/CommandResult.java
+++ b/core/src/main/java/media/barney/crap/core/CommandResult.java
@@ -1,6 +1,13 @@
 package media.barney.crap.core;
 
+import java.util.Objects;
+
 record CommandResult(int exitCode, String stdout, String stderr) {
+
+    CommandResult {
+        Objects.requireNonNull(stdout, "stdout");
+        Objects.requireNonNull(stderr, "stderr");
+    }
 
     static CommandResult exitCode(int exitCode) {
         return new CommandResult(exitCode, "", "");

--- a/core/src/main/java/media/barney/crap/core/CoverageRunner.java
+++ b/core/src/main/java/media/barney/crap/core/CoverageRunner.java
@@ -43,7 +43,7 @@ final class CoverageRunner {
     }
 
     private void appendOutput(StringBuilder message, String label, String output) {
-        String trimmed = output.strip();
+        String trimmed = output.stripTrailing();
         if (!trimmed.isEmpty()) {
             message.append(System.lineSeparator())
                     .append(label)

--- a/core/src/main/java/media/barney/crap/core/CoverageRunner.java
+++ b/core/src/main/java/media/barney/crap/core/CoverageRunner.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
 
 final class CoverageRunner {
 
@@ -21,9 +22,34 @@ final class CoverageRunner {
             deleteIfExists(module.moduleRoot(), moduleRootRealPath, staleCoveragePath);
         }
 
-        int exit = executor.run(module.coverageCommand(), module.executionRoot());
-        if (exit != 0) {
-            throw new IllegalStateException("Coverage command failed with exit " + exit);
+        List<String> command = module.coverageCommand();
+        CommandResult result = executor.runWithResult(command, module.executionRoot());
+        if (result.exitCode() != 0) {
+            throw new IllegalStateException(failureMessage(module, command, result));
+        }
+    }
+
+    private String failureMessage(ProjectModule module, List<String> command, CommandResult result) {
+        StringBuilder message = new StringBuilder()
+                .append("Coverage command '")
+                .append(String.join(" ", command))
+                .append("' failed in ")
+                .append(module.executionRoot().toAbsolutePath().normalize())
+                .append(" with exit ")
+                .append(result.exitCode());
+        appendOutput(message, "stderr", result.stderr());
+        appendOutput(message, "stdout", result.stdout());
+        return message.toString();
+    }
+
+    private void appendOutput(StringBuilder message, String label, String output) {
+        String trimmed = output.strip();
+        if (!trimmed.isEmpty()) {
+            message.append(System.lineSeparator())
+                    .append(label)
+                    .append(':')
+                    .append(System.lineSeparator())
+                    .append(trimmed);
         }
     }
 

--- a/core/src/main/java/media/barney/crap/core/CoverageRunner.java
+++ b/core/src/main/java/media/barney/crap/core/CoverageRunner.java
@@ -31,9 +31,9 @@ final class CoverageRunner {
 
     private String failureMessage(ProjectModule module, List<String> command, CommandResult result) {
         StringBuilder message = new StringBuilder()
-                .append("Coverage command '")
-                .append(String.join(" ", command))
-                .append("' failed in ")
+                .append("Coverage command ")
+                .append(command)
+                .append(" failed in ")
                 .append(module.executionRoot().toAbsolutePath().normalize())
                 .append(" with exit ")
                 .append(result.exitCode());

--- a/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
@@ -3,7 +3,7 @@ package media.barney.crap.core;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -16,6 +16,7 @@ final class ProcessCommandExecutor implements CommandExecutor {
 
     private final Duration timeout;
     private final PrintStream processOutput;
+    private final Charset outputCharset;
 
     ProcessCommandExecutor() {
         this(Duration.ofMinutes(10), System.err);
@@ -26,8 +27,13 @@ final class ProcessCommandExecutor implements CommandExecutor {
     }
 
     ProcessCommandExecutor(Duration timeout, PrintStream processOutput) {
+        this(timeout, processOutput, Charset.defaultCharset());
+    }
+
+    ProcessCommandExecutor(Duration timeout, PrintStream processOutput, Charset outputCharset) {
         this.timeout = timeout;
         this.processOutput = processOutput;
+        this.outputCharset = outputCharset;
     }
 
     @Override
@@ -68,7 +74,7 @@ final class ProcessCommandExecutor implements CommandExecutor {
         }, "crap-java-process-output-" + label);
         thread.setDaemon(true);
         thread.start();
-        return new OutputPipe(thread, capture);
+        return new OutputPipe(thread, capture, outputCharset);
     }
 
     private void copyOutput(InputStream input, BoundedOutputCapture capture) throws IOException {
@@ -76,18 +82,18 @@ final class ProcessCommandExecutor implements CommandExecutor {
         int read;
         while ((read = input.read(buffer)) != -1) {
             processOutput.write(buffer, 0, read);
+            processOutput.flush();
             capture.write(buffer, 0, read);
         }
-        processOutput.flush();
     }
 
-    private record OutputPipe(Thread thread, BoundedOutputCapture capture) {
+    private record OutputPipe(Thread thread, BoundedOutputCapture capture, Charset outputCharset) {
         private void join() throws InterruptedException {
             thread.join();
         }
 
         private String output() {
-            return capture.toString(StandardCharsets.UTF_8);
+            return capture.toString(outputCharset);
         }
     }
 

--- a/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
@@ -1,7 +1,10 @@
 package media.barney.crap.core;
 
 import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -29,12 +32,17 @@ final class ProcessCommandExecutor implements CommandExecutor {
 
     @Override
     public int run(List<String> command, Path directory) throws Exception {
+        return runWithResult(command, directory).exitCode();
+    }
+
+    @Override
+    public CommandResult runWithResult(List<String> command, Path directory) throws Exception {
         Process process = new ProcessBuilder(command)
                 .directory(directory.toFile())
                 .start();
         process.getOutputStream().close();
-        Thread stdout = pipe(process.getInputStream());
-        Thread stderr = pipe(process.getErrorStream());
+        OutputPipe stdout = pipe(process.getInputStream());
+        OutputPipe stderr = pipe(process.getErrorStream());
         if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
             process.destroyForcibly();
             if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
@@ -46,20 +54,41 @@ final class ProcessCommandExecutor implements CommandExecutor {
         }
         stdout.join();
         stderr.join();
-        return process.exitValue();
+        return new CommandResult(process.exitValue(), stdout.output(), stderr.output());
     }
 
-    private Thread pipe(InputStream input) {
+    private OutputPipe pipe(InputStream input) {
+        ByteArrayOutputStream capture = new ByteArrayOutputStream();
         Thread thread = new Thread(() -> {
             try (input) {
-                input.transferTo(processOutput);
+                copyOutput(input, capture);
             } catch (Exception ex) {
                 processOutput.println("Failed to read process output: " + ex.getMessage());
             }
         }, "crap-java-process-output");
         thread.setDaemon(true);
         thread.start();
-        return thread;
+        return new OutputPipe(thread, capture);
+    }
+
+    private void copyOutput(InputStream input, ByteArrayOutputStream capture) throws IOException {
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            processOutput.write(buffer, 0, read);
+            capture.write(buffer, 0, read);
+        }
+        processOutput.flush();
+    }
+
+    private record OutputPipe(Thread thread, ByteArrayOutputStream capture) {
+        private void join() throws InterruptedException {
+            thread.join();
+        }
+
+        private String output() {
+            return capture.toString(StandardCharsets.UTF_8);
+        }
     }
 }
 

--- a/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
@@ -1,8 +1,7 @@
 package media.barney.crap.core;
 
-import java.io.InputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -13,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 final class ProcessCommandExecutor implements CommandExecutor {
 
     private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
+    private static final int CAPTURE_LIMIT_BYTES = 64 * 1024;
 
     private final Duration timeout;
     private final PrintStream processOutput;
@@ -58,7 +58,7 @@ final class ProcessCommandExecutor implements CommandExecutor {
     }
 
     private OutputPipe pipe(InputStream input) {
-        ByteArrayOutputStream capture = new ByteArrayOutputStream();
+        BoundedOutputCapture capture = new BoundedOutputCapture();
         Thread thread = new Thread(() -> {
             try (input) {
                 copyOutput(input, capture);
@@ -71,7 +71,7 @@ final class ProcessCommandExecutor implements CommandExecutor {
         return new OutputPipe(thread, capture);
     }
 
-    private void copyOutput(InputStream input, ByteArrayOutputStream capture) throws IOException {
+    private void copyOutput(InputStream input, BoundedOutputCapture capture) throws IOException {
         byte[] buffer = new byte[8192];
         int read;
         while ((read = input.read(buffer)) != -1) {
@@ -81,13 +81,51 @@ final class ProcessCommandExecutor implements CommandExecutor {
         processOutput.flush();
     }
 
-    private record OutputPipe(Thread thread, ByteArrayOutputStream capture) {
+    private record OutputPipe(Thread thread, BoundedOutputCapture capture) {
         private void join() throws InterruptedException {
             thread.join();
         }
 
         private String output() {
             return capture.toString(StandardCharsets.UTF_8);
+        }
+    }
+
+    private static final class BoundedOutputCapture {
+        private final byte[] tail = new byte[CAPTURE_LIMIT_BYTES];
+        private int nextIndex;
+        private int length;
+        private long totalBytes;
+
+        private void write(byte[] buffer, int offset, int count) {
+            for (int index = offset; index < offset + count; index++) {
+                writeByte(buffer[index]);
+            }
+        }
+
+        private void writeByte(byte value) {
+            tail[nextIndex] = value;
+            nextIndex = (nextIndex + 1) % tail.length;
+            length = Math.min(length + 1, tail.length);
+            totalBytes++;
+        }
+
+        private String toString(java.nio.charset.Charset charset) {
+            String text = new String(bytes(), charset);
+            if (totalBytes <= CAPTURE_LIMIT_BYTES) {
+                return text;
+            }
+            return "[captured output truncated to last " + CAPTURE_LIMIT_BYTES + " bytes]" + System.lineSeparator()
+                    + text;
+        }
+
+        private byte[] bytes() {
+            byte[] output = new byte[length];
+            int startIndex = length == tail.length ? nextIndex : 0;
+            for (int index = 0; index < length; index++) {
+                output[index] = tail[(startIndex + index) % tail.length];
+            }
+            return output;
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
@@ -41,8 +41,8 @@ final class ProcessCommandExecutor implements CommandExecutor {
                 .directory(directory.toFile())
                 .start();
         process.getOutputStream().close();
-        OutputPipe stdout = pipe(process.getInputStream());
-        OutputPipe stderr = pipe(process.getErrorStream());
+        OutputPipe stdout = pipe(process.getInputStream(), "stdout");
+        OutputPipe stderr = pipe(process.getErrorStream(), "stderr");
         if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
             process.destroyForcibly();
             if (!process.waitFor(TERMINATION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
@@ -57,7 +57,7 @@ final class ProcessCommandExecutor implements CommandExecutor {
         return new CommandResult(process.exitValue(), stdout.output(), stderr.output());
     }
 
-    private OutputPipe pipe(InputStream input) {
+    private OutputPipe pipe(InputStream input, String label) {
         BoundedOutputCapture capture = new BoundedOutputCapture();
         Thread thread = new Thread(() -> {
             try (input) {
@@ -65,7 +65,7 @@ final class ProcessCommandExecutor implements CommandExecutor {
             } catch (Exception ex) {
                 processOutput.println("Failed to read process output: " + ex.getMessage());
             }
-        }, "crap-java-process-output");
+        }, "crap-java-process-output-" + label);
         thread.setDaemon(true);
         thread.start();
         return new OutputPipe(thread, capture);
@@ -98,16 +98,21 @@ final class ProcessCommandExecutor implements CommandExecutor {
         private long totalBytes;
 
         private void write(byte[] buffer, int offset, int count) {
-            for (int index = offset; index < offset + count; index++) {
-                writeByte(buffer[index]);
-            }
+            int keptCount = Math.min(count, tail.length);
+            int keptOffset = offset + count - keptCount;
+            copy(buffer, keptOffset, keptCount);
+            length = Math.min(length + keptCount, tail.length);
+            totalBytes += count;
         }
 
-        private void writeByte(byte value) {
-            tail[nextIndex] = value;
-            nextIndex = (nextIndex + 1) % tail.length;
-            length = Math.min(length + 1, tail.length);
-            totalBytes++;
+        private void copy(byte[] buffer, int offset, int count) {
+            int firstCount = Math.min(count, tail.length - nextIndex);
+            System.arraycopy(buffer, offset, tail, nextIndex, firstCount);
+            int secondCount = count - firstCount;
+            if (secondCount > 0) {
+                System.arraycopy(buffer, offset + firstCount, tail, 0, secondCount);
+            }
+            nextIndex = (nextIndex + count) % tail.length;
         }
 
         private String toString(java.nio.charset.Charset charset) {

--- a/core/src/test/java/media/barney/crap/core/CommandResultTest.java
+++ b/core/src/test/java/media/barney/crap/core/CommandResultTest.java
@@ -1,0 +1,15 @@
+package media.barney.crap.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CommandResultTest {
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void rejectsNullCapturedOutput() {
+        assertThrows(NullPointerException.class, () -> new CommandResult(1, null, ""));
+        assertThrows(NullPointerException.class, () -> new CommandResult(1, "", null));
+    }
+}

--- a/core/src/test/java/media/barney/crap/core/CoverageRunnerTest.java
+++ b/core/src/test/java/media/barney/crap/core/CoverageRunnerTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -51,13 +52,17 @@ class CoverageRunnerTest {
 
     @Test
     void failsWhenCoverageCommandFails() {
-        RecordingExecutor executor = new RecordingExecutor(2);
+        RecordingExecutor executor = new RecordingExecutor(2, "coverage progress", "coverage failed");
         CoverageRunner runner = new CoverageRunner(executor);
 
         IllegalStateException ex = assertThrows(IllegalStateException.class,
                 () -> runner.generateCoverage(new ProjectModule(tempDir, tempDir, BuildTool.GRADLE)));
 
-        assertEquals("Coverage command failed with exit 2", ex.getMessage());
+        String message = Objects.requireNonNull(ex.getMessage());
+        assertTrue(message.startsWith("Coverage command '"));
+        assertTrue(message.contains("' failed in " + tempDir.toAbsolutePath().normalize() + " with exit 2"));
+        assertTrue(message.contains("stderr:" + System.lineSeparator() + "coverage failed"));
+        assertTrue(message.contains("stdout:" + System.lineSeparator() + "coverage progress"));
     }
 
     @Test
@@ -104,11 +109,19 @@ class CoverageRunnerTest {
 
     private static final class RecordingExecutor implements CommandExecutor {
         private final int exitCode;
+        private final String stdout;
+        private final String stderr;
         private final List<List<String>> commands = new ArrayList<>();
         private final List<Path> directories = new ArrayList<>();
 
         private RecordingExecutor(int exitCode) {
+            this(exitCode, "", "");
+        }
+
+        private RecordingExecutor(int exitCode, String stdout, String stderr) {
             this.exitCode = exitCode;
+            this.stdout = stdout;
+            this.stderr = stderr;
         }
 
         @Override
@@ -116,6 +129,13 @@ class CoverageRunnerTest {
             commands.add(command);
             directories.add(directory);
             return exitCode;
+        }
+
+        @Override
+        public CommandResult runWithResult(List<String> command, Path directory) {
+            commands.add(command);
+            directories.add(directory);
+            return new CommandResult(exitCode, stdout, stderr);
         }
     }
 

--- a/core/src/test/java/media/barney/crap/core/CoverageRunnerTest.java
+++ b/core/src/test/java/media/barney/crap/core/CoverageRunnerTest.java
@@ -59,8 +59,8 @@ class CoverageRunnerTest {
                 () -> runner.generateCoverage(new ProjectModule(tempDir, tempDir, BuildTool.GRADLE)));
 
         String message = Objects.requireNonNull(ex.getMessage());
-        assertTrue(message.startsWith("Coverage command '"));
-        assertTrue(message.contains("' failed in " + tempDir.toAbsolutePath().normalize() + " with exit 2"));
+        assertTrue(message.startsWith("Coverage command ["));
+        assertTrue(message.contains("] failed in " + tempDir.toAbsolutePath().normalize() + " with exit 2"));
         assertTrue(message.contains("stderr:" + System.lineSeparator() + "coverage failed"));
         assertTrue(message.contains("stdout:" + System.lineSeparator() + "coverage progress"));
     }

--- a/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,6 +43,20 @@ class ProcessCommandExecutorTest {
         String streamed = streamedOutput.toString(StandardCharsets.UTF_8);
         assertTrue(streamed.contains("stdout message"));
         assertTrue(streamed.contains("stderr message"));
+    }
+
+    @Test
+    void limitsCapturedProcessOutputToTail() throws Exception {
+        ByteArrayOutputStream streamedOutput = new ByteArrayOutputStream();
+        ProcessCommandExecutor executor = new ProcessCommandExecutor(Duration.ofSeconds(5),
+                new PrintStream(streamedOutput, true, StandardCharsets.UTF_8));
+
+        CommandResult result = executor.runWithResult(largeOutputCommand(), tempDir);
+
+        assertEquals(0, result.exitCode());
+        assertTrue(result.stdout().contains("captured output truncated to last 65536 bytes"));
+        assertFalse(result.stdout().contains("first-line"));
+        assertTrue(result.stdout().contains("last-line"));
     }
 
     @Test
@@ -76,6 +91,33 @@ class ProcessCommandExecutorTest {
             return List.of("cmd", "/c", "echo stdout message && echo stderr message 1>&2 && exit 3");
         }
         return List.of("sh", "-c", "printf 'stdout message\\n'; printf 'stderr message\\n' >&2; exit 3");
+    }
+
+    private static List<String> largeOutputCommand() {
+        return List.of(
+                javaExecutable(),
+                "-cp",
+                System.getProperty("java.class.path"),
+                LargeOutput.class.getName()
+        );
+    }
+
+    private static String javaExecutable() {
+        String executable = System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
+                ? "java.exe"
+                : "java";
+        return Path.of(System.getProperty("java.home"), "bin", executable).toString();
+    }
+
+    public static final class LargeOutput {
+        public static void main(String[] args) {
+            System.out.println("first-line");
+            for (int index = 0; index < 70_000; index++) {
+                System.out.print('x');
+            }
+            System.out.println();
+            System.out.println("last-line");
+        }
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
@@ -3,6 +3,9 @@ package media.barney.crap.core;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -23,6 +26,22 @@ class ProcessCommandExecutorTest {
         int exit = new ProcessCommandExecutor().run(exitCommand(7), tempDir);
 
         assertEquals(7, exit);
+    }
+
+    @Test
+    void returnsCapturedProcessOutput() throws Exception {
+        ByteArrayOutputStream streamedOutput = new ByteArrayOutputStream();
+        ProcessCommandExecutor executor = new ProcessCommandExecutor(Duration.ofSeconds(5),
+                new PrintStream(streamedOutput, true, StandardCharsets.UTF_8));
+
+        CommandResult result = executor.runWithResult(outputCommand(), tempDir);
+
+        assertEquals(3, result.exitCode());
+        assertTrue(result.stdout().contains("stdout message"));
+        assertTrue(result.stderr().contains("stderr message"));
+        String streamed = streamedOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(streamed.contains("stdout message"));
+        assertTrue(streamed.contains("stderr message"));
     }
 
     @Test
@@ -50,6 +69,13 @@ class ProcessCommandExecutorTest {
             return List.of("powershell", "-Command", "Start-Sleep -Seconds 5");
         }
         return List.of("sh", "-c", "sleep 5");
+    }
+
+    private static List<String> outputCommand() {
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
+            return List.of("cmd", "/c", "echo stdout message && echo stderr message 1>&2 && exit 3");
+        }
+        return List.of("sh", "-c", "printf 'stdout message\\n'; printf 'stderr message\\n' >&2; exit 3");
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
@@ -54,7 +54,8 @@ class ProcessCommandExecutorTest {
         CommandResult result = executor.runWithResult(largeOutputCommand(), tempDir);
 
         assertEquals(0, result.exitCode());
-        assertTrue(result.stdout().contains("captured output truncated to last 65536 bytes"));
+        assertTrue(result.stdout().contains("captured output truncated to last "));
+        assertTrue(result.stdout().contains(" bytes"));
         assertFalse(result.stdout().contains("first-line"));
         assertTrue(result.stdout().contains("last-line"));
     }


### PR DESCRIPTION
## Summary
- return captured stdout/stderr from process-backed command execution while preserving live streaming
- include coverage command, execution directory, exit code, and captured output in coverage generation failures
- cover diagnostic messages and command output capture in core tests

Closes #109

## Verification
- mvn verify