### PR TITLE
Gate release publishing with project checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,14 @@ jobs:
           server-username: MAVEN_CENTRAL_TOKEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN_PASSWORD
 
+      - name: Make Gradle wrapper executable
+        run: chmod +x gradle-plugin/gradlew
+
       - name: Verify release version
         shell: bash
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
           pom_version="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
-          chmod +x gradle-plugin/gradlew
           gradle_version="$(cd gradle-plugin && ./gradlew -q properties | awk -F': ' '/^version:/ {print $2; exit}')"
           test "${pom_version}" = "${tag_version}"
           test "${gradle_version}" = "${tag_version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,6 @@ jobs:
             --build-tool maven \
             core/src/main/java cli/src/main/java maven-plugin/src/main/java
 
-      - name: Set up Gradle wrapper permissions for crap-java gate
-        run: chmod +x gradle-plugin/gradlew
-
       - name: Run Gradle-plugin crap-java gate
         run: |
           mkdir -p target/crap-java

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,52 @@ jobs:
           test "${pom_version}" = "${tag_version}"
           test "${gradle_version}" = "${tag_version}"
 
+      - name: Run cognitive-java gate
+        run: mvn -B cognitive-java:check
+
+      - name: Build CLI for crap-java gate
+        run: mvn -B -pl cli -am package
+
+      - name: Resolve CLI jar path
+        shell: bash
+        run: |
+          shopt -s nullglob
+          jars=(cli/target/crap-java-cli-*.jar)
+          filtered=()
+          for jar in "${jars[@]}"; do
+            case "$jar" in
+              *-sources.jar|*-javadoc.jar|*-shaded.jar|*original*.jar) ;;
+              *) filtered+=("$jar") ;;
+            esac
+          done
+          if [ "${#filtered[@]}" -ne 1 ]; then
+            echo "Expected exactly one built CLI jar, found ${#filtered[@]}" >&2
+            printf 'Candidates:\n%s\n' "${filtered[@]}" >&2
+            exit 1
+          fi
+          echo "CLI_JAR=${filtered[0]}" >> "$GITHUB_ENV"
+
+      - name: Run Maven-source crap-java gate
+        run: |
+          mkdir -p target/crap-java
+          java -jar "$CLI_JAR" \
+            --format text \
+            --junit-report target/crap-java/TEST-crap-java-maven-sources.xml \
+            --build-tool maven \
+            core/src/main/java cli/src/main/java maven-plugin/src/main/java
+
+      - name: Set up Gradle wrapper permissions for crap-java gate
+        run: chmod +x gradle-plugin/gradlew
+
+      - name: Run Gradle-plugin crap-java gate
+        run: |
+          mkdir -p target/crap-java
+          java -jar "$CLI_JAR" \
+            --format text \
+            --junit-report target/crap-java/TEST-crap-java-gradle-plugin.xml \
+            --build-tool gradle \
+            gradle-plugin/src/main/java
+
       - name: Import GPG key
         env:
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- add the cognitive-java gate to the release workflow before publishing
- build and resolve the CLI jar during releases
- run the same Maven-source and Gradle-plugin crap-java gates used by CI before deployment steps

Closes #132

## Verification
- mvn verify
- git diff --check