### PR TITLE
Fail release Javadocs on errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
-              <failOnError>false</failOnError>
+              <failOnError>true</failOnError>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
## Summary
- restore fail-on-error behavior for release Javadoc generation
- keep release profile packaging validated with strict Javadoc errors enabled

Closes #135

## Verification
- mvn verify
- mvn -B -Prelease "-Dgpg.skip=true" "-Dcentral.skipPublishing=true" -pl .,cli,maven-plugin -am package