### PR TITLE
Add security disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released minor version. Please upgrade to the latest release before reporting an issue that may already be fixed.
+
+## Reporting a Vulnerability
+
+Report suspected vulnerabilities privately through GitHub Security Advisories:
+
+https://github.com/fabian-barney/crap-java/security/advisories/new
+
+Do not open a public issue for suspected vulnerabilities.
+
+Reports are handled on a best-effort basis. You can generally expect an initial triage response within 14 days. This project does not currently run a paid bug bounty program.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,4 +12,4 @@ https://github.com/fabian-barney/crap-java/security/advisories/new
 
 Do not open a public issue for suspected vulnerabilities.
 
-Reports are handled on a best-effort basis. You can generally expect an initial triage response within 14 days. This project does not currently run a paid bug bounty program.
+Reports are handled on a best-effort basis. You can generally expect an acknowledgement and preliminary severity assessment within 14 days when the report includes enough information to reproduce or reason about the issue. This project does not currently run a paid bug bounty program.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Security fixes are provided for the latest released minor version. Please upgrade to the latest release before reporting an issue that may already be fixed.
+Security fixes are provided for the most recent published release only. Please upgrade to the latest release before reporting an issue that may already be fixed.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary
- add a SECURITY.md with supported-version guidance and a private disclosure path
- document expected triage timing and the absence of a paid bug bounty program

Closes #134

## Verification
- git diff --check