### PR TITLE
Fix macOS case sensitivity fallback

### DIFF
--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -178,9 +178,9 @@ record ReportOptions(
         return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
     }
 
-    private static boolean isLikelyCaseInsensitiveOs() {
+    static boolean isLikelyCaseInsensitiveOs() {
         String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
-        return os.contains("win") || os.contains("mac");
+        return os.startsWith("windows");
     }
 
     private static boolean sameCaseInsensitivePath(Path first, Path second) {

--- a/core/src/test/java/media/barney/crap/core/ReportOptionsTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportOptionsTest.java
@@ -1,0 +1,38 @@
+package media.barney.crap.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ReportOptionsTest {
+
+    @Test
+    void caseSensitivityFallbackTreatsWindowsAsInsensitive() {
+        withOsName("Windows 11", () -> assertTrue(ReportOptions.isLikelyCaseInsensitiveOs()));
+    }
+
+    @Test
+    void caseSensitivityFallbackTreatsMacOsAsUnknown() {
+        withOsName("Mac OS X", () -> assertFalse(ReportOptions.isLikelyCaseInsensitiveOs()));
+    }
+
+    @Test
+    void caseSensitivityFallbackDoesNotMatchDarwinAsWindows() {
+        withOsName("Darwin", () -> assertFalse(ReportOptions.isLikelyCaseInsensitiveOs()));
+    }
+
+    private static void withOsName(String osName, Runnable assertion) {
+        String original = System.getProperty("os.name");
+        try {
+            System.setProperty("os.name", osName);
+            assertion.run();
+        } finally {
+            if (original == null) {
+                System.clearProperty("os.name");
+            } else {
+                System.setProperty("os.name", original);
+            }
+        }
+    }
+}

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -468,9 +468,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
     }
 
-    private boolean isLikelyCaseInsensitiveOs() {
+    static boolean isLikelyCaseInsensitiveOs() {
         String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
-        return os.contains("win") || os.contains("mac");
+        return os.startsWith("windows");
     }
 
     private void cleanupStaleReports(Path currentOutputPath, Path currentJunitReportPath) throws Exception {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaCheckTaskTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaCheckTaskTest.java
@@ -1,0 +1,38 @@
+package media.barney.crap.gradle;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CrapJavaCheckTaskTest {
+
+    @Test
+    void caseSensitivityFallbackTreatsWindowsAsInsensitive() {
+        withOsName("Windows 11", () -> assertTrue(CrapJavaCheckTask.isLikelyCaseInsensitiveOs()));
+    }
+
+    @Test
+    void caseSensitivityFallbackTreatsMacOsAsUnknown() {
+        withOsName("Mac OS X", () -> assertFalse(CrapJavaCheckTask.isLikelyCaseInsensitiveOs()));
+    }
+
+    @Test
+    void caseSensitivityFallbackDoesNotMatchDarwinAsWindows() {
+        withOsName("Darwin", () -> assertFalse(CrapJavaCheckTask.isLikelyCaseInsensitiveOs()));
+    }
+
+    private static void withOsName(String osName, Runnable assertion) {
+        String original = System.getProperty("os.name");
+        try {
+            System.setProperty("os.name", osName);
+            assertion.run();
+        } finally {
+            if (original == null) {
+                System.clearProperty("os.name");
+            } else {
+                System.setProperty("os.name", original);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- classify the macOS fallback finding as valid and stop assuming every macOS filesystem is case-insensitive
- keep Windows as the only OS-based case-insensitive fallback when the filesystem probe cannot decide
- add core and Gradle task coverage for Windows, macOS, and Darwin fallback behavior

Closes #130

## Verification
- mvn verify
- git diff --check