### PR TITLE
Route Maven plugin output through Maven log

### DIFF
--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -5,14 +5,19 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.jspecify.annotations.Nullable;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -105,8 +110,9 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     }
 
     private void runCheck(Path executionRoot) throws MojoExecutionException, MojoFailureException {
-        try {
-            int exit = runner.run(true, reportArgs(executionRoot), executionRoot, System.out, System.err);
+        try (PrintStream out = logPrintStream(getLog(), false);
+             PrintStream err = logPrintStream(getLog(), true)) {
+            int exit = runner.run(true, reportArgs(executionRoot), executionRoot, out, err);
             handleExitCode(exit);
         } catch (MojoFailureException | MojoExecutionException ex) {
             throw ex;
@@ -234,6 +240,65 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         }
         if (exit != 0) {
             throw new MojoExecutionException("crap-java check failed with exit " + exit);
+        }
+    }
+
+    private static PrintStream logPrintStream(Log log, boolean errorByDefault) {
+        return new PrintStream(new LogOutputStream(log, errorByDefault), true, StandardCharsets.UTF_8);
+    }
+
+    private static final class LogOutputStream extends OutputStream {
+        private final Log log;
+        private final boolean errorByDefault;
+        private final ByteArrayOutputStream line = new ByteArrayOutputStream();
+
+        private LogOutputStream(Log log, boolean errorByDefault) {
+            this.log = log;
+            this.errorByDefault = errorByDefault;
+        }
+
+        @Override
+        public void write(int value) {
+            if (value == '\n') {
+                logLine();
+                return;
+            }
+            if (value != '\r') {
+                line.write(value);
+            }
+        }
+
+        @Override
+        public void write(byte[] buffer, int offset, int length) {
+            for (int index = offset; index < offset + length; index++) {
+                write(buffer[index]);
+            }
+        }
+
+        @Override
+        public void flush() {
+            logLine();
+        }
+
+        @Override
+        public void close() throws IOException {
+            flush();
+            super.close();
+        }
+
+        private void logLine() {
+            if (line.size() == 0) {
+                return;
+            }
+            String message = line.toString(StandardCharsets.UTF_8);
+            line.reset();
+            if (message.startsWith("Warning: ")) {
+                log.warn(message);
+            } else if (message.startsWith("Error: ") || errorByDefault) {
+                log.error(message);
+            } else {
+                log.info(message);
+            }
         }
     }
 

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -270,6 +270,7 @@ public class CrapJavaCheckMojo extends AbstractMojo {
 
         @Override
         public void write(byte[] buffer, int offset, int length) {
+            Objects.checkFromIndexSize(offset, length, buffer.length);
             for (int index = offset; index < offset + length; index++) {
                 write(buffer[index]);
             }

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -72,6 +72,26 @@ class CrapJavaCheckMojoTest {
     }
 
     @Test
+    void routesRunnerOutputThroughMavenLog() throws Exception {
+        Path root = tempDir.resolve("root");
+        writeCoverageReport(root);
+
+        RecordingRunner runner = new RecordingRunner();
+        runner.emitOutput = true;
+        RecordingLog log = new RecordingLog();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        mojo.setLog(log);
+        setField(mojo, "session", session(List.of(project(root, "root")), root));
+        setField(mojo, "project", project(root, "root"));
+
+        mojo.execute();
+
+        assertEquals(List.of("Report line", "partial report"), log.infoMessages);
+        assertEquals(List.of("Warning: generated coverage missing"), log.warnMessages);
+        assertEquals(List.of("Execution failed"), log.errorMessages);
+    }
+
+    @Test
     void usesConfiguredJunitReport() throws Exception {
         Path root = tempDir.resolve("root");
         writeCoverageReport(root);
@@ -400,6 +420,7 @@ class CrapJavaCheckMojoTest {
         private @Nullable Path projectRoot;
         private int exitCode;
         private @Nullable Exception failure;
+        private boolean emitOutput;
 
         @Override
         public int run(boolean useExistingCoverage, String[] args, Path projectRoot, java.io.PrintStream out, java.io.PrintStream err)
@@ -411,11 +432,18 @@ class CrapJavaCheckMojoTest {
             if (failure != null) {
                 throw failure;
             }
+            if (emitOutput) {
+                out.println("Report line");
+                out.print("partial report");
+                out.flush();
+                err.println("Warning: generated coverage missing");
+                err.println("Execution failed");
+            }
             return exitCode;
         }
     }
 
-    private static final class SilentLog implements Log {
+    private static class SilentLog implements Log {
 
         @Override
         public boolean isDebugEnabled() {
@@ -483,6 +511,27 @@ class CrapJavaCheckMojoTest {
 
         @Override
         public void error(Throwable error) {
+        }
+    }
+
+    private static final class RecordingLog extends SilentLog {
+        private final List<String> infoMessages = new ArrayList<>();
+        private final List<String> warnMessages = new ArrayList<>();
+        private final List<String> errorMessages = new ArrayList<>();
+
+        @Override
+        public void info(CharSequence content) {
+            infoMessages.add(content.toString());
+        }
+
+        @Override
+        public void warn(CharSequence content) {
+            warnMessages.add(content.toString());
+        }
+
+        @Override
+        public void error(CharSequence content) {
+            errorMessages.add(content.toString());
         }
     }
 }


### PR DESCRIPTION
## Summary
- classify the Maven logging finding as valid and route mojo runner output through Maven's Log API
- add a line-buffered PrintStream bridge that maps normal output to info, warning-prefixed lines to warn, and stderr lines to error
- cover newline and flushed partial-line logging behavior in mojo tests

Closes #129

## Verification
- mvn -pl maven-plugin test
- mvn verify
- git diff --check