### PR TITLE
Report elapsed time in JUnit XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,13 @@ doubt.
 
 The JUnit XML format exposes each analyzed method as a testcase and is shaped
 for GitLab's Tests tab. Testcases use the project-relative source path for
-`classname` and `file`, use `method:lineStart` as the testcase `name`, and
-write `time="0"`. Methods with CRAP scores over the configured threshold fail,
-methods with unavailable coverage are skipped, and failure/skipped element text
-includes CRAP score, threshold, coverage kind, source path, and line range.
-Custom properties remain for tools that read them, but GitLab-visible details do
-not rely on properties.
+`classname` and `file`, use `method:lineStart` as the testcase `name`, write the
+measured analysis duration on the testsuite, and divide that duration across
+testcases. Methods with CRAP scores over the configured threshold fail, methods
+with unavailable coverage are skipped, and failure/skipped element text includes
+CRAP score, threshold, coverage kind, source path, and line range. Custom
+properties remain for tools that read them, but GitLab-visible details do not
+rely on properties.
 
 ## Distribution
 

--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.LongSupplier;
 import org.jspecify.annotations.Nullable;
 
 final class CliApplication {
@@ -20,17 +21,28 @@ final class CliApplication {
     private final PrintStream err;
     private final CoverageRunner coverageRunner;
     private final CoverageMode coverageMode;
+    private final LongSupplier nanoTime;
 
     CliApplication(Path projectRoot,
                    PrintStream out,
                    PrintStream err,
                    CoverageRunner coverageRunner,
                    CoverageMode coverageMode) {
+        this(projectRoot, out, err, coverageRunner, coverageMode, System::nanoTime);
+    }
+
+    CliApplication(Path projectRoot,
+                   PrintStream out,
+                   PrintStream err,
+                   CoverageRunner coverageRunner,
+                   CoverageMode coverageMode,
+                   LongSupplier nanoTime) {
         this.projectRoot = projectRoot;
         this.out = out;
         this.err = err;
         this.coverageRunner = coverageRunner;
         this.coverageMode = coverageMode;
+        this.nanoTime = nanoTime;
     }
 
     int execute(String[] args) throws Exception {
@@ -38,6 +50,7 @@ final class CliApplication {
         if (parse.exitCode >= 0) {
             return parse.exitCode;
         }
+        long startedAt = nanoTime.getAsLong();
         CliArguments parsed = parse.arguments();
         try {
             Main.writeThresholdWarning(err, parsed.threshold());
@@ -49,7 +62,8 @@ final class CliApplication {
                     audit
             );
             if (filesToAnalyze.isEmpty()) {
-                CrapReport report = CrapReport.from(List.of(), parsed.threshold(), audit.build());
+                CrapReport report = CrapReport.from(List.of(), parsed.threshold(), audit.build())
+                        .withElapsedNanos(nanoTime.getAsLong() - startedAt);
                 ReportPublisher.publish(report, reportOptions(parsed), out);
                 return 0;
             }
@@ -62,7 +76,8 @@ final class CliApplication {
             );
             metrics.sort(Comparator.comparing(MethodMetrics::crapScore,
                     Comparator.nullsLast(Comparator.reverseOrder())));
-            CrapReport report = CrapReport.from(metrics, parsed.threshold(), audit.build());
+            CrapReport report = CrapReport.from(metrics, parsed.threshold(), audit.build())
+                    .withElapsedNanos(nanoTime.getAsLong() - startedAt);
             ReportPublisher.publish(report, reportOptions(parsed), out);
 
             double max = Main.maxCrap(metrics);

--- a/core/src/main/java/media/barney/crap/core/CrapReport.java
+++ b/core/src/main/java/media/barney/crap/core/CrapReport.java
@@ -7,8 +7,13 @@ record CrapReport(
         String status,
         double threshold,
         List<MethodReport> methods,
-        SourceExclusionAudit exclusions
+        SourceExclusionAudit exclusions,
+        double elapsedSeconds
 ) {
+    CrapReport(String status, double threshold, List<MethodReport> methods, SourceExclusionAudit exclusions) {
+        this(status, threshold, methods, exclusions, 0.0);
+    }
+
     CrapReport(String status, double threshold, List<MethodReport> methods) {
         this(status, threshold, methods, SourceExclusionAudit.empty());
     }
@@ -23,6 +28,11 @@ record CrapReport(
                 .map(metric -> MethodReport.from(metric, validatedThreshold))
                 .toList();
         return new CrapReport(status(methods), validatedThreshold, methods, exclusions);
+    }
+
+    CrapReport withElapsedNanos(long elapsedNanos) {
+        double seconds = Math.max(0.0, elapsedNanos / 1_000_000_000.0);
+        return new CrapReport(status, threshold, methods, exclusions, seconds);
     }
 
     private static String status(List<MethodReport> methods) {

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -150,6 +150,7 @@ public final class Main {
                                           ReportOptions reportOptions,
                                           double threshold,
                                           SourceExclusionOptions exclusionOptions) throws Exception {
+        long startedAt = System.nanoTime();
         Thresholds.validate(threshold);
         writeThresholdWarning(err, threshold);
         List<MethodMetrics> metrics = new ArrayList<>();
@@ -166,7 +167,8 @@ public final class Main {
             metrics.addAll(CrapAnalyzer.analyze(reportRoot, includedSources, module.coverageReport(), exclusions, audit));
         }
 
-        CrapReport report = CrapReport.from(metrics, threshold, audit.build());
+        CrapReport report = CrapReport.from(metrics, threshold, audit.build())
+                .withElapsedNanos(System.nanoTime() - startedAt);
         ReportPublisher.publish(report, reportOptions, out);
 
         double max = Main.maxCrap(metrics);

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -242,30 +242,33 @@ final class ReportFormatter {
         List<CrapReport.MethodReport> methods = sortedMethods(report.methods());
         int failed = countStatus(methods, MethodStatus.FAILED);
         int skipped = countStatus(methods, MethodStatus.SKIPPED);
+        String suiteTime = formatTime(report.elapsedSeconds());
+        String testCaseTime = formatTime(methods.isEmpty() ? 0.0 : report.elapsedSeconds() / methods.size());
         JunitTestSuite testSuite = new JunitTestSuite(
                 "crap-java",
                 methods.size(),
                 failed,
                 0,
                 skipped,
-                "0",
+                suiteTime,
                 new JunitProperties(junitSuiteProperties(report, includeExclusionAudit)),
                 methods.stream()
-                        .map(method -> junitTestCase(method, report.threshold(), omitRedundancy))
+                        .map(method -> junitTestCase(method, report.threshold(), omitRedundancy, testCaseTime))
                         .toList()
         );
-        return new JunitTestSuites(methods.size(), failed, 0, skipped, "0", List.of(testSuite));
+        return new JunitTestSuites(methods.size(), failed, 0, skipped, suiteTime, List.of(testSuite));
     }
 
     private static JunitTestCase junitTestCase(CrapReport.MethodReport method,
                                                double threshold,
-                                               boolean omitRedundancy) {
+                                               boolean omitRedundancy,
+                                               String time) {
         return new JunitTestCase(
                 method.sourcePath(),
                 testcaseName(method),
                 method.sourcePath(),
                 method.startLine(),
-                "0",
+                time,
                 junitProperties(method, omitRedundancy),
                 junitFailure(method, threshold),
                 junitSkipped(method, threshold)
@@ -379,7 +382,13 @@ final class ReportFormatter {
         List<CrapReport.MethodReport> failedMethods = report.methods().stream()
                 .filter(method -> method.status() == MethodStatus.FAILED)
                 .toList();
-        return new CrapReport(report.status(), report.threshold(), failedMethods, report.exclusions());
+        return new CrapReport(
+                report.status(),
+                report.threshold(),
+                failedMethods,
+                report.exclusions(),
+                report.elapsedSeconds()
+        );
     }
 
     private static boolean hasExclusionAudit(SourceExclusionAudit audit) {
@@ -409,6 +418,10 @@ final class ReportFormatter {
 
     private static String number(double value) {
         return Double.toString(value);
+    }
+
+    private static String formatTime(double elapsedSeconds) {
+        return String.format(Locale.ROOT, "%.1f", Math.max(0.0, elapsedSeconds));
     }
 
     private record JsonReport(

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -231,7 +231,7 @@ class MainTest {
         assertEquals("", utf8(out));
         assertEquals("", utf8(err));
         assertTrue(Files.readString(jsonReport).contains("\"covKind\": \"instruction\""));
-        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
+        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\""));
     }
 
     @Test
@@ -255,7 +255,7 @@ class MainTest {
         String junit = Files.readString(junitReport);
         assertEquals(2, exit);
         assertEquals("", utf8(out));
-        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\""));
         assertTrue(junit.contains("name=\"danger:4\""));
         assertTrue(junit.contains("name=\"safe:14\""));
         assertTrue(junit.contains("name=\"unknown:18\""));
@@ -286,7 +286,7 @@ class MainTest {
         assertEquals("", utf8(out));
         assertTrue(Files.exists(primaryReport));
         assertEquals("", Files.readString(primaryReport));
-        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\""));
     }
 
     @Test
@@ -320,7 +320,7 @@ class MainTest {
         assertTrue(primary.contains("\"method\": \"danger\""));
         assertFalse(primary.contains("\"method\": \"safe\""));
         assertFalse(primary.contains("\"method\": \"unknown\""));
-        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\""));
         assertTrue(junit.contains("name=\"danger:4\""));
         assertTrue(junit.contains("name=\"safe:14\""));
         assertTrue(junit.contains("name=\"unknown:18\""));
@@ -389,7 +389,7 @@ class MainTest {
         assertTrue(primary.contains("\"method\": \"danger\""));
         assertFalse(primary.contains("\"method\": \"safe\""));
         assertFalse(primary.contains("\"method\": \"unknown\""));
-        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(junit.contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\""));
         assertTrue(junit.contains("name=\"danger:4\""));
         assertTrue(junit.contains("name=\"safe:14\""));
         assertTrue(junit.contains("name=\"unknown:18\""));
@@ -517,7 +517,7 @@ class MainTest {
 
         assertEquals(2, exit);
         assertTrue(Files.exists(junitReport));
-        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"0\">"));
+        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\""));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.LongSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -215,23 +216,52 @@ class MainTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
 
-        int exit = Main.runWithExistingCoverage(
+        int exit = new CliApplication(
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err),
+                NOOP_COVERAGE,
+                CoverageMode.USE_EXISTING,
+                elapsedNanos(1_200_000_000L)
+        ).execute(
                 new String[]{
                         "--format", "json",
                         "--output", "target/crap-java/report.json",
                         "--junit-report", "target/crap-java/TEST-crap-java.xml",
                         "src/main/java/demo/Sample.java"
-                },
-                tempDir,
-                new PrintStream(out),
-                new PrintStream(err)
+                }
         );
 
         assertEquals(0, exit);
         assertEquals("", utf8(out));
         assertEquals("", utf8(err));
         assertTrue(Files.readString(jsonReport).contains("\"covKind\": \"instruction\""));
-        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\""));
+        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"1.2\">"));
+    }
+
+    @Test
+    void cliJunitReportUsesElapsedTimeWhenNoFilesAreAnalyzed() throws Exception {
+        Path junitReport = tempDir.resolve("target/crap-java/TEST-empty.xml");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exit = new CliApplication(
+                tempDir,
+                new PrintStream(out),
+                new PrintStream(err),
+                NOOP_COVERAGE,
+                CoverageMode.USE_EXISTING,
+                elapsedNanos(1_200_000_000L)
+        ).execute(
+                new String[]{
+                        "--format", "none",
+                        "--junit-report", "target/crap-java/TEST-empty.xml"
+                }
+        );
+
+        assertEquals(0, exit);
+        assertEquals("", utf8(out));
+        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"0\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"1.2\">"));
     }
 
     @Test
@@ -828,6 +858,19 @@ class MainTest {
 
     private static String utf8(ByteArrayOutputStream output) {
         return output.toString(StandardCharsets.UTF_8);
+    }
+
+    private static LongSupplier elapsedNanos(long elapsedNanos) {
+        return new LongSupplier() {
+            private long next;
+
+            @Override
+            public long getAsLong() {
+                long current = next;
+                next += elapsedNanos;
+                return current;
+            }
+        };
     }
 
     private void writeMixedCoverageSample() throws Exception {

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -218,7 +218,7 @@ class ReportFormatterTest {
         assertEquals("0", root.getAttribute("skipped"));
         assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("classname"));
         assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("file"));
-        assertEquals("0", danger.getAttribute("time"));
+        assertEquals("0.0", danger.getAttribute("time"));
         assertTrue(report.contains("<property name=\"threshold\" value=\"8.0\"/>"));
         assertFalse(hasTestcase(document, "safe:9"));
         assertFalse(hasTestcase(document, "unknown:20"));
@@ -360,13 +360,14 @@ class ReportFormatterTest {
 
     @Test
     void formatsJunitReportWithFailuresSkippedAndProperties() throws Exception {
-        String report = ReportFormatter.format(report(
+        String report = ReportFormatter.format(reportWithElapsed(1.2,
                 metric("danger", "demo.Sample", 4, 5, 10.0, 9.645),
                 metric("unknown", "demo.Sample", 20, 2, null, null)
         ), ReportFormat.JUNIT);
 
         Document document = parseXml(report);
         Element root = document.getDocumentElement();
+        Element suite = (Element) document.getElementsByTagName("testsuite").item(0);
         Element failure = (Element) document.getElementsByTagName("failure").item(0);
         Element skipped = (Element) document.getElementsByTagName("skipped").item(0);
         Element danger = testcaseByName(document, "danger:4");
@@ -377,16 +378,17 @@ class ReportFormatterTest {
         assertEquals("1", root.getAttribute("failures"));
         assertEquals("0", root.getAttribute("errors"));
         assertEquals("1", root.getAttribute("skipped"));
-        assertEquals("0", root.getAttribute("time"));
+        assertEquals("1.2", root.getAttribute("time"));
+        assertEquals("1.2", suite.getAttribute("time"));
         assertTrue(report.contains("    <property name=\"threshold\" value=\"8.0\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"instruction\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"N/A\"/>"));
         assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("classname"));
         assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("file"));
-        assertEquals("0", danger.getAttribute("time"));
+        assertEquals("0.6", danger.getAttribute("time"));
         assertEquals("src/main/java/demo/Sample.java", unknown.getAttribute("classname"));
         assertEquals("src/main/java/demo/Sample.java", unknown.getAttribute("file"));
-        assertEquals("0", unknown.getAttribute("time"));
+        assertEquals("0.6", unknown.getAttribute("time"));
         assertEquals("CRAP threshold exceeded: 9.6 > 8.0", failure.getAttribute("message"));
         assertEquals("crap-java.threshold", failure.getAttribute("type"));
         assertTrue(failure.getTextContent().contains("CRAP score: 9.6"));
@@ -482,6 +484,17 @@ class ReportFormatterTest {
 
     private static CrapReport report(MethodMetrics... metrics) {
         return CrapReport.from(List.of(metrics), Main.DEFAULT_THRESHOLD);
+    }
+
+    private static CrapReport reportWithElapsed(double elapsedSeconds, MethodMetrics... metrics) {
+        CrapReport report = CrapReport.from(List.of(metrics), Main.DEFAULT_THRESHOLD);
+        return new CrapReport(
+                report.status(),
+                report.threshold(),
+                report.methods(),
+                report.exclusions(),
+                elapsedSeconds
+        );
     }
 
     private static int tableHeaderIndex(List<String> lines, String firstColumn) {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -243,7 +243,7 @@ class CrapJavaGradlePluginFunctionalTest {
         assertTrue(primaryReport.contains("\"threshold\": 8.0"));
         assertTrue(primaryReport.contains("\"method\": \"alpha\""));
         assertFalse(primaryReport.contains("      \"status\":"));
-        assertTrue(junitReport.contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
+        assertTrue(junitReport.contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\""));
         assertTrue(junitReport.contains("<property name=\"status\" value=\"passed\"/>"));
     }
 

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -277,7 +277,8 @@ class CrapJavaGradlePluginTest {
         task.runCheck();
 
         assertTrue(Files.exists(jacocoXml));
-        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
+        assertTrue(Files.readString(junitReport)
+                .contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\""));
     }
 
     @Test
@@ -329,7 +330,8 @@ class CrapJavaGradlePluginTest {
 
         task.runCheck();
 
-        assertTrue(Files.readString(junitReport).contains("<testsuites tests=\"0\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">"));
+        assertTrue(Files.readString(junitReport)
+                .contains("<testsuites tests=\"0\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\""));
     }
 
     @Test

--- a/maven-plugin/src/it/configured-report-controls/verify.bsh
+++ b/maven-plugin/src/it/configured-report-controls/verify.bsh
@@ -26,7 +26,7 @@ if (primary.contains("      \"status\":")) {
 }
 
 String junit = Files.readString(junitReport);
-if (!junit.contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0\">")) {
+if (!junit.contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"")) {
     throw new RuntimeException("Configured JUnit sidecar should contain the full report");
 }
 if (!junit.contains("<property name=\"status\" value=\"passed\"/>")) {


### PR DESCRIPTION
## Summary
- classify the JUnit timing finding as partially valid and report elapsed analysis time in JUnit XML
- keep `errors=0` unchanged because threshold breaches are modeled as JUnit failures and execution errors do not emit a report
- set suite/testsuite time from elapsed seconds and distribute testcase time as a best-effort share

Closes #128

## Verification
- mvn -pl core test
- mvn verify
- git diff --check