### PR TITLE
Document report path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ java -jar cli/target/crap-java-cli-0.5.0.jar module-a module-b
 The CLI writes only the requested primary report format to stdout unless
 `--output` is set. Warnings and threshold errors are written to stderr. Use
 `--format none` when you only want the exit status or a JUnit sidecar.
+Report paths passed to `--output` and `--junit-report` are filesystem targets:
+relative paths resolve against the analyzed project root, absolute paths remain
+absolute, and normalized `..` segments may target locations outside that root.
+Keep those values fixed or otherwise trusted in CI configurations.
 
 Machine-readable primary reports include top-level `status` (`passed` or
 `failed`) and `threshold` values. Method entries use compact fields `status`,

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -202,6 +202,10 @@ public final class Main {
                   0   Pass - no methods exceed threshold
                   1   Error - invalid arguments, parse failure, or I/O failure
                   2   Threshold exceeded - at least one method has CRAP > threshold
+
+                Report paths:
+                  Relative --output and --junit-report paths resolve against the project root
+                  Absolute paths and normalized paths outside the project root are honored
                 """;
     }
 

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -47,6 +47,8 @@ class MainTest {
         assertTrue(utf8(out).contains("0   Pass"));
         assertTrue(utf8(out).contains("1   Error"));
         assertTrue(utf8(out).contains("2   Threshold exceeded"));
+        assertTrue(utf8(out).contains("Report paths:"));
+        assertTrue(utf8(out).contains("outside the project root are honored"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Document the existing report path contract for `--output` and `--junit-report` in CLI help and README.
- Clarify that relative report paths resolve from the analyzed project root, while absolute paths and normalized paths outside the root are honored.
- Keep the existing behavior intact because callers and build plugins can intentionally target external artifact locations.

## Classification
Valid as a documentation hardening issue. I am not restricting paths because that would be a compatibility change for an intentional filesystem-output contract; CI configurations should keep these values trusted.

## Verification
- `mvn verify`

Closes #125