### PR TITLE
Report Java parse diagnostics

### DIFF
--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -20,6 +20,9 @@ import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 
 import javax.tools.JavaCompiler;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
 import java.io.IOException;
@@ -27,6 +30,7 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 final class JavaMethodParser {
 
@@ -40,15 +44,17 @@ final class JavaMethodParser {
         }
 
         try {
+            DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
             JavacTask task = (JavacTask) compiler.getTask(
                     null,
                     null,
-                    null,
+                    diagnostics,
                     List.of("-proc:none"),
                     null,
                     List.of(new SourceFileObject(className, source))
             );
             Iterable<? extends CompilationUnitTree> units = task.parse();
+            throwIfParseErrors(className, diagnostics.getDiagnostics());
             return collectMethods(task, units);
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
@@ -64,6 +70,23 @@ final class JavaMethodParser {
 
     static URI sourceUri(String className) {
         return URI.create("string:///" + sourcePath(className));
+    }
+
+    private static void throwIfParseErrors(String className, List<Diagnostic<? extends JavaFileObject>> diagnostics) {
+        List<String> errors = diagnostics.stream()
+                .filter(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR)
+                .map(JavaMethodParser::formatDiagnostic)
+                .toList();
+        if (!errors.isEmpty()) {
+            throw new JavaMethodParseException(sourcePath(className), errors);
+        }
+    }
+
+    private static String formatDiagnostic(Diagnostic<? extends JavaFileObject> diagnostic) {
+        long line = diagnostic.getLineNumber();
+        long column = diagnostic.getColumnNumber();
+        String location = line < 0 ? "unknown location" : "line " + line + ", column " + column;
+        return location + ": " + diagnostic.getMessage(Locale.ROOT);
     }
 
     private static List<MethodDescriptor> collectMethods(JavacTask task,
@@ -226,6 +249,12 @@ final class JavaMethodParser {
                 complexity++;
             }
             return super.visitBinary(node, null);
+        }
+    }
+
+    static final class JavaMethodParseException extends IllegalArgumentException {
+        private JavaMethodParseException(String sourcePath, List<String> diagnostics) {
+            super("Unable to parse Java source " + sourcePath + ":\n" + String.join("\n", diagnostics));
         }
     }
 

--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -83,10 +83,18 @@ final class JavaMethodParser {
     }
 
     private static String formatDiagnostic(Diagnostic<? extends JavaFileObject> diagnostic) {
-        long line = diagnostic.getLineNumber();
-        long column = diagnostic.getColumnNumber();
-        String location = line < 0 ? "unknown location" : "line " + line + ", column " + column;
-        return location + ": " + diagnostic.getMessage(Locale.ROOT);
+        return formatDiagnosticLocation(diagnostic.getLineNumber(), diagnostic.getColumnNumber())
+                + ": " + diagnostic.getMessage(Locale.ROOT);
+    }
+
+    static String formatDiagnosticLocation(long line, long column) {
+        if (line < 0) {
+            return "unknown location";
+        }
+        if (column < 0) {
+            return "line " + line;
+        }
+        return "line " + line + ", column " + column;
     }
 
     private static List<MethodDescriptor> collectMethods(JavacTask task,

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JavaMethodParserTest {
 
@@ -96,6 +99,28 @@ class JavaMethodParserTest {
         List<MethodDescriptor> methods = JavaMethodParser.parse("demo.Sample", source);
 
         assertEquals(List.of(new MethodDescriptor("demo.Sample", "helper", 4, 6, 1)), methods);
+    }
+
+    @Test
+    void failsOnParseErrorsInsteadOfReturningPartialMethods() {
+        String source = """
+                package demo;
+
+                class Broken {
+                    int partial() {
+                        if (true) {
+                            return 1;
+                    }
+                """;
+
+        JavaMethodParser.JavaMethodParseException thrown = assertThrows(
+                JavaMethodParser.JavaMethodParseException.class,
+                () -> JavaMethodParser.parse("demo.Broken", source)
+        );
+
+        String message = requireNonNull(thrown.getMessage());
+        assertTrue(message.contains("Unable to parse Java source demo/Broken.java:"));
+        assertTrue(message.contains("line "));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -124,6 +124,13 @@ class JavaMethodParserTest {
     }
 
     @Test
+    void formatsUnknownDiagnosticLocationsWithoutNegativeColumns() {
+        assertEquals("unknown location", JavaMethodParser.formatDiagnosticLocation(-1, -1));
+        assertEquals("line 5", JavaMethodParser.formatDiagnosticLocation(5, -1));
+        assertEquals("line 5, column 7", JavaMethodParser.formatDiagnosticLocation(5, 7));
+    }
+
+    @Test
     void ignoresKeywordsInsideCommentsAndStrings() {
         String source = """
                 class Sample {


### PR DESCRIPTION
## Summary
- classify #103 as valid: javac diagnostics were discarded while parsing source text
- collect javac diagnostics and fail parse attempts with the source path and diagnostic locations instead of returning partial method data
- add a malformed-source regression test

Closes #103

## Verification
- mvn -pl core test
- mvn verify