### PR TITLE
Skip methods with unknown source positions

### DIFF
--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -19,6 +19,7 @@ import com.sun.source.util.TreeScanner;
 import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 
+import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
@@ -64,6 +65,12 @@ final class JavaMethodParser {
 
     static URI sourceUri(String className) {
         return URI.create("string:///" + sourcePath(className));
+    }
+
+    static boolean hasKnownLineRange(long start, long endExclusive) {
+        return start != Diagnostic.NOPOS
+                && endExclusive != Diagnostic.NOPOS
+                && endExclusive > start;
     }
 
     private static List<MethodDescriptor> collectMethods(JavacTask task,
@@ -118,8 +125,11 @@ final class JavaMethodParser {
 
             long start = positions.getStartPosition(unit, node);
             long bodyEndExclusive = positions.getEndPosition(unit, node.getBody());
+            if (!hasKnownLineRange(start, bodyEndExclusive)) {
+                return null;
+            }
             int startLine = lineNumber(start);
-            int endLine = lineNumber(Math.decrementExact((int) bodyEndExclusive));
+            int endLine = lineNumber(Math.decrementExact(bodyEndExclusive));
             int complexity = ComplexityCounter.count(node);
             methods.add(new MethodDescriptor(
                     currentClassName(),

--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -67,7 +67,7 @@ final class JavaMethodParser {
         return URI.create("string:///" + sourcePath(className));
     }
 
-    static boolean hasKnownLineRange(long start, long endExclusive) {
+    static boolean hasKnownSourceRange(long start, long endExclusive) {
         return start != Diagnostic.NOPOS
                 && endExclusive != Diagnostic.NOPOS
                 && endExclusive > start;
@@ -125,7 +125,7 @@ final class JavaMethodParser {
 
             long start = positions.getStartPosition(unit, node);
             long bodyEndExclusive = positions.getEndPosition(unit, node.getBody());
-            if (!hasKnownLineRange(start, bodyEndExclusive)) {
+            if (!hasKnownSourceRange(start, bodyEndExclusive)) {
                 return null;
             }
             int startLine = lineNumber(start);

--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -75,12 +75,17 @@ final class JavaMethodParser {
 
     private static List<MethodDescriptor> collectMethods(JavacTask task,
                                                          Iterable<? extends CompilationUnitTree> units) {
-        Trees trees = Trees.instance(task);
         List<MethodDescriptor> methods = new ArrayList<>();
+        Trees trees = Trees.instance(task);
         for (CompilationUnitTree unit : units) {
-            SourcePositions positions = trees.getSourcePositions();
-            new MethodScanner(unit, positions, methods).scan(unit, null);
+            methods.addAll(collectMethods(unit, trees.getSourcePositions()));
         }
+        return methods;
+    }
+
+    static List<MethodDescriptor> collectMethods(CompilationUnitTree unit, SourcePositions positions) {
+        List<MethodDescriptor> methods = new ArrayList<>();
+        new MethodScanner(unit, positions, methods).scan(unit, null);
         return methods;
     }
 

--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -78,15 +78,21 @@ final class JavaMethodParser {
         List<MethodDescriptor> methods = new ArrayList<>();
         Trees trees = Trees.instance(task);
         for (CompilationUnitTree unit : units) {
-            methods.addAll(collectMethods(unit, trees.getSourcePositions()));
+            collectMethods(unit, trees.getSourcePositions(), methods);
         }
         return methods;
     }
 
     static List<MethodDescriptor> collectMethods(CompilationUnitTree unit, SourcePositions positions) {
         List<MethodDescriptor> methods = new ArrayList<>();
-        new MethodScanner(unit, positions, methods).scan(unit, null);
+        collectMethods(unit, positions, methods);
         return methods;
+    }
+
+    private static void collectMethods(CompilationUnitTree unit,
+                                       SourcePositions positions,
+                                       List<MethodDescriptor> methods) {
+        new MethodScanner(unit, positions, methods).scan(unit, null);
     }
 
     private static final class MethodScanner extends TreePathScanner<Void, Void> {

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -12,11 +12,13 @@ import java.util.List;
 import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler;
 import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class JavaMethodParserTest {
 
@@ -140,7 +142,7 @@ class JavaMethodParserTest {
 
         List<MethodDescriptor> methods = JavaMethodParser.collectMethods(unit, unknownPositions);
 
-        assertEquals(List.of(), methods);
+        assertTrue(methods.isEmpty(), "methods with unknown source positions should be skipped");
     }
 
     @Test
@@ -305,23 +307,24 @@ class JavaMethodParserTest {
 
     private static CompilationUnitTree parseUnit(String source) throws IOException {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        if (compiler == null) {
-            throw new IllegalStateException("No system Java compiler is available");
+        assumeTrue(compiler != null, "system Java compiler is required");
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
+            JavacTask task = (JavacTask) compiler.getTask(
+                    null,
+                    fileManager,
+                    null,
+                    List.of("-proc:none"),
+                    null,
+                    List.of(new SimpleJavaFileObject(URI.create("string:///Sample.java"),
+                            SimpleJavaFileObject.Kind.SOURCE) {
+                        @Override
+                        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                            return source;
+                        }
+                    })
+            );
+            return task.parse().iterator().next();
         }
-        JavacTask task = (JavacTask) compiler.getTask(
-                null,
-                null,
-                null,
-                List.of("-proc:none"),
-                null,
-                List.of(new SimpleJavaFileObject(URI.create("string:///Sample.java"), SimpleJavaFileObject.Kind.SOURCE) {
-                    @Override
-                    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-                        return source;
-                    }
-                })
-        );
-        return task.parse().iterator().next();
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -1,10 +1,18 @@
 package media.barney.crap.core;
 
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.SourcePositions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import javax.tools.Diagnostic;
+import javax.tools.JavaCompiler;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -107,6 +115,32 @@ class JavaMethodParserTest {
         assertFalse(JavaMethodParser.hasKnownSourceRange(10, Diagnostic.NOPOS));
         assertFalse(JavaMethodParser.hasKnownSourceRange(10, 10));
         assertTrue(JavaMethodParser.hasKnownSourceRange(10, 11));
+    }
+
+    @Test
+    void skipsParsedMethodsWithUnknownSourcePositions() throws IOException {
+        CompilationUnitTree unit = parseUnit("""
+                class Sample {
+                    int alpha() {
+                        return 1;
+                    }
+                }
+                """);
+        SourcePositions unknownPositions = new SourcePositions() {
+            @Override
+            public long getStartPosition(CompilationUnitTree file, Tree tree) {
+                return Diagnostic.NOPOS;
+            }
+
+            @Override
+            public long getEndPosition(CompilationUnitTree file, Tree tree) {
+                return Diagnostic.NOPOS;
+            }
+        };
+
+        List<MethodDescriptor> methods = JavaMethodParser.collectMethods(unit, unknownPositions);
+
+        assertEquals(List.of(), methods);
     }
 
     @Test
@@ -267,6 +301,27 @@ class JavaMethodParserTest {
         assertEquals("demo/Sample.java", JavaMethodParser.sourcePath("demo.Sample.java"));
         assertEquals(URI.create("string:///demo/Sample.java"), JavaMethodParser.sourceUri("demo.Sample"));
         assertEquals(URI.create("string:///demo/Sample.java"), JavaMethodParser.sourceUri("demo.Sample.java"));
+    }
+
+    private static CompilationUnitTree parseUnit(String source) throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new IllegalStateException("No system Java compiler is available");
+        }
+        JavacTask task = (JavacTask) compiler.getTask(
+                null,
+                null,
+                null,
+                List.of("-proc:none"),
+                null,
+                List.of(new SimpleJavaFileObject(URI.create("string:///Sample.java"), SimpleJavaFileObject.Kind.SOURCE) {
+                    @Override
+                    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                        return source;
+                    }
+                })
+        );
+        return task.parse().iterator().next();
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -103,10 +103,10 @@ class JavaMethodParserTest {
 
     @Test
     void rejectsUnknownSourcePositionRanges() {
-        assertFalse(JavaMethodParser.hasKnownLineRange(Diagnostic.NOPOS, 10));
-        assertFalse(JavaMethodParser.hasKnownLineRange(10, Diagnostic.NOPOS));
-        assertFalse(JavaMethodParser.hasKnownLineRange(10, 10));
-        assertTrue(JavaMethodParser.hasKnownLineRange(10, 11));
+        assertFalse(JavaMethodParser.hasKnownSourceRange(Diagnostic.NOPOS, 10));
+        assertFalse(JavaMethodParser.hasKnownSourceRange(10, Diagnostic.NOPOS));
+        assertFalse(JavaMethodParser.hasKnownSourceRange(10, 10));
+        assertTrue(JavaMethodParser.hasKnownSourceRange(10, 11));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -4,8 +4,11 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.List;
+import javax.tools.Diagnostic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JavaMethodParserTest {
 
@@ -96,6 +99,14 @@ class JavaMethodParserTest {
         List<MethodDescriptor> methods = JavaMethodParser.parse("demo.Sample", source);
 
         assertEquals(List.of(new MethodDescriptor("demo.Sample", "helper", 4, 6, 1)), methods);
+    }
+
+    @Test
+    void rejectsUnknownSourcePositionRanges() {
+        assertFalse(JavaMethodParser.hasKnownLineRange(Diagnostic.NOPOS, 10));
+        assertFalse(JavaMethodParser.hasKnownLineRange(10, Diagnostic.NOPOS));
+        assertFalse(JavaMethodParser.hasKnownLineRange(10, 10));
+        assertTrue(JavaMethodParser.hasKnownLineRange(10, 11));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- classify #104 as valid: javac source positions can use Diagnostic.NOPOS and must not produce line 0 or negative ranges
- skip methods whose start or body end position is unknown or empty
- add a regression test for the source-position guard

Closes #104

## Verification
- mvn -pl core test
- mvn verify