### PR TITLE
Reject malformed JaCoCo integer attributes

### DIFF
--- a/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
+++ b/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
@@ -71,7 +71,7 @@ final class JacocoCoverageParser {
                 continue;
             }
             String methodName = method.getAttribute("name");
-            int line = parseInt(method.getAttribute("line"));
+            int line = parseInt("line", method.getAttribute("line"));
             String key = className + "#" + methodName + ":" + line;
             coverage.put(key, data);
         }
@@ -98,16 +98,21 @@ final class JacocoCoverageParser {
     }
 
     private static CoverageCounter readCounter(Element counter) {
-        int missed = parseInt(counter.getAttribute("missed"));
-        int covered = parseInt(counter.getAttribute("covered"));
+        int missed = parseInt("missed", counter.getAttribute("missed"));
+        int covered = parseInt("covered", counter.getAttribute("covered"));
         return new CoverageCounter(missed, covered);
     }
 
-    private static int parseInt(String value) {
+    private static int parseInt(String attributeName, String value) {
         try {
-            return Integer.parseInt(value);
+            int parsed = Integer.parseInt(value);
+            if (parsed < 0) {
+                throw new NumberFormatException("negative value");
+            }
+            return parsed;
         } catch (NumberFormatException ex) {
-            return 0;
+            throw new IllegalArgumentException(
+                    "Invalid JaCoCo integer attribute " + attributeName + "=\"" + value + "\"", ex);
         }
     }
 }

--- a/core/src/test/java/media/barney/crap/core/JacocoCoverageParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JacocoCoverageParserTest.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JacocoCoverageParserTest {
@@ -175,7 +176,7 @@ class JacocoCoverageParserTest {
     }
 
     @Test
-    void parsesInvalidLineNumbersAsZero() throws IOException {
+    void rejectsInvalidLineNumbers() throws IOException {
         Path xml = tempDir.resolve("jacoco-invalid-line.xml");
         Files.writeString(xml, """
                 <report name="demo">
@@ -189,9 +190,33 @@ class JacocoCoverageParserTest {
                 </report>
                 """);
 
-        Map<String, CoverageData> result = JacocoCoverageParser.parse(xml);
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> JacocoCoverageParser.parse(xml));
 
-        assertEquals(90.0, Objects.requireNonNull(result.get("demo.Sample#alpha:0")).coveragePercent(), 0.001);
+        String message = Objects.requireNonNull(Objects.requireNonNull(error.getCause()).getMessage());
+        assertTrue(message.contains("Invalid JaCoCo integer attribute line=\"oops\""));
+    }
+
+    @Test
+    void rejectsInvalidCounterValues() throws IOException {
+        Path xml = tempDir.resolve("jacoco-invalid-counter.xml");
+        Files.writeString(xml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()V" line="10">
+                        <counter type="INSTRUCTION" missed="abc" covered="9"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> JacocoCoverageParser.parse(xml));
+
+        String message = Objects.requireNonNull(Objects.requireNonNull(error.getCause()).getMessage());
+        assertTrue(message.contains("Invalid JaCoCo integer attribute missed=\"abc\""));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- classify #110 as valid: malformed JaCoCo line/counter attributes should not silently become zero
- reject invalid or negative integer attributes with an attribute-specific message
- update coverage parser tests for malformed line and counter values

Closes #110

## Verification
- mvn -pl core test
- mvn verify