### PR TITLE
Use platform Gradle fallback launcher

### DIFF
--- a/core/src/main/java/media/barney/crap/core/ProjectModule.java
+++ b/core/src/main/java/media/barney/crap/core/ProjectModule.java
@@ -93,7 +93,7 @@ record ProjectModule(Path moduleRoot, Path executionRoot, BuildTool buildTool) {
     }
 
     private String gradleLauncher() {
-        return launcher("gradlew.bat", "gradlew", "gradle");
+        return launcher("gradlew.bat", "gradlew", isWindows() ? "gradle.bat" : "gradle");
     }
 
     private String launcher(String windowsWrapper, String unixWrapper, String fallback) {

--- a/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -218,7 +219,8 @@ class CliApplicationTest {
 
         assertEquals(0, exit);
         assertEquals(List.of(tempDir), directories);
-        assertEquals(List.of(List.of("gradle", "--no-daemon", "-q", ":apps:demo:test", ":apps:demo:jacocoTestReport")), commands);
+        assertEquals(List.of(List.of(gradleFallbackLauncher(), "--no-daemon", "-q",
+                ":apps:demo:test", ":apps:demo:jacocoTestReport")), commands);
         assertTrue(utf8(out).contains("apps/demo/src/main/java/demo/Sample.java"));
         assertFalse(utf8(err).contains("Warning: JaCoCo XML not found"));
     }
@@ -355,6 +357,12 @@ class CliApplicationTest {
 
     private static String utf8(ByteArrayOutputStream output) {
         return output.toString(StandardCharsets.UTF_8);
+    }
+
+    private static String gradleFallbackLauncher() {
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
+                ? "gradle.bat"
+                : "gradle";
     }
 
     private static void run(Path dir, String... command) throws Exception {

--- a/core/src/test/java/media/barney/crap/core/ProjectModuleTest.java
+++ b/core/src/test/java/media/barney/crap/core/ProjectModuleTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
-import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -14,15 +13,28 @@ class ProjectModuleTest {
     Path tempDir;
 
     @Test
-    void gradleFallbackLauncherMatchesTheCurrentPlatform() {
-        ProjectModule module = new ProjectModule(tempDir, tempDir, BuildTool.GRADLE);
-
-        assertEquals(gradleFallbackLauncher(), module.coverageCommand().get(0));
+    void gradleFallbackLauncherUsesGradleBatOnWindows() {
+        assertGradleFallbackLauncher("Windows 11", "gradle.bat");
     }
 
-    private static String gradleFallbackLauncher() {
-        return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
-                ? "gradle.bat"
-                : "gradle";
+    @Test
+    void gradleFallbackLauncherUsesGradleOnOtherPlatforms() {
+        assertGradleFallbackLauncher("Linux", "gradle");
+    }
+
+    private void assertGradleFallbackLauncher(String osName, String expectedLauncher) {
+        String originalOsName = System.getProperty("os.name");
+        try {
+            System.setProperty("os.name", osName);
+            ProjectModule module = new ProjectModule(tempDir, tempDir, BuildTool.GRADLE);
+
+            assertEquals(expectedLauncher, module.coverageCommand().get(0));
+        } finally {
+            if (originalOsName == null) {
+                System.clearProperty("os.name");
+            } else {
+                System.setProperty("os.name", originalOsName);
+            }
+        }
     }
 }

--- a/core/src/test/java/media/barney/crap/core/ProjectModuleTest.java
+++ b/core/src/test/java/media/barney/crap/core/ProjectModuleTest.java
@@ -1,0 +1,28 @@
+package media.barney.crap.core;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProjectModuleTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void gradleFallbackLauncherMatchesTheCurrentPlatform() {
+        ProjectModule module = new ProjectModule(tempDir, tempDir, BuildTool.GRADLE);
+
+        assertEquals(gradleFallbackLauncher(), module.coverageCommand().get(0));
+    }
+
+    private static String gradleFallbackLauncher() {
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
+                ? "gradle.bat"
+                : "gradle";
+    }
+}


### PR DESCRIPTION
## Summary
- use `gradle.bat` as the command fallback on Windows when no Gradle wrapper exists
- keep the existing wrapper preference order unchanged
- cover the platform-specific fallback through core tests

## Verification
- `mvn verify`

Closes #116