### PR TITLE
Exercise core and CLI CI on JDK 21 and 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,22 +10,23 @@ permissions:
 
 jobs:
   core-and-cli:
-    name: Core and CLI (${{ matrix.os }})
+    name: Core and CLI (${{ matrix.os }}, JDK ${{ matrix.java }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+        java: [ "17", "21", "25" ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: ${{ matrix.java }}
           cache: maven
 
       - name: Build CLI and run core tests


### PR DESCRIPTION
Closes #133.

## Summary
- expand the core-and-CLI CI matrix to run on JDK 17, 21, and 25 across Linux, Windows, and macOS
- include the selected JDK in the job and setup step names for easier Actions triage

## Verification
- mvn verify