### PR TITLE
Accept inline values for CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ java -jar cli/target/crap-java-cli-0.5.0.jar
 <directory ...>       Analyze all Java files under each directory's nested src/main/java trees
 ```
 
+Value-taking long options may also be written with inline assignment, such as
+`--build-tool=maven`, `--format=json`, or `--exclude=module-a/**`.
+
 Examples:
 
 ```bash
@@ -129,6 +132,7 @@ java -jar cli/target/crap-java-cli-0.5.0.jar --help
 java -jar cli/target/crap-java-cli-0.5.0.jar
 java -jar cli/target/crap-java-cli-0.5.0.jar --changed
 java -jar cli/target/crap-java-cli-0.5.0.jar --build-tool gradle
+java -jar cli/target/crap-java-cli-0.5.0.jar --build-tool=maven
 java -jar cli/target/crap-java-cli-0.5.0.jar --format json
 java -jar cli/target/crap-java-cli-0.5.0.jar --format none --junit-report target/crap-java/TEST-crap-java.xml
 java -jar cli/target/crap-java-cli-0.5.0.jar --format json --output target/crap-java/report.json
@@ -138,7 +142,9 @@ java -jar cli/target/crap-java-cli-0.5.0.jar --agent
 java -jar cli/target/crap-java-cli-0.5.0.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
 java -jar cli/target/crap-java-cli-0.5.0.jar --junit-report target/crap-java/TEST-crap-java.xml
 java -jar cli/target/crap-java-cli-0.5.0.jar --threshold 6
+java -jar cli/target/crap-java-cli-0.5.0.jar --threshold=6
 java -jar cli/target/crap-java-cli-0.5.0.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
+java -jar cli/target/crap-java-cli-0.5.0.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
 java -jar cli/target/crap-java-cli-0.5.0.jar --build-tool maven module-a/src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.5.0.jar src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.5.0.jar module-a module-b

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ java -jar cli/target/crap-java-cli-0.5.0.jar
 ```
 
 Value-taking long options may also be written with inline assignment, such as
-`--build-tool=maven`, `--format=json`, or `--exclude=module-a/**`.
+`--build-tool=maven`, `--format=json`, or `--exclude='module-a/**'`.
 
 Examples:
 

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -143,73 +143,98 @@ final class CliArgumentsParser {
     }
 
     private static int parseValuedOption(String[] args, int index, ParseStateBuilder state, String arg) {
-        if (parseBuildToolOption(args, index, state, arg)
-                || parseReportFormatOption(args, index, state, arg)
-                || parseOutputOption(args, index, state, arg)
-                || parseJunitReportOption(args, index, state, arg)
-                || parseThresholdOption(args, index, state, arg)
-                || parseExclusionOption(args, index, state, arg)) {
-            return index + 1;
+        AssignedOption option = AssignedOption.parse(arg);
+        if (parseBuildToolOption(args, index, state, option)
+                || parseReportFormatOption(args, index, state, option)
+                || parseOutputOption(args, index, state, option)
+                || parseJunitReportOption(args, index, state, option)
+                || parseThresholdOption(args, index, state, option)
+                || parseExclusionOption(args, index, state, option)) {
+            return option.hasInlineValue() ? index : index + 1;
         }
         throw new IllegalArgumentException("Unknown option: " + arg);
     }
 
-    private static boolean parseBuildToolOption(String[] args, int index, ParseStateBuilder state, String arg) {
-        if ("--build-tool".equals(arg)) {
-            state.buildToolSelection = parseBuildTool(args, index, state.buildToolSeen);
+    private static boolean parseBuildToolOption(String[] args,
+                                                int index,
+                                                ParseStateBuilder state,
+                                                AssignedOption option) {
+        if ("--build-tool".equals(option.name())) {
+            state.buildToolSelection = parseBuildTool(args, index, option, state.buildToolSeen);
             state.buildToolSeen = true;
             return true;
         }
         return false;
     }
 
-    private static boolean parseReportFormatOption(String[] args, int index, ParseStateBuilder state, String arg) {
-        if ("--format".equals(arg)) {
-            state.reportFormat = parseReportFormat(args, index, state.reportFormatSeen);
+    private static boolean parseReportFormatOption(String[] args,
+                                                   int index,
+                                                   ParseStateBuilder state,
+                                                   AssignedOption option) {
+        if ("--format".equals(option.name())) {
+            state.reportFormat = parseReportFormat(args, index, option, state.reportFormatSeen);
             state.reportFormatSeen = true;
             return true;
         }
         return false;
     }
 
-    private static boolean parseOutputOption(String[] args, int index, ParseStateBuilder state, String arg) {
-        if ("--output".equals(arg)) {
-            state.outputPath = parsePathOption(args, index, state.outputPathSeen, "--output");
+    private static boolean parseOutputOption(String[] args,
+                                             int index,
+                                             ParseStateBuilder state,
+                                             AssignedOption option) {
+        if ("--output".equals(option.name())) {
+            state.outputPath = parsePathOption(args, index, option, state.outputPathSeen, "--output");
             state.outputPathSeen = true;
             return true;
         }
         return false;
     }
 
-    private static boolean parseJunitReportOption(String[] args, int index, ParseStateBuilder state, String arg) {
-        if ("--junit-report".equals(arg)) {
-            state.junitReportPath = parsePathOption(args, index, state.junitReportPathSeen, "--junit-report");
+    private static boolean parseJunitReportOption(String[] args,
+                                                  int index,
+                                                  ParseStateBuilder state,
+                                                  AssignedOption option) {
+        if ("--junit-report".equals(option.name())) {
+            state.junitReportPath = parsePathOption(args, index, option, state.junitReportPathSeen, "--junit-report");
             state.junitReportPathSeen = true;
             return true;
         }
         return false;
     }
 
-    private static boolean parseThresholdOption(String[] args, int index, ParseStateBuilder state, String arg) {
-        if ("--threshold".equals(arg)) {
-            state.threshold = parseThreshold(args, index, state.thresholdSeen);
+    private static boolean parseThresholdOption(String[] args,
+                                                int index,
+                                                ParseStateBuilder state,
+                                                AssignedOption option) {
+        if ("--threshold".equals(option.name())) {
+            state.threshold = parseThreshold(args, index, option, state.thresholdSeen);
             state.thresholdSeen = true;
             return true;
         }
         return false;
     }
 
-    private static boolean parseExclusionOption(String[] args, int index, ParseStateBuilder state, String arg) {
-        if ("--exclude".equals(arg)) {
-            state.excludes.add(parseListOption(args, index, "--exclude", "a glob"));
+    private static boolean parseExclusionOption(String[] args,
+                                                int index,
+                                                ParseStateBuilder state,
+                                                AssignedOption option) {
+        if ("--exclude".equals(option.name())) {
+            state.excludes.add(parseListOption(args, index, option, "--exclude", "a glob"));
             return true;
         }
-        if ("--exclude-class".equals(arg)) {
-            state.excludeClasses.add(parseListOption(args, index, "--exclude-class", "a regex"));
+        if ("--exclude-class".equals(option.name())) {
+            state.excludeClasses.add(parseListOption(args, index, option, "--exclude-class", "a regex"));
             return true;
         }
-        if ("--exclude-annotation".equals(arg)) {
-            state.excludeAnnotations.add(parseListOption(args, index, "--exclude-annotation", "an annotation name"));
+        if ("--exclude-annotation".equals(option.name())) {
+            state.excludeAnnotations.add(parseListOption(
+                    args,
+                    index,
+                    option,
+                    "--exclude-annotation",
+                    "an annotation name"
+            ));
             return true;
         }
         return false;
@@ -243,59 +268,91 @@ final class CliArgumentsParser {
         throw new IllegalArgumentException(option + " requires true or false when assigned");
     }
 
-    private static BuildToolSelection parseBuildTool(String[] args, int index, boolean buildToolSeen) {
+    private static BuildToolSelection parseBuildTool(String[] args,
+                                                     int index,
+                                                     AssignedOption option,
+                                                     boolean buildToolSeen) {
         if (buildToolSeen) {
             throw new IllegalArgumentException("--build-tool can only be provided once");
         }
-        if (index + 1 >= args.length) {
-            throw new IllegalArgumentException("--build-tool requires one of: auto, maven, gradle");
-        }
-        return BuildToolSelection.parse(args[index + 1]);
+        return BuildToolSelection.parse(optionValue(
+                args,
+                index,
+                option,
+                "--build-tool",
+                "one of: auto, maven, gradle"
+        ));
     }
 
-    private static ReportFormat parseReportFormat(String[] args, int index, boolean reportFormatSeen) {
+    private static ReportFormat parseReportFormat(String[] args,
+                                                  int index,
+                                                  AssignedOption option,
+                                                  boolean reportFormatSeen) {
         if (reportFormatSeen) {
             throw new IllegalArgumentException("--format can only be provided once");
         }
-        if (index + 1 >= args.length) {
-            throw new IllegalArgumentException("--format requires one of: toon, json, text, junit, none");
-        }
-        return ReportFormat.parse(args[index + 1]);
+        return ReportFormat.parse(optionValue(args, index, option, "--format", "one of: toon, json, text, junit, none"));
     }
 
-    private static String parsePathOption(String[] args, int index, boolean seen, String option) {
+    private static String parsePathOption(String[] args,
+                                          int index,
+                                          AssignedOption assignedOption,
+                                          boolean seen,
+                                          String option) {
         if (seen) {
             throw new IllegalArgumentException(option + " can only be provided once");
         }
-        if (index + 1 >= args.length) {
-            throw new IllegalArgumentException(option + " requires a path");
-        }
-        return args[index + 1];
+        return optionValue(args, index, assignedOption, option, "a path");
     }
 
-    private static double parseThreshold(String[] args, int index, boolean thresholdSeen) {
+    private static double parseThreshold(String[] args,
+                                         int index,
+                                         AssignedOption option,
+                                         boolean thresholdSeen) {
         if (thresholdSeen) {
             throw new IllegalArgumentException("--threshold can only be provided once");
         }
-        if (index + 1 >= args.length) {
-            throw new IllegalArgumentException("--threshold requires a finite number greater than 0");
-        }
         try {
-            return Thresholds.parse(args[index + 1]);
+            return Thresholds.parse(optionValue(
+                    args,
+                    index,
+                    option,
+                    "--threshold",
+                    "a finite number greater than 0"
+            ));
         } catch (IllegalArgumentException ex) {
             throw new IllegalArgumentException("--threshold requires a finite number greater than 0", ex);
         }
     }
 
-    private static String parseListOption(String[] args, int index, String option, String valueDescription) {
-        if (index + 1 >= args.length) {
-            throw new IllegalArgumentException(option + " requires " + valueDescription);
-        }
-        String value = args[index + 1].trim();
+    private static String parseListOption(String[] args,
+                                          int index,
+                                          AssignedOption assignedOption,
+                                          String option,
+                                          String valueDescription) {
+        String value = optionValue(args, index, assignedOption, option, valueDescription).trim();
         if (value.isEmpty()) {
             throw new IllegalArgumentException(option + " requires " + valueDescription);
         }
         return value;
+    }
+
+    private static String optionValue(String[] args,
+                                      int index,
+                                      AssignedOption option,
+                                      String optionName,
+                                      String valueDescription) {
+        @Nullable String inlineValue = option.inlineValue();
+        if (inlineValue != null) {
+            if (inlineValue.isEmpty()) {
+                throw new IllegalArgumentException(optionName + " requires " + valueDescription);
+            }
+            return inlineValue;
+        }
+        if (index + 1 >= args.length) {
+            throw new IllegalArgumentException(optionName + " requires " + valueDescription);
+        }
+        return args[index + 1];
     }
 
     private static void ensureChangedIsNotCombined(boolean changed, List<String> values) {
@@ -366,6 +423,20 @@ final class CliArgumentsParser {
                     ),
                     values
             );
+        }
+    }
+
+    private record AssignedOption(String name, @Nullable String inlineValue) {
+        private static AssignedOption parse(String arg) {
+            int equalsIndex = arg.indexOf('=');
+            if (equalsIndex < 0) {
+                return new AssignedOption(arg, null);
+            }
+            return new AssignedOption(arg.substring(0, equalsIndex), arg.substring(equalsIndex + 1));
+        }
+
+        private boolean hasInlineValue() {
+            return inlineValue != null;
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -184,7 +184,7 @@ final class CliArgumentsParser {
                                              ParseStateBuilder state,
                                              AssignedOption option) {
         if ("--output".equals(option.name())) {
-            state.outputPath = parsePathOption(args, index, option, state.outputPathSeen, "--output");
+            state.outputPath = parsePathOption(args, index, option, state.outputPathSeen);
             state.outputPathSeen = true;
             return true;
         }
@@ -196,7 +196,7 @@ final class CliArgumentsParser {
                                                   ParseStateBuilder state,
                                                   AssignedOption option) {
         if ("--junit-report".equals(option.name())) {
-            state.junitReportPath = parsePathOption(args, index, option, state.junitReportPathSeen, "--junit-report");
+            state.junitReportPath = parsePathOption(args, index, option, state.junitReportPathSeen);
             state.junitReportPathSeen = true;
             return true;
         }
@@ -220,11 +220,11 @@ final class CliArgumentsParser {
                                                 ParseStateBuilder state,
                                                 AssignedOption option) {
         if ("--exclude".equals(option.name())) {
-            state.excludes.add(parseListOption(args, index, option, "--exclude", "a glob"));
+            state.excludes.add(parseListOption(args, index, option, "a glob"));
             return true;
         }
         if ("--exclude-class".equals(option.name())) {
-            state.excludeClasses.add(parseListOption(args, index, option, "--exclude-class", "a regex"));
+            state.excludeClasses.add(parseListOption(args, index, option, "a regex"));
             return true;
         }
         if ("--exclude-annotation".equals(option.name())) {
@@ -232,7 +232,6 @@ final class CliArgumentsParser {
                     args,
                     index,
                     option,
-                    "--exclude-annotation",
                     "an annotation name"
             ));
             return true;
@@ -279,7 +278,6 @@ final class CliArgumentsParser {
                 args,
                 index,
                 option,
-                "--build-tool",
                 "one of: auto, maven, gradle"
         ));
     }
@@ -291,18 +289,17 @@ final class CliArgumentsParser {
         if (reportFormatSeen) {
             throw new IllegalArgumentException("--format can only be provided once");
         }
-        return ReportFormat.parse(optionValue(args, index, option, "--format", "one of: toon, json, text, junit, none"));
+        return ReportFormat.parse(optionValue(args, index, option, "one of: toon, json, text, junit, none"));
     }
 
     private static String parsePathOption(String[] args,
                                           int index,
                                           AssignedOption assignedOption,
-                                          boolean seen,
-                                          String option) {
+                                          boolean seen) {
         if (seen) {
-            throw new IllegalArgumentException(option + " can only be provided once");
+            throw new IllegalArgumentException(assignedOption.name() + " can only be provided once");
         }
-        return optionValue(args, index, assignedOption, option, "a path");
+        return optionValue(args, index, assignedOption, "a path");
     }
 
     private static double parseThreshold(String[] args,
@@ -317,7 +314,6 @@ final class CliArgumentsParser {
                     args,
                     index,
                     option,
-                    "--threshold",
                     "a finite number greater than 0"
             ));
         } catch (IllegalArgumentException ex) {
@@ -328,11 +324,10 @@ final class CliArgumentsParser {
     private static String parseListOption(String[] args,
                                           int index,
                                           AssignedOption assignedOption,
-                                          String option,
                                           String valueDescription) {
-        String value = optionValue(args, index, assignedOption, option, valueDescription).trim();
+        String value = optionValue(args, index, assignedOption, valueDescription).trim();
         if (value.isEmpty()) {
-            throw new IllegalArgumentException(option + " requires " + valueDescription);
+            throw new IllegalArgumentException(assignedOption.name() + " requires " + valueDescription);
         }
         return value;
     }
@@ -340,17 +335,16 @@ final class CliArgumentsParser {
     private static String optionValue(String[] args,
                                       int index,
                                       AssignedOption option,
-                                      String optionName,
                                       String valueDescription) {
         @Nullable String inlineValue = option.inlineValue();
         if (inlineValue != null) {
             if (inlineValue.isEmpty()) {
-                throw new IllegalArgumentException(optionName + " requires " + valueDescription);
+                throw new IllegalArgumentException(option.name() + " requires " + valueDescription);
             }
             return inlineValue;
         }
         if (index + 1 >= args.length) {
-            throw new IllegalArgumentException(optionName + " requires " + valueDescription);
+            throw new IllegalArgumentException(option.name() + " requires " + valueDescription);
         }
         return args[index + 1];
     }

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -209,7 +209,7 @@ public final class Main {
                   Relative --output and --junit-report paths resolve against the project root
                   Absolute paths and normalized paths outside the project root are honored
 
-                Value options may also be written as --option=value.
+                Long options that take a value may also be written as --option=value.
                 """;
     }
 

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -206,6 +206,8 @@ public final class Main {
                 Report paths:
                   Relative --output and --junit-report paths resolve against the project root
                   Absolute paths and normalized paths outside the project root are honored
+
+                Value options may also be written as --option=value.
                 """;
     }
 

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -264,6 +264,8 @@ class CliArgumentsParserTest {
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--format"}));
         assertEquals("--format requires one of: toon, json, text, junit, none", error.getMessage());
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--format="}));
     }
 
     @Test
@@ -284,6 +286,8 @@ class CliArgumentsParserTest {
     void thresholdRequiresValue() {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--threshold"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--threshold="}));
     }
 
     @Test
@@ -310,6 +314,8 @@ class CliArgumentsParserTest {
     void outputRequiresValue() {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--output"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--output="}));
     }
 
     @Test
@@ -322,6 +328,8 @@ class CliArgumentsParserTest {
     void junitReportRequiresValue() {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--junit-report"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--junit-report="}));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -73,16 +73,12 @@ class CliArgumentsParserTest {
     }
 
     @Test
-    void valueOptionsAcceptInlineAssignments() {
+    void buildAndReportOptionsAcceptInlineAssignments() {
         CliArguments args = CliArgumentsParser.parse(new String[]{
                 "--build-tool=maven",
                 "--format=json",
                 "--output=target/crap-java/report.json",
                 "--junit-report=target/crap-java/TEST-crap-java.xml",
-                "--threshold=6.0",
-                "--exclude=module-a/**",
-                "--exclude-class=.*MapperImpl$",
-                "--exclude-annotation=Generated",
                 "--changed"
         });
 
@@ -91,7 +87,25 @@ class CliArgumentsParserTest {
         assertEquals(ReportFormat.JSON, args.reportFormat());
         assertEquals("target/crap-java/report.json", args.outputPath());
         assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
+    }
+
+    @Test
+    void thresholdAcceptsInlineAssignment() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{"--threshold=6.0", "--changed"});
+
+        assertEquals(CliMode.CHANGED_SRC, args.mode());
         assertEquals(6.0, args.threshold(), 1.0e-9);
+    }
+
+    @Test
+    void sourceExclusionOptionsAcceptInlineAssignments() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{
+                "--exclude=module-a/**",
+                "--exclude-class=.*MapperImpl$",
+                "--exclude-annotation=Generated",
+                "--changed"
+        });
+
         assertEquals(List.of("module-a/**"), args.exclusionOptions().excludes());
         assertEquals(List.of(".*MapperImpl$"), args.exclusionOptions().excludeClasses());
         assertEquals(List.of("Generated"), args.exclusionOptions().excludeAnnotations());
@@ -261,11 +275,8 @@ class CliArgumentsParserTest {
 
     @Test
     void reportFormatRequiresValue() {
-        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--format"}));
-        assertEquals("--format requires one of: toon, json, text, junit, none", error.getMessage());
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--format="}));
+        assertParseError("--format requires one of: toon, json, text, junit, none", "--format");
+        assertParseError("--format requires one of: toon, json, text, junit, none", "--format=");
     }
 
     @Test
@@ -284,10 +295,8 @@ class CliArgumentsParserTest {
 
     @Test
     void thresholdRequiresValue() {
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--threshold"}));
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--threshold="}));
+        assertParseError("--threshold requires a finite number greater than 0", "--threshold");
+        assertParseError("--threshold requires a finite number greater than 0", "--threshold=");
     }
 
     @Test
@@ -312,10 +321,8 @@ class CliArgumentsParserTest {
 
     @Test
     void outputRequiresValue() {
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--output"}));
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--output="}));
+        assertParseError("--output requires a path", "--output");
+        assertParseError("--output requires a path", "--output=");
     }
 
     @Test
@@ -326,10 +333,8 @@ class CliArgumentsParserTest {
 
     @Test
     void junitReportRequiresValue() {
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--junit-report"}));
-        assertThrows(IllegalArgumentException.class,
-                () -> CliArgumentsParser.parse(new String[]{"--junit-report="}));
+        assertParseError("--junit-report requires a path", "--junit-report");
+        assertParseError("--junit-report requires a path", "--junit-report=");
     }
 
     @Test
@@ -394,6 +399,14 @@ class CliArgumentsParserTest {
 
         assertEquals(CliMode.EXPLICIT_FILES, args.mode());
         assertEquals(List.of("src/main/java/demo/A.java"), args.fileArgs());
+    }
+
+    private static void assertParseError(String expectedMessage, String... args) {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(args)
+        );
+        assertEquals(expectedMessage, error.getMessage());
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -91,7 +91,7 @@ class CliArgumentsParserTest {
         assertEquals(ReportFormat.JSON, args.reportFormat());
         assertEquals("target/crap-java/report.json", args.outputPath());
         assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
-        assertEquals(6.0, args.threshold());
+        assertEquals(6.0, args.threshold(), 1.0e-9);
         assertEquals(List.of("module-a/**"), args.exclusionOptions().excludes());
         assertEquals(List.of(".*MapperImpl$"), args.exclusionOptions().excludeClasses());
         assertEquals(List.of("Generated"), args.exclusionOptions().excludeAnnotations());

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -73,6 +73,31 @@ class CliArgumentsParserTest {
     }
 
     @Test
+    void valueOptionsAcceptInlineAssignments() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{
+                "--build-tool=maven",
+                "--format=json",
+                "--output=target/crap-java/report.json",
+                "--junit-report=target/crap-java/TEST-crap-java.xml",
+                "--threshold=6.0",
+                "--exclude=module-a/**",
+                "--exclude-class=.*MapperImpl$",
+                "--exclude-annotation=Generated",
+                "--changed"
+        });
+
+        assertEquals(CliMode.CHANGED_SRC, args.mode());
+        assertEquals(BuildToolSelection.MAVEN, args.buildToolSelection());
+        assertEquals(ReportFormat.JSON, args.reportFormat());
+        assertEquals("target/crap-java/report.json", args.outputPath());
+        assertEquals("target/crap-java/TEST-crap-java.xml", args.junitReportPath());
+        assertEquals(6.0, args.threshold());
+        assertEquals(List.of("module-a/**"), args.exclusionOptions().excludes());
+        assertEquals(List.of(".*MapperImpl$"), args.exclusionOptions().excludeClasses());
+        assertEquals(List.of("Generated"), args.exclusionOptions().excludeAnnotations());
+    }
+
+    @Test
     void sourceExclusionOptionsAreParsed() {
         CliArguments args = CliArgumentsParser.parse(new String[]{
                 "--exclude", "module-a/**",
@@ -315,6 +340,12 @@ class CliArgumentsParserTest {
                 () -> CliArgumentsParser.parse(new String[]{"--exclude-annotation"}));
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--use-default-exclusions=maybe"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--exclude="}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--exclude-class="}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--exclude-annotation="}));
     }
 
     @Test
@@ -327,6 +358,8 @@ class CliArgumentsParserTest {
     void buildToolRequiresValue() {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--build-tool"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--build-tool="}));
     }
 
     @Test


### PR DESCRIPTION
Closes #124.

## Summary
- support `--option=value` syntax for value-taking CLI options while keeping the existing separated value form
- cover build tool, report format, output paths, threshold, and source exclusion options
- document the inline assignment form in usage and README examples

## Verification
- mvn -pl core test
- mvn verify