### PR TITLE
Remove fragile package regex from analysis

### DIFF
--- a/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
+++ b/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
@@ -10,13 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
 
 final class CrapAnalyzer {
-
-    private static final Pattern PACKAGE_PATTERN = Pattern.compile("(?m)^\\s*package\\s+([a-zA-Z_][\\w.]*)\\s*;");
 
     private CrapAnalyzer() {
     }
@@ -70,8 +66,8 @@ final class CrapAnalyzer {
         }
         Path normalizedFile = file.toAbsolutePath().normalize();
         String source = Files.readString(file);
-        String primaryClassName = classNameFromSource(file, source);
-        for (MethodDescriptor method : JavaMethodParser.parse(primaryClassName, source)) {
+        String sourceName = file.getFileName().toString();
+        for (MethodDescriptor method : JavaMethodParser.parse(sourceName, source)) {
             addMetricIfIncluded(method, projectRoot, normalizedFile, coverageMap, exclusions, audit, excludedClasses, metrics);
         }
     }
@@ -125,15 +121,6 @@ final class CrapAnalyzer {
     private static String sourcePath(Path projectRoot, Path file) {
         Path path = file.startsWith(projectRoot) ? projectRoot.relativize(file) : file;
         return path.normalize().toString().replace('\\', '/');
-    }
-
-    static String classNameFromSource(Path file, String source) {
-        String simpleName = file.getFileName().toString().replaceFirst("\\.java$", "");
-        Matcher matcher = PACKAGE_PATTERN.matcher(source);
-        if (!matcher.find()) {
-            return simpleName;
-        }
-        return matcher.group(1) + "." + simpleName;
     }
 
     static @Nullable EffectiveCoverage lookupCoverage(Map<String, CoverageData> coverageMap,

--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -33,7 +33,7 @@ final class JavaMethodParser {
     private JavaMethodParser() {
     }
 
-    static List<MethodDescriptor> parse(String className, String source) {
+    static List<MethodDescriptor> parse(String sourceName, String source) {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         if (compiler == null) {
             throw new IllegalStateException("No system Java compiler is available");
@@ -46,7 +46,7 @@ final class JavaMethodParser {
                     null,
                     List.of("-proc:none"),
                     null,
-                    List.of(new SourceFileObject(className, source))
+                    List.of(new SourceFileObject(sourceName, source))
             );
             Iterable<? extends CompilationUnitTree> units = task.parse();
             return collectMethods(task, units);
@@ -55,15 +55,15 @@ final class JavaMethodParser {
         }
     }
 
-    static String sourcePath(String className) {
-        String normalized = className.endsWith(".java")
-                ? className.substring(0, className.length() - ".java".length())
-                : className;
+    static String sourcePath(String sourceName) {
+        String normalized = sourceName.endsWith(".java")
+                ? sourceName.substring(0, sourceName.length() - ".java".length())
+                : sourceName;
         return normalized.replace('.', '/') + ".java";
     }
 
-    static URI sourceUri(String className) {
-        return URI.create("string:///" + sourcePath(className));
+    static URI sourceUri(String sourceName) {
+        return URI.create("string:///" + sourcePath(sourceName));
     }
 
     private static List<MethodDescriptor> collectMethods(JavacTask task,
@@ -232,8 +232,8 @@ final class JavaMethodParser {
     private static final class SourceFileObject extends SimpleJavaFileObject {
         private final String source;
 
-        private SourceFileObject(String className, String source) {
-            super(uriFor(className), Kind.SOURCE);
+        private SourceFileObject(String sourceName, String source) {
+            super(uriFor(sourceName), Kind.SOURCE);
             this.source = source;
         }
 
@@ -242,8 +242,8 @@ final class JavaMethodParser {
             return source;
         }
 
-        private static URI uriFor(String className) {
-            return sourceUri(className);
+        private static URI uriFor(String sourceName) {
+            return sourceUri(sourceName);
         }
     }
 }

--- a/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
+++ b/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
@@ -234,19 +234,6 @@ class CrapAnalyzerTest {
     }
 
     @Test
-    void usesSimpleClassNameWhenSourceHasNoPackage() {
-        String className = CrapAnalyzer.classNameFromSource(
-                Path.of("src/main/java/Sample.java"),
-                """
-                class Sample {
-                }
-                """
-        );
-
-        assertEquals("Sample", className);
-    }
-
-    @Test
     void attributesCoverageToNestedAndSecondaryTypes() throws IOException {
         Path sourceRoot = tempDir.resolve("src/main/java/demo");
         Files.createDirectories(sourceRoot);
@@ -308,6 +295,44 @@ class CrapAnalyzerTest {
         assertEquals("demo.Secondary", Objects.requireNonNull(metricsByMethod.get("beta")).className());
         assertEquals(100.0, Objects.requireNonNull(Objects.requireNonNull(metricsByMethod.get("beta")).coveragePercent()), 0.001);
         assertEquals("instruction", Objects.requireNonNull(metricsByMethod.get("beta")).coverageKind());
+    }
+
+    @Test
+    void ignoresPackageDeclarationsInsideBlockCommentsWhenAttributingCoverage() throws IOException {
+        Path sourceRoot = tempDir.resolve("src/main/java/real/example");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                /*
+                 * Example package declaration:
+                package fake.example;
+                 */
+                package real.example;
+
+                class Sample {
+                    int alpha() {
+                        return 1;
+                    }
+                }
+                """);
+
+        Path jacoco = tempDir.resolve("jacoco.xml");
+        Files.writeString(jacoco, """
+                <report>
+                  <package name="real/example">
+                    <class name="real/example/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()I" line="8">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        MethodMetrics metric = CrapAnalyzer.analyze(tempDir, List.of(source), jacoco).get(0);
+
+        assertEquals("real.example.Sample", metric.className());
+        assertEquals(100.0, Objects.requireNonNull(metric.coveragePercent()), 0.001);
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
+++ b/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
@@ -336,6 +336,38 @@ class CrapAnalyzerTest {
     }
 
     @Test
+    void attributesCoverageToDefaultPackageSources() throws IOException {
+        Path sourceRoot = tempDir.resolve("src/main/java");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                class Sample {
+                    int alpha() {
+                        return 1;
+                    }
+                }
+                """);
+
+        Path jacoco = tempDir.resolve("jacoco.xml");
+        Files.writeString(jacoco, """
+                <report>
+                  <package name="">
+                    <class name="Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()I" line="2">
+                        <counter type="INSTRUCTION" missed="0" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        MethodMetrics metric = CrapAnalyzer.analyze(tempDir, List.of(source), jacoco).get(0);
+
+        assertEquals("Sample", metric.className());
+        assertEquals(100.0, Objects.requireNonNull(metric.coveragePercent()), 0.001);
+    }
+
+    @Test
     void lookupCoveragePrefersExactLineBeforeNearestMatch() {
         Map<String, CoverageData> coverageMap = Map.of(
                 "demo.Sample#alpha:10", new CoverageData(1, 3),


### PR DESCRIPTION
Closes #119.

## Summary
- remove the regex package scan from `CrapAnalyzer`; method class names already come from javac's parsed AST in `JavaMethodParser`
- pass only the source filename to the parser's in-memory source object, avoiding package text in comments influencing that URI
- add a coverage attribution regression test with a fake package declaration inside a block comment

## Verification
- mvn -pl core test
- mvn verify