### PR TITLE
Document source symlink discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ For each resolved module today:
    - Gradle: `build/reports/jacoco/test/jacocoTestReport.xml`
 5. Analyze the selected Java files for that module
 
+Source discovery walks `src/main/java` roots without following directory
+symlinks. Symlinked Java files inside a source root can still be selected and
+are reported using the symlink path rather than a canonicalized target path.
+
 ## Build and Test
 
 ```bash

--- a/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
+++ b/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
@@ -23,6 +23,8 @@ final class SourceFileFinder {
         List<Path> javaFiles = new ArrayList<>();
         for (Path sourceRoot : productionSourceRoots(projectRoot)) {
             try (var stream = Files.walk(sourceRoot)) {
+                // Directory symlinks are not followed because FOLLOW_LINKS is not passed.
+                // Symlinked files are kept as link paths when Files.isRegularFile follows them.
                 stream.filter(Files::isRegularFile)
                         .filter(path -> path.toString().endsWith(".java"))
                         .forEach(javaFiles::add);


### PR DESCRIPTION
Closes #115.

## Summary
- classify the report as valid documentation feedback: `Files.walk` is safe from directory symlink cycles by default, but symlinked regular files are discovered as link paths
- document that behavior in source discovery and in the README coverage pipeline

## Verification
- mvn verify