### PR TITLE
Clarify threshold leniency boundary

### DIFF
--- a/core/src/main/java/media/barney/crap/core/Thresholds.java
+++ b/core/src/main/java/media/barney/crap/core/Thresholds.java
@@ -1,10 +1,12 @@
 package media.barney.crap.core;
 
+import java.util.Locale;
+
 final class Thresholds {
 
     static final double DEFAULT = 8.0;
-    // The recommended default is also the highest threshold before leniency warnings start.
-    private static final double TOO_LENIENT_BOUNDARY = DEFAULT;
+    // Keep the warning boundary independent from the recommended default.
+    private static final double TOO_LENIENT_BOUNDARY = 8.0;
 
     private Thresholds() {
     }
@@ -38,10 +40,14 @@ final class Thresholds {
                     + recommendation();
         }
         if (isTooLenient(value)) {
-            return "Warning: CRAP threshold above " + TOO_LENIENT_BOUNDARY + " is too lenient even for hard gates. "
-                    + recommendation();
+            return "Warning: CRAP threshold above " + formatBoundary(TOO_LENIENT_BOUNDARY)
+                    + " is too lenient even for hard gates. " + recommendation();
         }
         return "";
+    }
+
+    private static String formatBoundary(double value) {
+        return String.format(Locale.ROOT, "%.1f", value);
     }
 
     private static String recommendation() {

--- a/core/src/main/java/media/barney/crap/core/Thresholds.java
+++ b/core/src/main/java/media/barney/crap/core/Thresholds.java
@@ -3,6 +3,8 @@ package media.barney.crap.core;
 final class Thresholds {
 
     static final double DEFAULT = 8.0;
+    // The recommended default is also the highest threshold before leniency warnings start.
+    private static final double TOO_LENIENT_BOUNDARY = DEFAULT;
 
     private Thresholds() {
     }
@@ -27,7 +29,7 @@ final class Thresholds {
     }
 
     static boolean isTooLenient(double value) {
-        return Double.compare(value, DEFAULT) > 0;
+        return Double.compare(value, TOO_LENIENT_BOUNDARY) > 0;
     }
 
     static String warning(double value) {
@@ -36,7 +38,7 @@ final class Thresholds {
                     + recommendation();
         }
         if (isTooLenient(value)) {
-            return "Warning: CRAP threshold above 8.0 is too lenient even for hard gates. "
+            return "Warning: CRAP threshold above " + TOO_LENIENT_BOUNDARY + " is too lenient even for hard gates. "
                     + recommendation();
         }
         return "";

--- a/core/src/main/java/media/barney/crap/core/Thresholds.java
+++ b/core/src/main/java/media/barney/crap/core/Thresholds.java
@@ -1,6 +1,6 @@
 package media.barney.crap.core;
 
-import java.util.Locale;
+import java.math.BigDecimal;
 
 final class Thresholds {
 
@@ -47,7 +47,11 @@ final class Thresholds {
     }
 
     private static String formatBoundary(double value) {
-        return String.format(Locale.ROOT, "%.1f", value);
+        BigDecimal boundary = BigDecimal.valueOf(value).stripTrailingZeros();
+        if (boundary.scale() <= 0) {
+            return boundary.toPlainString() + ".0";
+        }
+        return boundary.toPlainString();
     }
 
     private static String recommendation() {


### PR DESCRIPTION
## Summary
- Split the threshold warning boundary from the recommended default constant.
- Preserve the current 8.0 threshold behavior and warning wording.

## Verification
- `mvn verify`

Closes #123