### PR TITLE
Remove duplicate CLI metric sort

### DIFF
--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -74,8 +74,6 @@ final class CliApplication {
                     exclusions,
                     audit
             );
-            metrics.sort(Comparator.comparing(MethodMetrics::crapScore,
-                    Comparator.nullsLast(Comparator.reverseOrder())));
             CrapReport report = CrapReport.from(metrics, parsed.threshold(), audit.build())
                     .withElapsedNanos(nanoTime.getAsLong() - startedAt);
             ReportPublisher.publish(report, reportOptions(parsed), out);


### PR DESCRIPTION
## Summary
- Remove the redundant CLI-level metric sort after module analysis.
- Keep analyzer canonical ordering and report formatter output ordering unchanged.

## Verification
- `mvn verify`

Closes #126