### PR TITLE
Document Maven CLI JaCoCo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ For each resolved module today:
    - Gradle: `build/reports/jacoco/test/jacocoTestReport.xml`
 5. Analyze the selected Java files for that module
 
+For Maven CLI coverage generation, crap-java invokes
+`org.jacoco:jacoco-maven-plugin:0.8.13` explicitly. It does not inspect or
+reuse a `jacoco-maven-plugin` version pinned in the analyzed project's POM. If
+your build requires a different JaCoCo version, generate the XML report in your
+own Maven build and run the Maven plugin path below, which consumes that report
+without starting another coverage run.
+
 ## Build and Test
 
 ```bash
@@ -320,7 +327,9 @@ Add the plugin:
 </build>
 ```
 
-The Maven plugin consumes the JaCoCo XML files produced by your build. It does not spawn a nested Maven run to generate coverage.
+The Maven plugin consumes the JaCoCo XML files produced by your build. It does
+not spawn a nested Maven run to generate coverage, so your project's configured
+JaCoCo version remains in control.
 
 No custom `<pluginRepositories>` or consumer-side authentication are required for published releases.
 


### PR DESCRIPTION
## Summary
- Document that CLI Maven coverage generation invokes JaCoCo 0.8.13 explicitly.
- Clarify that the Maven plugin path consumes project-generated JaCoCo XML and keeps the project-owned JaCoCo version in control.

## Verification
- `mvn verify`

Closes #114