### PR TITLE
Bound process output pipe joins

### DIFF
--- a/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
+++ b/core/src/main/java/media/barney/crap/core/ProcessCommandExecutor.java
@@ -11,10 +11,12 @@ import java.util.List;
 final class ProcessCommandExecutor implements CommandExecutor {
 
     private static final int CAPTURE_LIMIT_BYTES = 64 * 1024;
+    private static final Duration DEFAULT_OUTPUT_PIPE_JOIN_GRACE = Duration.ofSeconds(5);
 
     private final Duration timeout;
     private final PrintStream processOutput;
     private final Charset outputCharset;
+    private final Duration outputPipeJoinGrace;
 
     ProcessCommandExecutor() {
         this(Duration.ofMinutes(10), System.err);
@@ -29,9 +31,19 @@ final class ProcessCommandExecutor implements CommandExecutor {
     }
 
     ProcessCommandExecutor(Duration timeout, PrintStream processOutput, Charset outputCharset) {
+        this(timeout, processOutput, outputCharset, DEFAULT_OUTPUT_PIPE_JOIN_GRACE);
+    }
+
+    ProcessCommandExecutor(
+            Duration timeout,
+            PrintStream processOutput,
+            Charset outputCharset,
+            Duration outputPipeJoinGrace
+    ) {
         this.timeout = timeout;
         this.processOutput = processOutput;
         this.outputCharset = outputCharset;
+        this.outputPipeJoinGrace = outputPipeJoinGrace;
     }
 
     @Override
@@ -42,6 +54,7 @@ final class ProcessCommandExecutor implements CommandExecutor {
     @Override
     public CommandResult runWithResult(List<String> command, Path directory) throws Exception {
         ProcessTimeout.validate(timeout);
+        validateOutputPipeJoinGrace();
         Process process = new ProcessBuilder(command)
                 .directory(directory.toFile())
                 .start();
@@ -49,8 +62,8 @@ final class ProcessCommandExecutor implements CommandExecutor {
         OutputPipe stdout = pipe(process.getInputStream(), "stdout");
         OutputPipe stderr = pipe(process.getErrorStream(), "stderr");
         int exit = ProcessTimeout.waitForOrTerminate(process, command, timeout, "Command");
-        stdout.join();
-        stderr.join();
+        stdout.join(outputPipeJoinGrace);
+        stderr.join(outputPipeJoinGrace);
         return new CommandResult(exit, stdout.output(), stderr.output());
     }
 
@@ -78,9 +91,23 @@ final class ProcessCommandExecutor implements CommandExecutor {
         }
     }
 
+    private void validateOutputPipeJoinGrace() {
+        if (outputPipeJoinGrace.isZero() || outputPipeJoinGrace.isNegative()) {
+            throw new IllegalArgumentException("Process output pipe join grace must be positive");
+        }
+    }
+
     private record OutputPipe(Thread thread, BoundedOutputCapture capture, Charset outputCharset) {
-        private void join() throws InterruptedException {
-            thread.join();
+        private void join(Duration grace) throws InterruptedException {
+            thread.join(joinMillis(grace));
+            if (thread.isAlive()) {
+                thread.interrupt();
+            }
+        }
+
+        private static long joinMillis(Duration grace) {
+            long millis = grace.toMillis();
+            return millis > 0 ? millis : 1L;
         }
 
         private String output() {

--- a/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ProcessCommandExecutorTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -11,9 +12,12 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,6 +62,29 @@ class ProcessCommandExecutorTest {
         assertTrue(result.stdout().contains(" bytes"));
         assertFalse(result.stdout().contains("first-line"));
         assertTrue(result.stdout().contains("last-line"));
+    }
+
+    @Test
+    void returnsWhenOutputPipeDoesNotFinish() throws Exception {
+        CountDownLatch writeStarted = new CountDownLatch(1);
+        CountDownLatch releaseWrite = new CountDownLatch(1);
+        BlockingOutputStream blockingOutput = new BlockingOutputStream(writeStarted, releaseWrite);
+        ProcessCommandExecutor executor = new ProcessCommandExecutor(
+                Duration.ofSeconds(5),
+                new PrintStream(blockingOutput, true, StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8,
+                Duration.ofMillis(50)
+        );
+
+        try {
+            CommandResult result = assertTimeoutPreemptively(Duration.ofSeconds(2),
+                    () -> executor.runWithResult(outputCommand(), tempDir));
+
+            assertEquals(3, result.exitCode());
+            assertTrue(writeStarted.await(0, TimeUnit.MILLISECONDS));
+        } finally {
+            releaseWrite.countDown();
+        }
     }
 
     @Test
@@ -117,6 +144,46 @@ class ProcessCommandExecutorTest {
             }
             System.out.println();
             System.out.println("last-line");
+        }
+    }
+
+    private static final class BlockingOutputStream extends OutputStream {
+        private final CountDownLatch writeStarted;
+        private final CountDownLatch releaseWrite;
+
+        BlockingOutputStream(CountDownLatch writeStarted, CountDownLatch releaseWrite) {
+            this.writeStarted = writeStarted;
+            this.releaseWrite = releaseWrite;
+        }
+
+        @Override
+        public void write(int value) {
+            blockUntilReleased();
+        }
+
+        @Override
+        public void write(byte[] buffer, int offset, int length) {
+            blockUntilReleased();
+        }
+
+        private void blockUntilReleased() {
+            writeStarted.countDown();
+            boolean interrupted = false;
+            try {
+                while (true) {
+                    try {
+                        if (releaseWrite.await(10, TimeUnit.MILLISECONDS)) {
+                            break;
+                        }
+                    } catch (InterruptedException ex) {
+                        interrupted = true;
+                    }
+                }
+            } finally {
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #113.

## Summary
- Bound stdout/stderr output-pipe joins with a small grace period instead of waiting forever.
- Interrupt still-alive pipe threads after the grace period so daemon readers do not block command completion.
- Added a regression test with a deliberately wedged output sink.

## Verification
- mvn -pl core test -Dtest=ProcessCommandExecutorTest
- mvn verify