### PR TITLE
Document switch case complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ The toolkit resolves Maven and Gradle modules natively, including standard multi
   `INSTRUCTION` and `BRANCH` counters. JaCoCo omits `BRANCH` counters for
   branchless methods, so those methods use instruction coverage.
 
+## Cyclomatic Complexity Model
+
+Java method complexity starts at `1` and increments for each AST decision node:
+loops, `if`, conditional expressions, `catch`, short-circuit boolean operators,
+and switch case clauses. Switch handling follows the javac AST: each
+`case`/`default` clause contributes `1`, regardless of how many constants appear
+in that clause. For example, `case A, B, C ->` contributes `1`, not `3`, and
+`default` also contributes `1`.
+
 ## Coverage Pipeline
 
 For each resolved module today:

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -203,6 +203,25 @@ class JavaMethodParserTest {
     }
 
     @Test
+    void countsOneDecisionPerSwitchCaseClauseIncludingDefault() {
+        String source = """
+                class Sample {
+                    int classify(int value) {
+                        return switch (value) {
+                            case 1, 2, 3 -> 1;
+                            case 4 -> 2;
+                            default -> 0;
+                        };
+                    }
+                }
+                """;
+
+        List<MethodDescriptor> methods = JavaMethodParser.parse("Sample", source);
+
+        assertEquals(List.of(new MethodDescriptor("Sample", "classify", 2, 8, 4)), methods);
+    }
+
+    @Test
     void includesOwningClassNameForNestedAndSecondaryTypes() {
         String source = """
                 package demo;


### PR DESCRIPTION
Closes #106.

## Summary
- Document the Java switch complexity rule: one increment per javac `CaseTree`, including `default`, regardless of multi-label constants.
- Add a parser test covering arrow switch syntax, multi-label case clauses, and default handling.

## Verification
- mvn -pl core test -Dtest=JavaMethodParserTest
- mvn verify