### PR TITLE
Include constructors in Java method parsing

### DIFF
--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -112,7 +112,7 @@ final class JavaMethodParser {
 
         @Override
         public Void visitMethod(MethodTree node, Void unused) {
-            if (node.getBody() == null || node.getReturnType() == null) {
+            if (node.getBody() == null) {
                 return null;
             }
 

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -40,10 +40,12 @@ class JavaMethodParserTest {
     }
 
     @Test
-    void ignoresConstructorsAndAbstractMethods() {
+    void extractsConstructorsAndIgnoresAbstractMethods() {
         String source = """
                 abstract class Sample {
-                    Sample() {
+                    Sample(boolean flag) {
+                        if (flag) {
+                        }
                     }
 
                     abstract int missing();
@@ -56,7 +58,10 @@ class JavaMethodParserTest {
 
         List<MethodDescriptor> methods = JavaMethodParser.parse("Sample", source);
 
-        assertEquals(List.of(new MethodDescriptor("Sample", "present", 7, 9, 1)), methods);
+        assertEquals(List.of(
+                new MethodDescriptor("Sample", "<init>", 2, 5, 2),
+                new MethodDescriptor("Sample", "present", 9, 11, 1)
+        ), methods);
     }
 
     @Test


### PR DESCRIPTION
Closes #102.

## Summary
- Stop filtering out methods whose return type is `null`, because javac uses that shape for constructors.
- Keep abstract/native methods skipped via the existing `getBody() == null` guard.
- Add a constructor fixture that verifies constructors are emitted as `<init>` with their own complexity.

## Evidence
- JDK `MethodTree#getReturnType()` returns `null` for constructors.
- JaCoCo counts constructors as methods and names them `<init>` in XML.

## Verification
- mvn -pl core test -Dtest=JavaMethodParserTest
- mvn verify