### PR TITLE
Support custom Java source roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ your build requires a different JaCoCo version, generate the XML report in your
 own Maven build and run the Maven plugin path below, which consumes that report
 without starting another coverage run.
 
-Source discovery walks `src/main/java` roots without following directory
-symlinks. Symlinked Java files inside a source root can still be selected and
-are reported using the symlink path rather than a canonicalized target path.
+Source discovery walks `src/main/java` roots by default without following
+directory symlinks. The CLI can override those roots with repeatable
+`--source-root <path>` options, the Maven plugin uses configured compile source
+roots when they differ from Maven defaults, and the Gradle plugin reads the
+Java plugin's configured `main` source set. Symlinked Java files inside a source
+root can still be selected and are reported using the symlink path rather than a
+canonicalized target path.
 
 ## Build and Test
 
@@ -124,8 +128,8 @@ java -jar cli/target/crap-java-cli-0.5.0.jar
 
 ```text
 --help                Print usage to stdout
-(no args)             Analyze all Java files under any nested src/main/java tree
---changed             Analyze changed Java files under any nested src/main/java tree
+(no args)             Analyze all Java files under any nested source root
+--changed             Analyze changed Java files under any nested source root
 --build-tool <tool>   Force `auto`, `maven`, or `gradle`
 --format <format>     Write `toon`, `json`, `text`, `junit`, or `none` output (`toon` by default)
 --agent               Apply AI-agent defaults: `toon`, failures only, omit redundancy
@@ -135,11 +139,12 @@ java -jar cli/target/crap-java-cli-0.5.0.jar
 --exclude-class <regex>  Exclude fully-qualified class names by regex; repeatable
 --exclude-annotation <name>  Exclude classes by annotation name; repeatable
 --use-default-exclusions[=true|false]  Enable built-in generated-code exclusions (`true` by default)
+--source-root <path>  Override production source roots; repeatable
 --output <path>       Write the selected output format to a file instead of stdout
 --junit-report <path> Also write a JUnit XML report for CI test-report UIs
 --threshold <number>  Override the CRAP threshold (`8.0` by default)
 <file ...>            Analyze only these files
-<directory ...>       Analyze all Java files under each directory's nested src/main/java trees
+<directory ...>       Analyze all Java files under each directory's nested source roots
 ```
 
 Value-taking long options may also be written with inline assignment, such as
@@ -165,6 +170,7 @@ java -jar cli/target/crap-java-cli-0.5.0.jar --threshold 6
 java -jar cli/target/crap-java-cli-0.5.0.jar --threshold=6
 java -jar cli/target/crap-java-cli-0.5.0.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
 java -jar cli/target/crap-java-cli-0.5.0.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
+java -jar cli/target/crap-java-cli-0.5.0.jar --source-root src/java --source-root src/main/java17
 java -jar cli/target/crap-java-cli-0.5.0.jar --build-tool maven module-a/src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.5.0.jar src/main/java/demo/Sample.java
 java -jar cli/target/crap-java-cli-0.5.0.jar module-a module-b

--- a/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
@@ -84,8 +84,13 @@ final class ChangedFileDetector {
     }
 
     static List<Path> changedJavaFilesUnderSourceRoots(Path projectRoot) throws IOException, InterruptedException {
+        return changedJavaFilesUnderSourceRoots(projectRoot, List.of());
+    }
+
+    static List<Path> changedJavaFilesUnderSourceRoots(Path projectRoot, List<Path> sourceRoots)
+            throws IOException, InterruptedException {
         return changedJavaFiles(projectRoot).stream()
-                .filter(ProductionSourceRoots::isUnderProductionSourceRoot)
+                .filter(path -> ProductionSourceRoots.isUnderSourceRoot(path, sourceRoots))
                 .toList();
     }
 

--- a/core/src/main/java/media/barney/crap/core/CliApplication.java
+++ b/core/src/main/java/media/barney/crap/core/CliApplication.java
@@ -130,11 +130,17 @@ final class CliApplication {
 
     private List<Path> filesForMode(CliArguments parsed) throws Exception {
         return switch (parsed.mode()) {
-            case ALL_SRC -> SourceFileFinder.findAllJavaFilesUnderSourceRoots(projectRoot);
-            case CHANGED_SRC -> ChangedFileDetector.changedJavaFilesUnderSourceRoots(projectRoot);
-            case EXPLICIT_FILES -> explicitFiles(parsed.fileArgs());
+            case ALL_SRC -> SourceFileFinder.findAllJavaFilesUnderSourceRoots(projectRoot, sourceRoots(parsed));
+            case CHANGED_SRC -> ChangedFileDetector.changedJavaFilesUnderSourceRoots(projectRoot, sourceRoots(parsed));
+            case EXPLICIT_FILES -> explicitFiles(parsed.fileArgs(), sourceRoots(parsed));
             case HELP -> List.of();
         };
+    }
+
+    private List<Path> sourceRoots(CliArguments parsed) {
+        return parsed.sourceRoots().stream()
+                .map(sourceRoot -> Path.of(sourceRoot).normalize())
+                .toList();
     }
 
     private ReportOptions reportOptions(CliArguments parsed) {
@@ -155,7 +161,7 @@ final class CliApplication {
         return projectRoot.resolve(path).normalize();
     }
 
-    private List<Path> explicitFiles(List<String> args) throws Exception {
+    private List<Path> explicitFiles(List<String> args, List<Path> sourceRoots) throws Exception {
         Set<Path> files = new LinkedHashSet<>();
         for (String arg : args) {
             Path path = projectRoot.resolve(arg).normalize();
@@ -163,7 +169,7 @@ final class CliApplication {
                 throw new IllegalArgumentException("Path does not exist: " + arg);
             }
             if (Files.isDirectory(path)) {
-                files.addAll(SourceFileFinder.findAllJavaFilesUnderSourceRoots(path));
+                files.addAll(SourceFileFinder.findAllJavaFilesUnderSourceRoots(path, sourceRoots));
             } else if (Files.isRegularFile(path)) {
                 files.add(path);
             } else {

--- a/core/src/main/java/media/barney/crap/core/CliArguments.java
+++ b/core/src/main/java/media/barney/crap/core/CliArguments.java
@@ -13,6 +13,7 @@ record CliArguments(
         boolean omitRedundancy,
         @Nullable String outputPath,
         @Nullable String junitReportPath,
+        List<String> sourceRoots,
         List<String> fileArgs,
         SourceExclusionOptions exclusionOptions
 ) {
@@ -36,6 +37,7 @@ record CliArguments(
                 omitRedundancy,
                 outputPath,
                 junitReportPath,
+                List.of(),
                 fileArgs,
                 SourceExclusionOptions.defaults()
         );

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -37,6 +37,7 @@ final class CliArgumentsParser {
                     state.omitRedundancy,
                     state.outputPath,
                     state.junitReportPath,
+                    state.sourceRoots,
                     List.of(),
                     state.exclusionOptions
             );
@@ -55,6 +56,7 @@ final class CliArgumentsParser {
                     state.omitRedundancy,
                     state.outputPath,
                     state.junitReportPath,
+                    state.sourceRoots,
                     List.of(),
                     state.exclusionOptions
             );
@@ -70,6 +72,7 @@ final class CliArgumentsParser {
                     state.omitRedundancy,
                     state.outputPath,
                     state.junitReportPath,
+                    state.sourceRoots,
                     List.of(),
                     state.exclusionOptions
             );
@@ -84,6 +87,7 @@ final class CliArgumentsParser {
                 state.omitRedundancy,
                 state.outputPath,
                 state.junitReportPath,
+                state.sourceRoots,
                 List.copyOf(values),
                 state.exclusionOptions
         );
@@ -148,6 +152,7 @@ final class CliArgumentsParser {
                 || parseReportFormatOption(args, index, state, option)
                 || parseOutputOption(args, index, state, option)
                 || parseJunitReportOption(args, index, state, option)
+                || parseSourceRootOption(args, index, state, option)
                 || parseThresholdOption(args, index, state, option)
                 || parseExclusionOption(args, index, state, option)) {
             return option.hasInlineValue() ? index : index + 1;
@@ -210,6 +215,17 @@ final class CliArgumentsParser {
         if ("--threshold".equals(option.name())) {
             state.threshold = parseThreshold(args, index, option, state.thresholdSeen);
             state.thresholdSeen = true;
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean parseSourceRootOption(String[] args,
+                                                 int index,
+                                                 ParseStateBuilder state,
+                                                 AssignedOption option) {
+        if ("--source-root".equals(option.name())) {
+            state.sourceRoots.add(parseListOption(args, index, option, "a source root path"));
             return true;
         }
         return false;
@@ -366,6 +382,7 @@ final class CliArgumentsParser {
                               @Nullable String outputPath,
                               @Nullable String junitReportPath,
                               SourceExclusionOptions exclusionOptions,
+                              List<String> sourceRoots,
                               List<String> fileArgs) {
     }
 
@@ -393,6 +410,7 @@ final class CliArgumentsParser {
         private boolean outputPathSeen;
         private @Nullable String junitReportPath;
         private boolean junitReportPathSeen;
+        private final List<String> sourceRoots = new ArrayList<>();
         private final List<String> values = new ArrayList<>();
 
         private ParseState build() {
@@ -415,6 +433,7 @@ final class CliArgumentsParser {
                             excludeAnnotations,
                             useDefaultExclusions
                     ),
+                    List.copyOf(sourceRoots),
                     values
             );
         }

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -148,16 +148,23 @@ final class CliArgumentsParser {
 
     private static int parseValuedOption(String[] args, int index, ParseStateBuilder state, String arg) {
         AssignedOption option = AssignedOption.parse(arg);
-        if (parseBuildToolOption(args, index, state, option)
-                || parseReportFormatOption(args, index, state, option)
-                || parseOutputOption(args, index, state, option)
-                || parseJunitReportOption(args, index, state, option)
-                || parseSourceRootOption(args, index, state, option)
+        if (parseGeneralValuedOption(args, index, state, option)
                 || parseThresholdOption(args, index, state, option)
                 || parseExclusionOption(args, index, state, option)) {
             return option.hasInlineValue() ? index : index + 1;
         }
         throw new IllegalArgumentException("Unknown option: " + arg);
+    }
+
+    private static boolean parseGeneralValuedOption(String[] args,
+                                                    int index,
+                                                    ParseStateBuilder state,
+                                                    AssignedOption option) {
+        return parseBuildToolOption(args, index, state, option)
+                || parseReportFormatOption(args, index, state, option)
+                || parseOutputOption(args, index, state, option)
+                || parseJunitReportOption(args, index, state, option)
+                || parseSourceRootOption(args, index, state, option);
     }
 
     private static boolean parseBuildToolOption(String[] args,

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -182,8 +182,8 @@ public final class Main {
     static String usage() {
         return """
                 Usage:
-                  crap-java                                Analyze all Java files under any nested src/main/java tree
-                  crap-java --changed                      Analyze changed Java files under any nested src/main/java tree
+                  crap-java                                Analyze all Java files under any nested source root
+                  crap-java --changed                      Analyze changed Java files under any nested source root
                   crap-java --build-tool gradle           Force Gradle for all resolved modules
                   crap-java --build-tool maven --changed  Force Maven for changed files
                   crap-java --format json                 Write report as toon, json, text, junit, or none (default: toon)
@@ -194,10 +194,11 @@ public final class Main {
                   crap-java --exclude-class '.*MapperImpl$' Exclude fully-qualified class names by regex, repeatable
                   crap-java --exclude-annotation Generated Exclude classes by annotation simple or qualified name, repeatable
                   crap-java --use-default-exclusions[=true|false]  Enable generated-code defaults (default: true)
+                  crap-java --source-root src/java       Override production source roots, repeatable
                   crap-java --output report.toon          Write the selected report format to a file
                   crap-java --junit-report report.xml     Also write a JUnit XML report for CI
                   crap-java --threshold 6                 Override the CRAP threshold (default: 8.0)
-                  crap-java <path...>                     Analyze files, or for directory args analyze nested src/main/java trees under each path
+                  crap-java <path...>                     Analyze files, or for directory args analyze nested source roots under each path
                   crap-java --help                        Print this help message
 
                 Exit codes:

--- a/core/src/main/java/media/barney/crap/core/ProductionSourceRoots.java
+++ b/core/src/main/java/media/barney/crap/core/ProductionSourceRoots.java
@@ -1,6 +1,7 @@
 package media.barney.crap.core;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 final class ProductionSourceRoots {
@@ -12,15 +13,54 @@ final class ProductionSourceRoots {
     }
 
     static boolean isProductionSourceRoot(Path directory) {
-        Path normalized = directory.normalize();
-        int startIndex = normalized.getNameCount() - PRODUCTION_SOURCE_ROOT.getNameCount();
-        return startIndex >= 0 && matchesProductionSourceRoot(normalized, startIndex);
+        return isRelativeSourceRoot(directory, PRODUCTION_SOURCE_ROOT);
     }
 
     static boolean isUnderProductionSourceRoot(Path path) {
+        return isUnderSourceRoot(path, List.of());
+    }
+
+    static boolean isSourceRoot(Path directory, Path sourceRoot) {
+        Path normalizedSourceRoot = sourceRoot.normalize();
+        if (normalizedSourceRoot.isAbsolute()) {
+            return directory.normalize().equals(normalizedSourceRoot);
+        }
+        return isRelativeSourceRoot(directory, normalizedSourceRoot);
+    }
+
+    static boolean isUnderSourceRoot(Path path, List<Path> sourceRoots) {
         Path normalized = path.normalize();
-        for (int index = 0; index <= normalized.getNameCount() - PRODUCTION_SOURCE_ROOT.getNameCount(); index++) {
-            if (matchesProductionSourceRoot(normalized, index)) {
+        for (Path sourceRoot : effectiveSourceRoots(sourceRoots)) {
+            Path normalizedSourceRoot = sourceRoot.normalize();
+            if (normalizedSourceRoot.isAbsolute()) {
+                if (normalized.startsWith(normalizedSourceRoot)) {
+                    return true;
+                }
+                continue;
+            }
+            for (int index = 0; index <= normalized.getNameCount() - normalizedSourceRoot.getNameCount(); index++) {
+                if (matchesSourceRoot(normalized, normalizedSourceRoot, index)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static List<Path> effectiveSourceRoots(List<Path> sourceRoots) {
+        return sourceRoots.isEmpty() ? List.of(PRODUCTION_SOURCE_ROOT) : List.copyOf(sourceRoots);
+    }
+
+    static boolean usesDefaultSourceRoots(List<Path> sourceRoots) {
+        return sourceRoots.isEmpty();
+    }
+
+    static boolean matchesAnyCustomSourceRoot(Path directory, List<Path> sourceRoots) {
+        if (usesDefaultSourceRoots(sourceRoots)) {
+            return false;
+        }
+        for (Path sourceRoot : effectiveSourceRoots(sourceRoots)) {
+            if (isSourceRoot(directory, sourceRoot)) {
                 return true;
             }
         }
@@ -32,9 +72,15 @@ final class ProductionSourceRoots {
         return fileName != null && SKIPPED_DIRECTORY_NAMES.contains(fileName.toString());
     }
 
-    private static boolean matchesProductionSourceRoot(Path path, int startIndex) {
-        for (int offset = 0; offset < PRODUCTION_SOURCE_ROOT.getNameCount(); offset++) {
-            if (!PRODUCTION_SOURCE_ROOT.getName(offset).toString().equals(path.getName(startIndex + offset).toString())) {
+    private static boolean isRelativeSourceRoot(Path directory, Path sourceRoot) {
+        Path normalized = directory.normalize();
+        int startIndex = normalized.getNameCount() - sourceRoot.getNameCount();
+        return startIndex >= 0 && matchesSourceRoot(normalized, sourceRoot, startIndex);
+    }
+
+    private static boolean matchesSourceRoot(Path path, Path sourceRoot, int startIndex) {
+        for (int offset = 0; offset < sourceRoot.getNameCount(); offset++) {
+            if (!sourceRoot.getName(offset).toString().equals(path.getName(startIndex + offset).toString())) {
                 return false;
             }
         }

--- a/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
+++ b/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
@@ -8,7 +8,9 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 final class SourceFileFinder {
 
@@ -16,40 +18,72 @@ final class SourceFileFinder {
     }
 
     static List<Path> findAllJavaFilesUnderSourceRoots(Path projectRoot) throws IOException {
+        return findAllJavaFilesUnderSourceRoots(projectRoot, List.of());
+    }
+
+    static List<Path> findAllJavaFilesUnderSourceRoots(Path projectRoot, List<Path> configuredSourceRoots)
+            throws IOException {
         if (!Files.isDirectory(projectRoot)) {
             return List.of();
         }
 
-        List<Path> javaFiles = new ArrayList<>();
-        for (Path sourceRoot : productionSourceRoots(projectRoot)) {
-            try (var stream = Files.walk(sourceRoot)) {
-                // Directory symlinks are not followed because FOLLOW_LINKS is not passed.
-                // Symlinked files are kept as link paths when Files.isRegularFile follows them.
-                stream.filter(Files::isRegularFile)
-                        .filter(path -> path.toString().endsWith(".java"))
-                        .forEach(javaFiles::add);
-            }
+        Set<Path> javaFiles = new LinkedHashSet<>();
+        for (Path sourceRoot : productionSourceRoots(projectRoot, configuredSourceRoots)) {
+            javaFiles.addAll(javaFilesUnder(sourceRoot));
         }
-        javaFiles.sort(Comparator.naturalOrder());
+        List<Path> sorted = new ArrayList<>(javaFiles);
+        sorted.sort(Comparator.naturalOrder());
+        return sorted;
+    }
+
+    private static List<Path> javaFilesUnder(Path sourceRoot) throws IOException {
+        List<Path> javaFiles = new ArrayList<>();
+        try (var stream = Files.walk(sourceRoot)) {
+            // Directory symlinks are not followed because FOLLOW_LINKS is not passed.
+            // Symlinked files are kept as link paths when Files.isRegularFile follows them.
+            stream.filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .forEach(javaFiles::add);
+        }
         return javaFiles;
     }
 
-    private static List<Path> productionSourceRoots(Path projectRoot) throws IOException {
+    private static List<Path> productionSourceRoots(Path projectRoot, List<Path> configuredSourceRoots)
+            throws IOException {
         List<Path> sourceRoots = new ArrayList<>();
+        sourceRoots.addAll(existingAbsoluteSourceRootsUnder(projectRoot, configuredSourceRoots));
         Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                if (ProductionSourceRoots.matchesAnyCustomSourceRoot(dir, configuredSourceRoots)) {
+                    sourceRoots.add(dir.normalize());
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
                 if (!dir.equals(projectRoot) && ProductionSourceRoots.isSkippableDirectory(dir)) {
                     return FileVisitResult.SKIP_SUBTREE;
                 }
-                if (ProductionSourceRoots.isProductionSourceRoot(dir)) {
+                if (ProductionSourceRoots.usesDefaultSourceRoots(configuredSourceRoots)
+                        && ProductionSourceRoots.isProductionSourceRoot(dir)) {
                     sourceRoots.add(dir.normalize());
                     return FileVisitResult.SKIP_SUBTREE;
                 }
                 return FileVisitResult.CONTINUE;
             }
         });
-        return sourceRoots;
+        return sourceRoots.stream()
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private static List<Path> existingAbsoluteSourceRootsUnder(Path projectRoot, List<Path> configuredSourceRoots) {
+        Path normalizedProjectRoot = projectRoot.toAbsolutePath().normalize();
+        return configuredSourceRoots.stream()
+                .map(Path::normalize)
+                .filter(Path::isAbsolute)
+                .filter(sourceRoot -> sourceRoot.startsWith(normalizedProjectRoot))
+                .filter(Files::isDirectory)
+                .toList();
     }
 }
 

--- a/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
+++ b/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
@@ -51,7 +51,7 @@ final class SourceFileFinder {
     private static List<Path> productionSourceRoots(Path projectRoot, List<Path> configuredSourceRoots)
             throws IOException {
         List<Path> sourceRoots = new ArrayList<>();
-        sourceRoots.addAll(existingAbsoluteSourceRootsUnder(projectRoot, configuredSourceRoots));
+        sourceRoots.addAll(existingAbsoluteSourceRoots(configuredSourceRoots));
         Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
@@ -76,12 +76,10 @@ final class SourceFileFinder {
                 .toList();
     }
 
-    private static List<Path> existingAbsoluteSourceRootsUnder(Path projectRoot, List<Path> configuredSourceRoots) {
-        Path normalizedProjectRoot = projectRoot.toAbsolutePath().normalize();
+    private static List<Path> existingAbsoluteSourceRoots(List<Path> configuredSourceRoots) {
         return configuredSourceRoots.stream()
                 .map(Path::normalize)
                 .filter(Path::isAbsolute)
-                .filter(sourceRoot -> sourceRoot.startsWith(normalizedProjectRoot))
                 .filter(Files::isDirectory)
                 .toList();
     }

--- a/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
+++ b/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
@@ -51,7 +51,7 @@ final class SourceFileFinder {
     private static List<Path> productionSourceRoots(Path projectRoot, List<Path> configuredSourceRoots)
             throws IOException {
         List<Path> sourceRoots = new ArrayList<>();
-        sourceRoots.addAll(existingAbsoluteSourceRoots(configuredSourceRoots));
+        sourceRoots.addAll(existingAbsoluteSourceRootsUnder(projectRoot, configuredSourceRoots));
         Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
@@ -76,12 +76,20 @@ final class SourceFileFinder {
                 .toList();
     }
 
-    private static List<Path> existingAbsoluteSourceRoots(List<Path> configuredSourceRoots) {
+    private static List<Path> existingAbsoluteSourceRootsUnder(Path projectRoot, List<Path> configuredSourceRoots) {
+        Path normalizedProjectRoot = projectRoot.toAbsolutePath().normalize();
         return configuredSourceRoots.stream()
                 .map(Path::normalize)
                 .filter(Path::isAbsolute)
+                .peek(sourceRoot -> validateSourceRootUnderProjectRoot(normalizedProjectRoot, sourceRoot))
                 .filter(Files::isDirectory)
                 .toList();
+    }
+
+    private static void validateSourceRootUnderProjectRoot(Path projectRoot, Path sourceRoot) {
+        if (!sourceRoot.startsWith(projectRoot)) {
+            throw new IllegalArgumentException("Absolute source root must be under the analyzed path: " + sourceRoot);
+        }
     }
 }
 

--- a/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
+++ b/core/src/main/java/media/barney/crap/core/SourceFileFinder.java
@@ -52,10 +52,15 @@ final class SourceFileFinder {
             throws IOException {
         List<Path> sourceRoots = new ArrayList<>();
         sourceRoots.addAll(existingAbsoluteSourceRootsUnder(projectRoot, configuredSourceRoots));
+        List<Path> relativeConfiguredSourceRoots = relativeConfiguredSourceRoots(configuredSourceRoots);
+        if (!ProductionSourceRoots.usesDefaultSourceRoots(configuredSourceRoots)
+                && relativeConfiguredSourceRoots.isEmpty()) {
+            return distinctSorted(sourceRoots);
+        }
         Files.walkFileTree(projectRoot, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-                if (ProductionSourceRoots.matchesAnyCustomSourceRoot(dir, configuredSourceRoots)) {
+                if (ProductionSourceRoots.matchesAnyCustomSourceRoot(dir, relativeConfiguredSourceRoots)) {
                     sourceRoots.add(dir.normalize());
                     return FileVisitResult.SKIP_SUBTREE;
                 }
@@ -70,7 +75,11 @@ final class SourceFileFinder {
                 return FileVisitResult.CONTINUE;
             }
         });
-        return sourceRoots.stream()
+        return distinctSorted(sourceRoots);
+    }
+
+    private static List<Path> distinctSorted(List<Path> paths) {
+        return paths.stream()
                 .distinct()
                 .sorted()
                 .toList();
@@ -83,6 +92,13 @@ final class SourceFileFinder {
                 .filter(Path::isAbsolute)
                 .peek(sourceRoot -> validateSourceRootUnderProjectRoot(normalizedProjectRoot, sourceRoot))
                 .filter(Files::isDirectory)
+                .toList();
+    }
+
+    private static List<Path> relativeConfiguredSourceRoots(List<Path> configuredSourceRoots) {
+        return configuredSourceRoots.stream()
+                .map(Path::normalize)
+                .filter(sourceRoot -> !sourceRoot.isAbsolute())
                 .toList();
     }
 

--- a/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
+++ b/core/src/test/java/media/barney/crap/core/ChangedFileDetectorTest.java
@@ -91,6 +91,30 @@ class ChangedFileDetectorTest {
     }
 
     @Test
+    void filtersChangedFilesToConfiguredSourceTrees() throws Exception {
+        run(tempDir, "git", "init");
+        run(tempDir, "git", "config", "user.email", "test@example.com");
+        run(tempDir, "git", "config", "user.name", "test");
+
+        Path customSource = tempDir.resolve("src/java/demo");
+        Path defaultSource = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(customSource);
+        Files.createDirectories(defaultSource);
+
+        Path tracked = customSource.resolve("Tracked.java");
+        Files.writeString(tracked, "class Tracked {}\n");
+        run(tempDir, "git", "add", ".");
+        run(tempDir, "git", "commit", "-m", "init");
+
+        Files.writeString(tracked, "class Tracked { int x = 1; }\n");
+        Files.writeString(defaultSource.resolve("DefaultChanged.java"), "class DefaultChanged {}\n");
+
+        List<Path> changed = ChangedFileDetector.changedJavaFilesUnderSourceRoots(tempDir, List.of(Path.of("src/java")));
+
+        assertEquals(List.of(tracked), changed);
+    }
+
+    @Test
     void ignoresDeletedJavaFiles() throws Exception {
         run(tempDir, "git", "init");
         run(tempDir, "git", "config", "user.email", "test@example.com");

--- a/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
@@ -128,6 +128,48 @@ class CliApplicationTest {
     }
 
     @Test
+    void sourceRootOptionDiscoversCustomSourceTrees() throws Exception {
+        Path sourceRoot = tempDir.resolve("src/java/demo");
+        Files.createDirectories(sourceRoot);
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int alpha() {
+                        return 1;
+                    }
+                }
+                """);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        Path jacocoXml = tempDir.resolve("target/site/jacoco/jacoco.xml");
+        CoverageRunner coverageRunner = new CoverageRunner((command, directory) -> {
+            Files.createDirectories(jacocoXml.getParent());
+            Files.writeString(jacocoXml, """
+                    <report name="demo">
+                      <package name="demo">
+                        <class name="demo/Sample" sourcefilename="Sample.java">
+                          <method name="alpha" desc="()I" line="4">
+                            <counter type="INSTRUCTION" missed="0" covered="1"/>
+                          </method>
+                        </class>
+                      </package>
+                    </report>
+                    """);
+            return 0;
+        });
+
+        int exit = new CliApplication(tempDir, new PrintStream(out), new PrintStream(err), coverageRunner, CoverageMode.GENERATE)
+                .execute(new String[]{"--source-root", "src/java"});
+
+        assertEquals(0, exit);
+        assertTrue(utf8(out).contains("src/java/demo/Sample.java"));
+        assertFalse(utf8(err).contains("Warning: JaCoCo XML not found"));
+    }
+
+    @Test
     void explicitFileUsesOwningModuleForCoverageAndJacocoXml() throws Exception {
         Path moduleRoot = tempDir.resolve("tools/mutate4java");
         Path sourceRoot = moduleRoot.resolve("src/mutate4java");

--- a/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliArgumentsParserTest.java
@@ -98,6 +98,18 @@ class CliArgumentsParserTest {
     }
 
     @Test
+    void sourceRootsAreParsed() {
+        CliArguments args = CliArgumentsParser.parse(new String[]{
+                "--source-root=src/java",
+                "--source-root",
+                "module-a/src/main/java17",
+                "--changed"
+        });
+
+        assertEquals(List.of("src/java", "module-a/src/main/java17"), args.sourceRoots());
+    }
+
+    @Test
     void sourceExclusionOptionsAcceptInlineAssignments() {
         CliArguments args = CliArgumentsParser.parse(new String[]{
                 "--exclude=module-a/**",
@@ -352,6 +364,8 @@ class CliArgumentsParserTest {
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--exclude-annotation"}));
         assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--source-root"}));
+        assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--use-default-exclusions=maybe"}));
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--exclude="}));
@@ -359,6 +373,8 @@ class CliArgumentsParserTest {
                 () -> CliArgumentsParser.parse(new String[]{"--exclude-class="}));
         assertThrows(IllegalArgumentException.class,
                 () -> CliArgumentsParser.parse(new String[]{"--exclude-annotation="}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArgumentsParser.parse(new String[]{"--source-root="}));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
@@ -83,6 +83,25 @@ class SourceFileFinderTest {
     }
 
     @Test
+    void supportsConfiguredAbsoluteSourceRootsUnderSearchedRoot() throws Exception {
+        Path customSourceRoot = tempDir.resolve("src/java/demo");
+        Files.createDirectories(customSourceRoot);
+        Path customSource = customSourceRoot.resolve("Sample.java");
+        Files.writeString(customSource, "class Sample {}\n");
+
+        Path defaultSourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(defaultSourceRoot);
+        Files.writeString(defaultSourceRoot.resolve("DefaultSample.java"), "class DefaultSample {}\n");
+
+        List<Path> files = SourceFileFinder.findAllJavaFilesUnderSourceRoots(
+                tempDir,
+                List.of(tempDir.resolve("src/java"))
+        );
+
+        assertEquals(List.of(customSource), files);
+    }
+
+    @Test
     void rejectsConfiguredAbsoluteSourceRootsOutsideSearchedRoot() throws Exception {
         Path projectRoot = tempDir.resolve("project");
         Files.createDirectories(projectRoot);

--- a/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
@@ -59,5 +59,26 @@ class SourceFileFinderTest {
 
         assertEquals(List.of(source), files);
     }
+
+    @Test
+    void supportsConfiguredRelativeSourceRoots() throws Exception {
+        Path customSourceRoot = tempDir.resolve("src/java/demo");
+        Files.createDirectories(customSourceRoot);
+        Path customSource = customSourceRoot.resolve("Sample.java");
+        Files.writeString(customSource, "class Sample {}\n");
+
+        Path defaultSourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(defaultSourceRoot);
+        Files.writeString(defaultSourceRoot.resolve("DefaultSample.java"), "class DefaultSample {}\n");
+
+        Path nestedModuleSourceRoot = tempDir.resolve("module-a/src/java/demo");
+        Files.createDirectories(nestedModuleSourceRoot);
+        Path nestedModuleSource = nestedModuleSourceRoot.resolve("NestedSample.java");
+        Files.writeString(nestedModuleSource, "class NestedSample {}\n");
+
+        List<Path> files = SourceFileFinder.findAllJavaFilesUnderSourceRoots(tempDir, List.of(Path.of("src/java")));
+
+        assertEquals(List.of(nestedModuleSource, customSource), files);
+    }
 }
 

--- a/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SourceFileFinderTest {
 
@@ -82,21 +83,25 @@ class SourceFileFinderTest {
     }
 
     @Test
-    void supportsConfiguredAbsoluteSourceRootsOutsideSearchedRoot() throws Exception {
+    void rejectsConfiguredAbsoluteSourceRootsOutsideSearchedRoot() throws Exception {
         Path projectRoot = tempDir.resolve("project");
         Files.createDirectories(projectRoot);
 
         Path externalSourceRoot = tempDir.resolve("external-src/demo");
         Files.createDirectories(externalSourceRoot);
-        Path externalSource = externalSourceRoot.resolve("ExternalSample.java");
-        Files.writeString(externalSource, "class ExternalSample {}\n");
 
-        List<Path> files = SourceFileFinder.findAllJavaFilesUnderSourceRoots(
-                projectRoot,
-                List.of(tempDir.resolve("external-src"))
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> SourceFileFinder.findAllJavaFilesUnderSourceRoots(
+                        projectRoot,
+                        List.of(tempDir.resolve("external-src"))
+                )
         );
 
-        assertEquals(List.of(externalSource), files);
+        assertEquals(
+                "Absolute source root must be under the analyzed path: " + tempDir.resolve("external-src"),
+                thrown.getMessage()
+        );
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
@@ -80,5 +80,23 @@ class SourceFileFinderTest {
 
         assertEquals(List.of(nestedModuleSource, customSource), files);
     }
+
+    @Test
+    void supportsConfiguredAbsoluteSourceRootsOutsideSearchedRoot() throws Exception {
+        Path projectRoot = tempDir.resolve("project");
+        Files.createDirectories(projectRoot);
+
+        Path externalSourceRoot = tempDir.resolve("external-src/demo");
+        Files.createDirectories(externalSourceRoot);
+        Path externalSource = externalSourceRoot.resolve("ExternalSample.java");
+        Files.writeString(externalSource, "class ExternalSample {}\n");
+
+        List<Path> files = SourceFileFinder.findAllJavaFilesUnderSourceRoots(
+                projectRoot,
+                List.of(tempDir.resolve("external-src"))
+        );
+
+        assertEquals(List.of(externalSource), files);
+    }
 }
 

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaGradlePlugin.java
@@ -8,6 +8,8 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.testing.jacoco.tasks.JacocoReport;
 
 import java.nio.file.Path;
@@ -80,11 +82,11 @@ public class CrapJavaGradlePlugin implements Plugin<Project> {
         String modulePath = relativeModulePath(analysisProject, candidate);
 
         checkTask.configure(task -> {
+            SourceSetContainer sourceSets = candidate.getExtensions().getByType(SourceSetContainer.class);
+            SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
             task.dependsOn(testTask);
             task.dependsOn(jacocoReportTask);
-            task.getAnalysisSources().from(candidate.fileTree(candidate.getProjectDir(), tree ->
-                    tree.include("src/main/java/**/*.java")
-            ));
+            task.getAnalysisSources().from(mainSourceSet.getAllJava());
             task.getCoverageReports().from(candidate.getLayout().getBuildDirectory().file("reports/jacoco/test/jacocoTestReport.xml"));
             task.getModuleCoverageReports().put(modulePath, coverageReportPath(modulePath));
         });

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -40,6 +40,72 @@ class CrapJavaGradlePluginFunctionalTest {
     }
 
     @Test
+    void singleModuleProjectUsesConfiguredMainJavaSourceSet() throws Exception {
+        writeFile("settings.gradle.kts", "rootProject.name = \"demo\"");
+        writeFile("build.gradle.kts", """
+                plugins {
+                    java
+                    id("media.barney.crap-java")
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                sourceSets {
+                    main {
+                        java.setSrcDirs(listOf("src/java"))
+                    }
+                    test {
+                        java.setSrcDirs(listOf("test/java"))
+                    }
+                }
+
+                dependencies {
+                    testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
+                    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+                }
+
+                tasks.test {
+                    useJUnitPlatform()
+                }
+                """);
+        writeFile("src/java/demo/Sample.java", """
+                package demo;
+
+                public class Sample {
+                    public int alpha(boolean value) {
+                        if (value) {
+                            return 1;
+                        }
+                        return 0;
+                    }
+                }
+                """);
+        writeFile("test/java/demo/SampleTest.java", """
+                package demo;
+
+                import org.junit.jupiter.api.Test;
+
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+
+                class SampleTest {
+                    @Test
+                    void alphaReturnsOneForTrue() {
+                        assertEquals(1, new Sample().alpha(true));
+                    }
+                }
+                """);
+
+        BuildResult result = runBuild("crap-java-check");
+
+        Path junitReport = tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml");
+        assertEquals(TaskOutcome.SUCCESS, result.task(":crap-java-check").getOutcome());
+        assertTrue(Files.exists(junitReport));
+        assertTrue(Files.readString(junitReport).contains("methodName\" value=\"alpha\""));
+    }
+
+    @Test
     void rootTaskAggregatesSubprojectCoverageForMultiModuleBuilds() throws Exception {
         writeFile("settings.gradle.kts", """
                 rootProject.name = "workspace"

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -137,6 +137,7 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         addRepeated(args, "--exclude", excludesProperty, excludes);
         addRepeated(args, "--exclude-class", excludeClassesProperty, excludeClasses);
         addRepeated(args, "--exclude-annotation", excludeAnnotationsProperty, excludeAnnotations);
+        addRepeated(args, "--source-root", null, sourceRootArguments());
         if (!useDefaultExclusions) {
             args.add("--use-default-exclusions=false");
         }
@@ -306,8 +307,8 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     private List<Path> missingCoverageReports() {
         List<Path> missingReports = new ArrayList<>();
         for (MavenProject reactorProject : reactorProjects()) {
-            Path basedir = reactorProject.getBasedir().toPath();
-            if (Files.exists(basedir.resolve("src/main/java"))
+            Path basedir = reactorProject.getBasedir().toPath().normalize();
+            if (compileSourceRoots(reactorProject).stream().anyMatch(Files::exists)
                     && !Files.exists(basedir.resolve("target/site/jacoco/jacoco.xml"))) {
                 missingReports.add(basedir.resolve("target/site/jacoco/jacoco.xml"));
             }
@@ -318,6 +319,39 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     private List<MavenProject> reactorProjects() {
         List<MavenProject> projects = session().getProjects();
         return projects == null || projects.isEmpty() ? List.of(project()) : projects;
+    }
+
+    private List<String> sourceRootArguments() {
+        if (!hasCustomCompileSourceRoot()) {
+            return List.of();
+        }
+        return reactorProjects().stream()
+                .flatMap(project -> compileSourceRoots(project).stream())
+                .map(Path::toString)
+                .distinct()
+                .toList();
+    }
+
+    private boolean hasCustomCompileSourceRoot() {
+        return reactorProjects().stream()
+                .anyMatch(project -> compileSourceRoots(project).stream()
+                        .anyMatch(sourceRoot -> !sourceRoot.equals(defaultSourceRoot(project))));
+    }
+
+    private static List<Path> compileSourceRoots(MavenProject project) {
+        List<String> roots = project.getCompileSourceRoots();
+        if (roots == null || roots.isEmpty()) {
+            return List.of(defaultSourceRoot(project));
+        }
+        return roots.stream()
+                .filter(Objects::nonNull)
+                .map(Path::of)
+                .map(path -> path.isAbsolute() ? path.normalize() : project.getBasedir().toPath().resolve(path).normalize())
+                .toList();
+    }
+
+    private static Path defaultSourceRoot(MavenProject project) {
+        return project.getBasedir().toPath().resolve("src/main/java").normalize();
     }
 
     private Path executionRoot() {

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -308,7 +309,7 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         List<Path> missingReports = new ArrayList<>();
         for (MavenProject reactorProject : reactorProjects()) {
             Path basedir = reactorProject.getBasedir().toPath().normalize();
-            if (compileSourceRoots(reactorProject).stream().anyMatch(Files::exists)
+            if (!analyzableCompileSourceRoots(reactorProject).isEmpty()
                     && !Files.exists(basedir.resolve("target/site/jacoco/jacoco.xml"))) {
                 missingReports.add(basedir.resolve("target/site/jacoco/jacoco.xml"));
             }
@@ -326,7 +327,7 @@ public class CrapJavaCheckMojo extends AbstractMojo {
             return List.of();
         }
         return reactorProjects().stream()
-                .flatMap(project -> compileSourceRoots(project).stream())
+                .flatMap(project -> analyzableCompileSourceRoots(project).stream())
                 .map(Path::toString)
                 .distinct()
                 .toList();
@@ -334,8 +335,15 @@ public class CrapJavaCheckMojo extends AbstractMojo {
 
     private boolean hasCustomCompileSourceRoot() {
         return reactorProjects().stream()
-                .anyMatch(project -> compileSourceRoots(project).stream()
+                .anyMatch(project -> analyzableCompileSourceRoots(project).stream()
                         .anyMatch(sourceRoot -> !sourceRoot.equals(defaultSourceRoot(project))));
+    }
+
+    private static List<Path> analyzableCompileSourceRoots(MavenProject project) {
+        return compileSourceRoots(project).stream()
+                .filter(Files::isDirectory)
+                .filter(sourceRoot -> !isGeneratedOrBuildOutputRoot(project, sourceRoot))
+                .toList();
     }
 
     private static List<Path> compileSourceRoots(MavenProject project) {
@@ -352,6 +360,28 @@ public class CrapJavaCheckMojo extends AbstractMojo {
 
     private static Path defaultSourceRoot(MavenProject project) {
         return project.getBasedir().toPath().resolve("src/main/java").normalize();
+    }
+
+    private static boolean isGeneratedOrBuildOutputRoot(MavenProject project, Path sourceRoot) {
+        Path basedir = project.getBasedir().toPath().normalize();
+        return isUnder(sourceRoot, basedir.resolve("target").normalize())
+                || isUnder(sourceRoot, basedir.resolve("build").normalize())
+                || isUnder(sourceRoot, basedir.resolve("out").normalize())
+                || hasGeneratedSegment(basedir, sourceRoot);
+    }
+
+    private static boolean isUnder(Path path, Path parent) {
+        return path.equals(parent) || path.startsWith(parent);
+    }
+
+    private static boolean hasGeneratedSegment(Path basedir, Path sourceRoot) {
+        Path relativeRoot = sourceRoot.startsWith(basedir) ? basedir.relativize(sourceRoot) : sourceRoot;
+        for (Path segment : relativeRoot) {
+            if (segment.toString().toLowerCase(Locale.ROOT).contains("generated")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Path executionRoot() {

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -138,7 +138,7 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         addRepeated(args, "--exclude", excludesProperty, excludes);
         addRepeated(args, "--exclude-class", excludeClassesProperty, excludeClasses);
         addRepeated(args, "--exclude-annotation", excludeAnnotationsProperty, excludeAnnotations);
-        addRepeated(args, "--source-root", null, sourceRootArguments());
+        addRepeated(args, "--source-root", null, sourceRootArguments(executionRoot));
         if (!useDefaultExclusions) {
             args.add("--use-default-exclusions=false");
         }
@@ -307,9 +307,10 @@ public class CrapJavaCheckMojo extends AbstractMojo {
 
     private List<Path> missingCoverageReports() {
         List<Path> missingReports = new ArrayList<>();
+        Path executionRoot = executionRoot();
         for (MavenProject reactorProject : reactorProjects()) {
             Path basedir = reactorProject.getBasedir().toPath().normalize();
-            if (!analyzableCompileSourceRoots(reactorProject).isEmpty()
+            if (!analyzableCompileSourceRoots(reactorProject, executionRoot).isEmpty()
                     && !Files.exists(basedir.resolve("target/site/jacoco/jacoco.xml"))) {
                 missingReports.add(basedir.resolve("target/site/jacoco/jacoco.xml"));
             }
@@ -322,26 +323,27 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         return projects == null || projects.isEmpty() ? List.of(project()) : projects;
     }
 
-    private List<String> sourceRootArguments() {
-        if (!hasCustomCompileSourceRoot()) {
+    private List<String> sourceRootArguments(Path executionRoot) {
+        if (!hasCustomCompileSourceRoot(executionRoot)) {
             return List.of();
         }
         return reactorProjects().stream()
-                .flatMap(project -> analyzableCompileSourceRoots(project).stream())
+                .flatMap(project -> analyzableCompileSourceRoots(project, executionRoot).stream())
                 .map(Path::toString)
                 .distinct()
                 .toList();
     }
 
-    private boolean hasCustomCompileSourceRoot() {
+    private boolean hasCustomCompileSourceRoot(Path executionRoot) {
         return reactorProjects().stream()
-                .anyMatch(project -> analyzableCompileSourceRoots(project).stream()
+                .anyMatch(project -> analyzableCompileSourceRoots(project, executionRoot).stream()
                         .anyMatch(sourceRoot -> !sourceRoot.equals(defaultSourceRoot(project))));
     }
 
-    private static List<Path> analyzableCompileSourceRoots(MavenProject project) {
+    private static List<Path> analyzableCompileSourceRoots(MavenProject project, Path executionRoot) {
         return compileSourceRoots(project).stream()
                 .filter(Files::isDirectory)
+                .filter(sourceRoot -> isUnder(sourceRoot, executionRoot))
                 .filter(sourceRoot -> !isGeneratedOrBuildOutputRoot(project, sourceRoot))
                 .toList();
     }
@@ -371,7 +373,9 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     }
 
     private static boolean isUnder(Path path, Path parent) {
-        return path.equals(parent) || path.startsWith(parent);
+        Path normalizedPath = path.toAbsolutePath().normalize();
+        Path normalizedParent = parent.toAbsolutePath().normalize();
+        return normalizedPath.equals(normalizedParent) || normalizedPath.startsWith(normalizedParent);
     }
 
     private static boolean hasGeneratedSegment(Path basedir, Path sourceRoot) {

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -160,6 +160,40 @@ class CrapJavaCheckMojoTest {
     }
 
     @Test
+    void filtersCompileSourceRootsOutsideExecutionRootWhenPassingSourceRootsToCli() throws Exception {
+        Path root = tempDir.resolve("root");
+        Path module = root.resolve("module-a");
+        Path sourceRoot = module.resolve("src/java");
+        Path externalModule = tempDir.resolve("external-module");
+        Path externalSourceRoot = externalModule.resolve("src/java");
+        Files.createDirectories(sourceRoot);
+        Files.createDirectories(externalSourceRoot);
+        writeCoverageReport(module);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        MavenProject moduleProject = project(module, "module-a");
+        moduleProject.addCompileSourceRoot(sourceRoot.toString());
+        MavenProject externalProject = project(externalModule, "external-module");
+        externalProject.addCompileSourceRoot(externalSourceRoot.toString());
+        setField(mojo, "session", session(List.of(project(root, "root"), moduleProject, externalProject), root));
+        setField(mojo, "project", externalProject);
+
+        mojo.execute();
+
+        assertEquals(List.of(
+                "--format",
+                "none",
+                "--source-root",
+                sourceRoot.toString(),
+                "--threshold",
+                "8.0",
+                "--junit-report",
+                root.resolve("target/crap-java/TEST-crap-java.xml").toString()
+        ), List.of(runner.args));
+    }
+
+    @Test
     void routesRunnerOutputThroughMavenLog() throws Exception {
         Path root = tempDir.resolve("root");
         writeCoverageReport(root);

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -72,6 +72,34 @@ class CrapJavaCheckMojoTest {
     }
 
     @Test
+    void passesConfiguredCompileSourceRootsToCli() throws Exception {
+        Path root = tempDir.resolve("root");
+        Path sourceRoot = root.resolve("src/java");
+        Files.createDirectories(sourceRoot);
+        writeCoverageReport(root);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        MavenProject project = project(root, "root");
+        project.addCompileSourceRoot(sourceRoot.toString());
+        setField(mojo, "session", session(List.of(project), root));
+        setField(mojo, "project", project);
+
+        mojo.execute();
+
+        assertEquals(List.of(
+                "--format",
+                "none",
+                "--source-root",
+                sourceRoot.toString(),
+                "--threshold",
+                "8.0",
+                "--junit-report",
+                root.resolve("target/crap-java/TEST-crap-java.xml").toString()
+        ), List.of(runner.args));
+    }
+
+    @Test
     void routesRunnerOutputThroughMavenLog() throws Exception {
         Path root = tempDir.resolve("root");
         writeCoverageReport(root);
@@ -312,6 +340,29 @@ class CrapJavaCheckMojoTest {
         assertTrue(runner.invoked);
         assertTrue(runner.useExistingCoverage);
         assertEquals(root, runner.projectRoot);
+    }
+
+    @Test
+    void checksCoverageReportsForConfiguredCompileSourceRoots() throws Exception {
+        Path root = tempDir.resolve("root");
+        Path sourceRoot = root.resolve("src/java");
+        Files.createDirectories(sourceRoot);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        MavenProject project = project(root, "root");
+        project.addCompileSourceRoot(sourceRoot.toString());
+        setField(mojo, "session", session(List.of(project), root));
+        setField(mojo, "project", project);
+
+        MojoFailureException ex = assertThrows(MojoFailureException.class, mojo::execute);
+
+        assertEquals(
+                "Missing JaCoCo XML reports. Configure jacoco-maven-plugin to generate target/site/jacoco/jacoco.xml before crap-java:check: "
+                        + root.resolve("target/site/jacoco/jacoco.xml"),
+                ex.getMessage()
+        );
+        assertFalse(runner.invoked);
     }
 
     @Test

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -100,6 +100,66 @@ class CrapJavaCheckMojoTest {
     }
 
     @Test
+    void ignoresGeneratedCompileSourceRootsWhenPassingSourceRootsToCli() throws Exception {
+        Path root = tempDir.resolve("root");
+        Path defaultSourceRoot = root.resolve("src/main/java");
+        Path generatedSourceRoot = root.resolve("target/generated-sources/annotations");
+        Files.createDirectories(defaultSourceRoot);
+        Files.createDirectories(generatedSourceRoot);
+        writeCoverageReport(root);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        MavenProject project = project(root, "root");
+        project.addCompileSourceRoot(defaultSourceRoot.toString());
+        project.addCompileSourceRoot(generatedSourceRoot.toString());
+        setField(mojo, "session", session(List.of(project), root));
+        setField(mojo, "project", project);
+
+        mojo.execute();
+
+        assertEquals(List.of(
+                "--format",
+                "none",
+                "--threshold",
+                "8.0",
+                "--junit-report",
+                root.resolve("target/crap-java/TEST-crap-java.xml").toString()
+        ), List.of(runner.args));
+    }
+
+    @Test
+    void passesOnlyAnalyzableConfiguredCompileSourceRootsToCli() throws Exception {
+        Path root = tempDir.resolve("root");
+        Path sourceRoot = root.resolve("src/java");
+        Path generatedSourceRoot = root.resolve("target/generated-sources/annotations");
+        Files.createDirectories(sourceRoot);
+        Files.createDirectories(generatedSourceRoot);
+        writeCoverageReport(root);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        MavenProject project = project(root, "root");
+        project.addCompileSourceRoot(sourceRoot.toString());
+        project.addCompileSourceRoot(generatedSourceRoot.toString());
+        setField(mojo, "session", session(List.of(project), root));
+        setField(mojo, "project", project);
+
+        mojo.execute();
+
+        assertEquals(List.of(
+                "--format",
+                "none",
+                "--source-root",
+                sourceRoot.toString(),
+                "--threshold",
+                "8.0",
+                "--junit-report",
+                root.resolve("target/crap-java/TEST-crap-java.xml").toString()
+        ), List.of(runner.args));
+    }
+
+    @Test
     void routesRunnerOutputThroughMavenLog() throws Exception {
         Path root = tempDir.resolve("root");
         writeCoverageReport(root);
@@ -363,6 +423,32 @@ class CrapJavaCheckMojoTest {
                 ex.getMessage()
         );
         assertFalse(runner.invoked);
+    }
+
+    @Test
+    void ignoresGeneratedCompileSourceRootsWhenCheckingCoverageReports() throws Exception {
+        Path root = tempDir.resolve("root");
+        Path generatedSourceRoot = root.resolve("target/generated-sources/annotations");
+        Files.createDirectories(generatedSourceRoot);
+
+        RecordingRunner runner = new RecordingRunner();
+        CrapJavaCheckMojo mojo = mojo(runner);
+        MavenProject project = project(root, "root");
+        project.addCompileSourceRoot(generatedSourceRoot.toString());
+        setField(mojo, "session", session(List.of(project), root));
+        setField(mojo, "project", project);
+
+        mojo.execute();
+
+        assertTrue(runner.invoked);
+        assertEquals(List.of(
+                "--format",
+                "none",
+                "--threshold",
+                "8.0",
+                "--junit-report",
+                root.resolve("target/crap-java/TEST-crap-java.xml").toString()
+        ), List.of(runner.args));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- classified #118 as valid source-selection/configuration feedback
- add repeatable CLI `--source-root` support for all-source, changed-source, and directory discovery modes
- use Maven compile source roots for custom layouts and Gradle `main` Java source sets instead of hardcoded `src/main/java`
- document default and custom source-root behavior

## Verification
- `mvn -B verify`
- `mvn -B -pl core test`
- `gradle-plugin\gradlew.bat test --no-daemon`

Closes #118