### PR TITLE
Fix #168 align CI stage families and quality gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,36 +9,9 @@ permissions:
   contents: read
 
 jobs:
-  core-and-cli:
-    name: Core and CLI (${{ matrix.os }}, JDK ${{ matrix.java }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ "17", "21", "25" ]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
-          cache: maven
-
-      - name: Build CLI and run core tests
-        run: mvn -B -pl cli -am package
-
-  gradle-plugin:
-    name: Gradle Plugin (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+  build:
+    name: build
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -51,31 +24,389 @@ jobs:
           java-version: "17"
           cache: maven
 
-      - name: Package core jar
-        run: mvn -B -pl core -am package
+      - name: Build
+        run: mvn -B -ntp -P!quality-gates-all -DskipTests install
 
-      - name: Set up Gradle wrapper permissions
-        if: runner.os != 'Windows'
-        run: chmod +x gradle-plugin/gradlew
+      - name: Upload Maven repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+          if-no-files-found: error
 
-      - name: Run Gradle plugin functional tests on Unix
-        if: runner.os != 'Windows'
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-targets
+          path: |
+            core/target
+            cli/target
+            gradle-plugin/target
+            maven-plugin/target
+          if-no-files-found: error
+
+  test-unit:
+    name: test / unit
+    runs-on: ubuntu-latest
+    needs:
+      - build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-targets
+          path: .
+
+      - name: Run unit tests
+        run: mvn -B -ntp -P!quality-gates-all -o verify
+
+      - name: Upload JaCoCo reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-reports
+          path: |
+            core/target/site/jacoco
+            cli/target/site/jacoco
+            gradle-plugin/target/site/jacoco
+            maven-plugin/target/site/jacoco
+          if-no-files-found: error
+
+  package:
+    name: package
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-targets
+          path: .
+
+      - name: Run package build
+        run: mvn -B -ntp -P!quality-gates-all -o -DskipTests package
+
+  quality-crap-core:
+    name: verify / quality-crap-core
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-targets
+          path: .
+
+      - name: Download JaCoCo reports
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-reports
+          path: .
+
+      - name: Run crap-java gate for core
+        working-directory: core
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -o -DskipTests verify
+
+  quality-crap-cli:
+    name: verify / quality-crap-cli
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-targets
+          path: .
+
+      - name: Download JaCoCo reports
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-reports
+          path: .
+
+      - name: Run crap-java gate for cli
+        working-directory: cli
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -o -DskipTests verify
+
+  quality-crap-gradle-plugin:
+    name: verify / quality-crap-gradle-plugin
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-targets
+          path: .
+
+      - name: Download JaCoCo reports
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-reports
+          path: .
+
+      - name: Run crap-java gate for gradle-plugin
         working-directory: gradle-plugin
-        run: ./gradlew test
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -o -DskipTests verify
 
-      - name: Run Gradle plugin functional tests on Windows
-        if: runner.os == 'Windows'
+  quality-crap-maven-plugin:
+    name: verify / quality-crap-maven-plugin
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-targets
+          path: .
+
+      - name: Download JaCoCo reports
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-reports
+          path: .
+
+      - name: Run crap-java gate for maven-plugin
+        working-directory: maven-plugin
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -o -DskipTests verify
+
+  quality-cognitive-core:
+    name: verify / quality-cognitive-core
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-targets
+          path: .
+
+      - name: Download JaCoCo reports
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-reports
+          path: .
+
+      - name: Run cognitive-java gate for core
+        working-directory: core
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -o -DskipTests verify
+
+  quality-cognitive-cli:
+    name: verify / quality-cognitive-cli
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-targets
+          path: .
+
+      - name: Download JaCoCo reports
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-reports
+          path: .
+
+      - name: Run cognitive-java gate for cli
+        working-directory: cli
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -o -DskipTests verify
+
+  quality-cognitive-gradle-plugin:
+    name: verify / quality-cognitive-gradle-plugin
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-targets
+          path: .
+
+      - name: Download JaCoCo reports
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-reports
+          path: .
+
+      - name: Run cognitive-java gate for gradle-plugin
         working-directory: gradle-plugin
-        shell: pwsh
-        run: .\gradlew.bat test
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -o -DskipTests verify
 
-  maven-plugin:
-    name: Maven Plugin (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+  quality-cognitive-maven-plugin:
+    name: verify / quality-cognitive-maven-plugin
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
 
     steps:
       - name: Checkout
@@ -88,114 +419,27 @@ jobs:
           java-version: "17"
           cache: maven
 
-      - name: Run Maven plugin integration tests
-        run: mvn -B -pl maven-plugin -am verify
-
-  nullaway-jdk25:
-    name: NullAway JDK 25
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
         with:
-          distribution: temurin
-          java-version: "25"
-          cache: maven
+          name: maven-repository
+          path: ~/.m2/repository
 
-      - name: Verify Maven build with NullAway profile
-        run: mvn -B verify
-
-  # Keep the self-hosted CRAP gate split by build tool so the metric job owns
-  # every source tree in this repo, including gradle-plugin/src/main/java.
-  crap-java-gate:
-    name: crap-java Gate
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
         with:
-          distribution: temurin
-          java-version: "17"
-          cache: maven
+          name: build-targets
+          path: .
 
-      - name: Build CLI
-        run: mvn -B -pl cli -am package
-
-      - name: Resolve CLI jar path
-        shell: bash
-        run: |
-          shopt -s nullglob
-          jars=(cli/target/crap-java-cli-*.jar)
-          filtered=()
-          for jar in "${jars[@]}"; do
-            case "$jar" in
-              *-sources.jar|*-javadoc.jar|*-shaded.jar|*original*.jar) ;;
-              *) filtered+=("$jar") ;;
-            esac
-          done
-          if [ "${#filtered[@]}" -ne 1 ]; then
-            echo "Expected exactly one built CLI jar, found ${#filtered[@]}" >&2
-            printf 'Candidates:\n%s\n' "${filtered[@]}" >&2
-            exit 1
-          fi
-          echo "CLI_JAR=${filtered[0]}" >> "$GITHUB_ENV"
-
-      - name: Run Maven-source crap-java gate
-        run: |
-          mkdir -p target/crap-java
-          java -jar "$CLI_JAR" \
-            --format text \
-            --junit-report target/crap-java/TEST-crap-java-maven-sources.xml \
-            --build-tool maven \
-            core/src/main/java cli/src/main/java maven-plugin/src/main/java
-
-      - name: Set up Gradle wrapper permissions
-        run: chmod +x gradle-plugin/gradlew
-
-      - name: Run Gradle-plugin crap-java gate
-        run: |
-          mkdir -p target/crap-java
-          java -jar "$CLI_JAR" \
-            --format text \
-            --junit-report target/crap-java/TEST-crap-java-gradle-plugin.xml \
-            --build-tool gradle \
-            gradle-plugin/src/main/java
-
-      - name: Upload crap-java JUnit reports
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - name: Download JaCoCo reports
+        uses: actions/download-artifact@v4
         with:
-          name: crap-java-junit-reports
-          path: target/crap-java/TEST-crap-java-*.xml
-          if-no-files-found: ignore
+          name: jacoco-reports
+          path: .
 
-  # Keep the self-hosted cognitive gate separate from the Gradle plugin test job
-  # so complexity violations in gradle-plugin/src/main/java fail this metric job.
-  cognitive-java-gate:
-    name: cognitive-java Gate
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
-        with:
-          distribution: temurin
-          java-version: "17"
-          cache: maven
-
-      - name: Run full-repo cognitive-java gate
-        run: mvn -B cognitive-java:check
+      - name: Run cognitive-java gate for maven-plugin
+        working-directory: maven-plugin
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -o -DskipTests verify
 
   publishing-preflight:
     name: Publishing Preflight

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,6 +237,9 @@ jobs:
           name: jacoco-reports
           path: .
 
+      - name: Remove Maven plugin IT fixtures from gate workspace
+        run: rm -rf maven-plugin/src/it
+
       - name: Run crap-java gate for maven-plugin
         working-directory: maven-plugin
         run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -DskipTests verify
@@ -396,6 +399,9 @@ jobs:
         with:
           name: jacoco-reports
           path: .
+
+      - name: Remove Maven plugin IT fixtures from gate workspace
+        run: rm -rf maven-plugin/src/it
 
       - name: Run cognitive-java gate for maven-plugin
         working-directory: maven-plugin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -28,14 +28,14 @@ jobs:
         run: mvn -B -ntp -P!quality-gates-all -DskipTests install
 
       - name: Upload Maven repository
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: maven-repository
           path: ~/.m2/repository
           if-no-files-found: error
 
       - name: Upload build outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-targets
           path: |
@@ -53,23 +53,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-targets
           path: .
@@ -78,7 +78,7 @@ jobs:
         run: mvn -B -ntp -P!quality-gates-all -o verify
 
       - name: Upload JaCoCo reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jacoco-reports
           path: |
@@ -97,23 +97,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-targets
           path: .
@@ -130,29 +130,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-targets
           path: .
 
       - name: Download JaCoCo reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jacoco-reports
           path: .
@@ -170,29 +170,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-targets
           path: .
 
       - name: Download JaCoCo reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jacoco-reports
           path: .
@@ -210,29 +210,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-targets
           path: .
 
       - name: Download JaCoCo reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jacoco-reports
           path: .
@@ -250,29 +250,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-targets
           path: .
 
       - name: Download JaCoCo reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jacoco-reports
           path: .
@@ -290,29 +290,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-targets
           path: .
 
       - name: Download JaCoCo reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jacoco-reports
           path: .
@@ -330,29 +330,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-targets
           path: .
 
       - name: Download JaCoCo reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jacoco-reports
           path: .
@@ -370,29 +370,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-targets
           path: .
 
       - name: Download JaCoCo reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jacoco-reports
           path: .
@@ -411,10 +411,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Run crap-java gate for core
         working-directory: core
-        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -o -DskipTests verify
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -DskipTests verify
 
   quality-crap-cli:
     name: verify / quality-crap-cli
@@ -199,47 +199,7 @@ jobs:
 
       - name: Run crap-java gate for cli
         working-directory: cli
-        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -o -DskipTests verify
-
-  quality-crap-gradle-plugin:
-    name: verify / quality-crap-gradle-plugin
-    runs-on: ubuntu-latest
-    needs:
-      - build
-      - test-unit
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
-        with:
-          distribution: temurin
-          java-version: "17"
-          cache: maven
-
-      - name: Download Maven repository
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repository
-          path: ~/.m2/repository
-
-      - name: Download build outputs
-        uses: actions/download-artifact@v4
-        with:
-          name: build-targets
-          path: .
-
-      - name: Download JaCoCo reports
-        uses: actions/download-artifact@v4
-        with:
-          name: jacoco-reports
-          path: .
-
-      - name: Run crap-java gate for gradle-plugin
-        working-directory: gradle-plugin
-        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -o -DskipTests verify
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -DskipTests verify
 
   quality-crap-maven-plugin:
     name: verify / quality-crap-maven-plugin
@@ -279,7 +239,7 @@ jobs:
 
       - name: Run crap-java gate for maven-plugin
         working-directory: maven-plugin
-        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -o -DskipTests verify
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-crap -DskipTests verify
 
   quality-cognitive-core:
     name: verify / quality-cognitive-core
@@ -319,7 +279,7 @@ jobs:
 
       - name: Run cognitive-java gate for core
         working-directory: core
-        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -o -DskipTests verify
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -DskipTests verify
 
   quality-cognitive-cli:
     name: verify / quality-cognitive-cli
@@ -359,7 +319,7 @@ jobs:
 
       - name: Run cognitive-java gate for cli
         working-directory: cli
-        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -o -DskipTests verify
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -DskipTests verify
 
   quality-cognitive-gradle-plugin:
     name: verify / quality-cognitive-gradle-plugin
@@ -399,7 +359,7 @@ jobs:
 
       - name: Run cognitive-java gate for gradle-plugin
         working-directory: gradle-plugin
-        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -o -DskipTests verify
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -DskipTests verify
 
   quality-cognitive-maven-plugin:
     name: verify / quality-cognitive-maven-plugin
@@ -439,7 +399,7 @@ jobs:
 
       - name: Run cognitive-java gate for maven-plugin
         working-directory: maven-plugin
-        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -o -DskipTests verify
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -DskipTests verify
 
   publishing-preflight:
     name: Publishing Preflight

--- a/maven-plugin/src/it/configured-report-controls/pom.xml
+++ b/maven-plugin/src/it/configured-report-controls/pom.xml
@@ -9,6 +9,7 @@
 
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>
@@ -69,4 +70,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>quality-gate-crap</id>
+    </profile>
+    <profile>
+      <id>quality-gate-cognitive</id>
+    </profile>
+  </profiles>
 </project>

--- a/maven-plugin/src/it/multi-module/pom.xml
+++ b/maven-plugin/src/it/multi-module/pom.xml
@@ -10,6 +10,7 @@
 
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <modules>
@@ -57,4 +58,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>quality-gate-crap</id>
+    </profile>
+    <profile>
+      <id>quality-gate-cognitive</id>
+    </profile>
+  </profiles>
 </project>

--- a/maven-plugin/src/it/single-module/pom.xml
+++ b/maven-plugin/src/it/single-module/pom.xml
@@ -9,6 +9,7 @@
 
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>
@@ -60,4 +61,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>quality-gate-crap</id>
+    </profile>
+    <profile>
+      <id>quality-gate-cognitive</id>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cognitive-java.version>0.4.0</cognitive-java.version>
+    <jacoco.version>0.8.14</jacoco.version>
     <junit.version>6.0.3</junit.version>
     <jspecify.version>1.0.0</jspecify.version>
     <jtoon.version>1.0.9</jtoon.version>
@@ -95,16 +96,20 @@
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>media.barney</groupId>
-        <artifactId>cognitive-java-maven-plugin</artifactId>
-        <version>${cognitive-java.version}</version>
-        <inherited>false</inherited>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
         <executions>
           <execution>
-            <id>cognitive-java-check</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
             <phase>verify</phase>
             <goals>
-              <goal>check</goal>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>
@@ -155,6 +160,82 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>quality-gates-all</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>media.barney</groupId>
+            <artifactId>crap-java-maven-plugin</artifactId>
+            <version>${project.version}</version>
+            <executions>
+              <execution>
+                <id>crap-java-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>media.barney</groupId>
+            <artifactId>cognitive-java-maven-plugin</artifactId>
+            <version>${cognitive-java.version}</version>
+            <executions>
+              <execution>
+                <id>cognitive-java-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>quality-gate-crap</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>media.barney</groupId>
+            <artifactId>crap-java-maven-plugin</artifactId>
+            <version>${project.version}</version>
+            <executions>
+              <execution>
+                <id>crap-java-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>quality-gate-cognitive</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>media.barney</groupId>
+            <artifactId>cognitive-java-maven-plugin</artifactId>
+            <version>${cognitive-java.version}</version>
+            <executions>
+              <execution>
+                <id>cognitive-java-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>nullaway</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
             <version>${project.version}</version>
             <configuration>
               <excludes>
-                <exclude>maven-plugin/src/it/**</exclude>
+                <exclude>**/src/it/**</exclude>
               </excludes>
             </configuration>
             <executions>
@@ -191,7 +191,7 @@
             <version>${cognitive-java.version}</version>
             <configuration>
               <excludes>
-                <exclude>maven-plugin/src/it/**</exclude>
+                <exclude>**/src/it/**</exclude>
               </excludes>
             </configuration>
             <executions>
@@ -216,7 +216,7 @@
             <version>${project.version}</version>
             <configuration>
               <excludes>
-                <exclude>maven-plugin/src/it/**</exclude>
+                <exclude>**/src/it/**</exclude>
               </excludes>
             </configuration>
             <executions>
@@ -241,7 +241,7 @@
             <version>${cognitive-java.version}</version>
             <configuration>
               <excludes>
-                <exclude>maven-plugin/src/it/**</exclude>
+                <exclude>**/src/it/**</exclude>
               </excludes>
             </configuration>
             <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -172,9 +172,6 @@
             <artifactId>crap-java-maven-plugin</artifactId>
             <version>${project.version}</version>
             <configuration>
-              <excludes>
-                <exclude>**/src/it/**</exclude>
-              </excludes>
             </configuration>
             <executions>
               <execution>
@@ -190,9 +187,6 @@
             <artifactId>cognitive-java-maven-plugin</artifactId>
             <version>${cognitive-java.version}</version>
             <configuration>
-              <excludes>
-                <exclude>**/src/it/**</exclude>
-              </excludes>
             </configuration>
             <executions>
               <execution>
@@ -215,9 +209,6 @@
             <artifactId>crap-java-maven-plugin</artifactId>
             <version>${project.version}</version>
             <configuration>
-              <excludes>
-                <exclude>**/src/it/**</exclude>
-              </excludes>
             </configuration>
             <executions>
               <execution>
@@ -240,9 +231,6 @@
             <artifactId>cognitive-java-maven-plugin</artifactId>
             <version>${cognitive-java.version}</version>
             <configuration>
-              <excludes>
-                <exclude>**/src/it/**</exclude>
-              </excludes>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,11 @@
             <groupId>media.barney</groupId>
             <artifactId>crap-java-maven-plugin</artifactId>
             <version>${project.version}</version>
+            <configuration>
+              <excludes>
+                <exclude>maven-plugin/src/it/**</exclude>
+              </excludes>
+            </configuration>
             <executions>
               <execution>
                 <id>crap-java-check</id>
@@ -184,6 +189,11 @@
             <groupId>media.barney</groupId>
             <artifactId>cognitive-java-maven-plugin</artifactId>
             <version>${cognitive-java.version}</version>
+            <configuration>
+              <excludes>
+                <exclude>maven-plugin/src/it/**</exclude>
+              </excludes>
+            </configuration>
             <executions>
               <execution>
                 <id>cognitive-java-check</id>
@@ -204,6 +214,11 @@
             <groupId>media.barney</groupId>
             <artifactId>crap-java-maven-plugin</artifactId>
             <version>${project.version}</version>
+            <configuration>
+              <excludes>
+                <exclude>maven-plugin/src/it/**</exclude>
+              </excludes>
+            </configuration>
             <executions>
               <execution>
                 <id>crap-java-check</id>
@@ -224,6 +239,11 @@
             <groupId>media.barney</groupId>
             <artifactId>cognitive-java-maven-plugin</artifactId>
             <version>${cognitive-java.version}</version>
+            <configuration>
+              <excludes>
+                <exclude>maven-plugin/src/it/**</exclude>
+              </excludes>
+            </configuration>
             <executions>
               <execution>
                 <id>cognitive-java-check</id>


### PR DESCRIPTION
## Summary - reshape the Maven workflow to stage-family job names - split CRAP and cognitive checks into per-module jobs - wire module-specific offline gate runs against reused build artifacts  ## Validation - ran the root install/test/package commands locally - ran representative per-module CRAP and cognitive gate commands locally from the module directories used by the workflow 

Closes #168