### PR TITLE
Fix CLI shade overlap warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,17 +34,6 @@ jobs:
           path: ~/.m2/repository
           if-no-files-found: error
 
-      - name: Upload build outputs
-        uses: actions/upload-artifact@v7
-        with:
-          name: build-targets
-          path: |
-            core/target
-            cli/target
-            gradle-plugin/target
-            maven-plugin/target
-          if-no-files-found: error
-
   test-unit:
     name: test / unit
     runs-on: ubuntu-latest
@@ -67,12 +56,6 @@ jobs:
         with:
           name: maven-repository
           path: ~/.m2/repository
-
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-targets
-          path: .
 
       - name: Run unit tests
         run: mvn -B -ntp -P!quality-gates-all -o verify
@@ -112,12 +95,6 @@ jobs:
           name: maven-repository
           path: ~/.m2/repository
 
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-targets
-          path: .
-
       - name: Run package build
         run: mvn -B -ntp -P!quality-gates-all -o -DskipTests package
 
@@ -144,12 +121,6 @@ jobs:
         with:
           name: maven-repository
           path: ~/.m2/repository
-
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-targets
-          path: .
 
       - name: Download JaCoCo reports
         uses: actions/download-artifact@v8
@@ -185,12 +156,6 @@ jobs:
           name: maven-repository
           path: ~/.m2/repository
 
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-targets
-          path: .
-
       - name: Download JaCoCo reports
         uses: actions/download-artifact@v8
         with:
@@ -224,12 +189,6 @@ jobs:
         with:
           name: maven-repository
           path: ~/.m2/repository
-
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-targets
-          path: .
 
       - name: Download JaCoCo reports
         uses: actions/download-artifact@v8
@@ -268,12 +227,6 @@ jobs:
           name: maven-repository
           path: ~/.m2/repository
 
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-targets
-          path: .
-
       - name: Download JaCoCo reports
         uses: actions/download-artifact@v8
         with:
@@ -307,12 +260,6 @@ jobs:
         with:
           name: maven-repository
           path: ~/.m2/repository
-
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-targets
-          path: .
 
       - name: Download JaCoCo reports
         uses: actions/download-artifact@v8
@@ -348,12 +295,6 @@ jobs:
           name: maven-repository
           path: ~/.m2/repository
 
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-targets
-          path: .
-
       - name: Download JaCoCo reports
         uses: actions/download-artifact@v8
         with:
@@ -387,12 +328,6 @@ jobs:
         with:
           name: maven-repository
           path: ~/.m2/repository
-
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-targets
-          path: .
 
       - name: Download JaCoCo reports
         uses: actions/download-artifact@v8

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -35,6 +35,13 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <forceCreation>true</forceCreation>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
@@ -48,7 +55,26 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>media.barney.crap.cli.Main</mainClass>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resource>META-INF/FastDoubleParser-LICENSE</resource>
+                </transformer>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/versions/*/module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## Summary
- remove the shared `build-targets` artifact handoff that was reusing stale shaded outputs
- keep Maven repository and JaCoCo artifact reuse in downstream jobs
- harden the CLI jar build so benign shade metadata overlaps are merged or filtered and reruns recreate the unshaded jar before shading

## Testing
- `mvn -B -ntp -pl cli -am clean package -P!quality-gates-all`
- `mvn -B -ntp -P!quality-gates-all -DskipTests install`
- `mvn -B -ntp -P!quality-gates-all -o verify`

Closes #170
