### PR TITLE
Prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+## 0.6.0 - 2026-05-24
+
+### Added
+
+- Added configurable source exclusions across the CLI, Maven plugin, and Gradle plugin, including path globs, class-name regexes, annotation names, and conservative generated-code defaults.
+- Added source-root overrides across the CLI and build-tool integrations, plus richer report-path, JUnit sidecar, and machine-readable primary-report controls.
+- Added broader self-hosting quality coverage for JDK `21` and `25`, Windows path-sensitive validation, and release-quality checks for shaded CLI packaging and publication preflight.
+
+### Changed
+
+- Hardened Java parsing and JaCoCo attribution around constructors, malformed counter values, source-position edge cases, deterministic metric ordering, and package-comment handling.
+- Expanded CLI and plugin documentation to cover report outputs, source roots, exclusion configuration, threshold guidance, exit-code behavior, and current published coordinates.
+- Tightened CI and release automation so Javadoc failures, publication preflight, cross-platform wrapper behavior, and sibling quality gates fail early before publication.
+
+### Fixed
+
+- Fixed Gradle and Maven module-path handling, Windows process cleanup and wrapper execution fallbacks, symlink and case-sensitive path handling, and Git-status timeout reporting.
+- Fixed GitLab-visible JUnit metadata and report path collision handling for both primary output and sidecar generation.
+
+### Dependencies
+
+- Updated stable Maven plugins, GitHub Actions, and supporting build dependencies used by the Java release and verification workflow.
+
 ## 0.5.0 - 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ mvn -B -pl cli -am -DskipTests package
 From the project root you want to analyze:
 
 ```bash
-java -jar cli/target/crap-java-cli-0.5.0.jar
+java -jar cli/target/crap-java-cli-0.6.0.jar
 ```
 
 ## CLI
@@ -153,27 +153,27 @@ Value-taking long options may also be written with inline assignment, such as
 Examples:
 
 ```bash
-java -jar cli/target/crap-java-cli-0.5.0.jar --help
-java -jar cli/target/crap-java-cli-0.5.0.jar
-java -jar cli/target/crap-java-cli-0.5.0.jar --changed
-java -jar cli/target/crap-java-cli-0.5.0.jar --build-tool gradle
-java -jar cli/target/crap-java-cli-0.5.0.jar --build-tool=maven
-java -jar cli/target/crap-java-cli-0.5.0.jar --format json
-java -jar cli/target/crap-java-cli-0.5.0.jar --format none --junit-report target/crap-java/TEST-crap-java.xml
-java -jar cli/target/crap-java-cli-0.5.0.jar --format json --output target/crap-java/report.json
-java -jar cli/target/crap-java-cli-0.5.0.jar --failures-only=false --format json
-java -jar cli/target/crap-java-cli-0.5.0.jar --omit-redundancy=false --format json
-java -jar cli/target/crap-java-cli-0.5.0.jar --agent
-java -jar cli/target/crap-java-cli-0.5.0.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
-java -jar cli/target/crap-java-cli-0.5.0.jar --junit-report target/crap-java/TEST-crap-java.xml
-java -jar cli/target/crap-java-cli-0.5.0.jar --threshold 6
-java -jar cli/target/crap-java-cli-0.5.0.jar --threshold=6
-java -jar cli/target/crap-java-cli-0.5.0.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
-java -jar cli/target/crap-java-cli-0.5.0.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
-java -jar cli/target/crap-java-cli-0.5.0.jar --source-root src/java --source-root src/main/java17
-java -jar cli/target/crap-java-cli-0.5.0.jar --build-tool maven module-a/src/main/java/demo/Sample.java
-java -jar cli/target/crap-java-cli-0.5.0.jar src/main/java/demo/Sample.java
-java -jar cli/target/crap-java-cli-0.5.0.jar module-a module-b
+java -jar cli/target/crap-java-cli-0.6.0.jar --help
+java -jar cli/target/crap-java-cli-0.6.0.jar
+java -jar cli/target/crap-java-cli-0.6.0.jar --changed
+java -jar cli/target/crap-java-cli-0.6.0.jar --build-tool gradle
+java -jar cli/target/crap-java-cli-0.6.0.jar --build-tool=maven
+java -jar cli/target/crap-java-cli-0.6.0.jar --format json
+java -jar cli/target/crap-java-cli-0.6.0.jar --format none --junit-report target/crap-java/TEST-crap-java.xml
+java -jar cli/target/crap-java-cli-0.6.0.jar --format json --output target/crap-java/report.json
+java -jar cli/target/crap-java-cli-0.6.0.jar --failures-only=false --format json
+java -jar cli/target/crap-java-cli-0.6.0.jar --omit-redundancy=false --format json
+java -jar cli/target/crap-java-cli-0.6.0.jar --agent
+java -jar cli/target/crap-java-cli-0.6.0.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
+java -jar cli/target/crap-java-cli-0.6.0.jar --junit-report target/crap-java/TEST-crap-java.xml
+java -jar cli/target/crap-java-cli-0.6.0.jar --threshold 6
+java -jar cli/target/crap-java-cli-0.6.0.jar --threshold=6
+java -jar cli/target/crap-java-cli-0.6.0.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
+java -jar cli/target/crap-java-cli-0.6.0.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
+java -jar cli/target/crap-java-cli-0.6.0.jar --source-root src/java --source-root src/main/java17
+java -jar cli/target/crap-java-cli-0.6.0.jar --build-tool maven module-a/src/main/java/demo/Sample.java
+java -jar cli/target/crap-java-cli-0.6.0.jar src/main/java/demo/Sample.java
+java -jar cli/target/crap-java-cli-0.6.0.jar module-a module-b
 ```
 
 The CLI writes only the requested primary report format to stdout unless
@@ -232,12 +232,12 @@ rely on properties.
 
 ## Distribution
 
-The current `0.5.0` release ships through Maven Central, with the Gradle Plugin Portal as the primary Gradle plugin channel:
+The current `0.6.0` release ships through Maven Central, with the Gradle Plugin Portal as the primary Gradle plugin channel:
 
-- `media.barney:crap-java-core:0.5.0`
-- `media.barney:crap-java-cli:0.5.0`
-- `media.barney:crap-java-maven-plugin:0.5.0`
-- Gradle plugin id `media.barney.crap-java` version `0.5.0`
+- `media.barney:crap-java-core:0.6.0`
+- `media.barney:crap-java-cli:0.6.0`
+- `media.barney:crap-java-maven-plugin:0.6.0`
+- Gradle plugin id `media.barney.crap-java` version `0.6.0`
 
 ### Gradle Plugin Portal
 
@@ -245,7 +245,7 @@ Apply the plugin in `build.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("media.barney.crap-java") version "0.5.0"
+    id("media.barney.crap-java") version "0.6.0"
 }
 ```
 
@@ -301,14 +301,14 @@ Then apply the same plugin id in `build.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("media.barney.crap-java") version "0.5.0"
+    id("media.barney.crap-java") version "0.6.0"
 }
 ```
 
 The marker publication lives at
-`media.barney.crap-java:media.barney.crap-java.gradle.plugin:0.5.0` and
+`media.barney.crap-java:media.barney.crap-java.gradle.plugin:0.6.0` and
 resolves to the implementation artifact
-`media.barney:crap-java-gradle-plugin:0.5.0`.
+`media.barney:crap-java-gradle-plugin:0.6.0`.
 
 ### Maven Central
 
@@ -339,7 +339,7 @@ Add the plugin:
     <plugin>
       <groupId>media.barney</groupId>
       <artifactId>crap-java-maven-plugin</artifactId>
-      <version>0.5.0</version>
+      <version>0.6.0</version>
       <executions>
         <execution>
           <goals>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
   </parent>
 
   <artifactId>crap-java-cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
   </parent>
 
   <artifactId>crap-java-core</artifactId>

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "media.barney"
-version = "0.5.0"
+version = "0.6.0"
 
 repositories {
     mavenCentral()

--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
   </parent>
 
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>media.barney</groupId>
   <artifactId>crap-java-parent</artifactId>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <packaging>pom</packaging>
 
   <name>crap-java Parent</name>


### PR DESCRIPTION
## Summary
- bump release metadata to v0.6.0
- align changelog with changes since v0.5.0
- update versioned README examples and release references

## Validation
- mvn -B verify
- mvn -B '-Dcentral.skipPublishing=true' -Prelease -pl .,cli,maven-plugin -am deploy *(blocked locally by workstation GPG pinentry; main branch GitHub preflight is green)*