### PR TITLE
Normalize release version checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,13 @@ jobs:
         shell: bash
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
-          pom_version="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
-          gradle_version="$(cd gradle-plugin && ./gradlew -q properties | awk -F': ' '/^version:/ {print $2; exit}')"
+          extract_semver() {
+            printf '%s\n' "$1" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1
+          }
+          pom_version="$(extract_semver "$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)")"
+          gradle_version="$(extract_semver "$(cd gradle-plugin && ./gradlew -q properties | awk -F': ' '/^version:/ {print $2; exit}')")"
+          test -n "${pom_version}"
+          test -n "${gradle_version}"
           test "${pom_version}" = "${tag_version}"
           test "${gradle_version}" = "${tag_version}"
 


### PR DESCRIPTION
## Summary
- make the release workflow normalize Maven and Gradle version output before comparing it to the tag
- prevent false negatives when the underlying tools emit extra formatting around the semantic version

## Validation
- reproduced the workflow check with Git Bash locally against v0.6.0 metadata