### PR TITLE
Share lossless release version validation

### DIFF
--- a/.github/scripts/verify-version-alignment.sh
+++ b/.github/scripts/verify-version-alignment.sh
@@ -75,19 +75,43 @@ read_maven_version_output() {
     printf '%s' "$MAVEN_VERSION_OUTPUT"
     return
   fi
-  mvn help:evaluate -Dexpression=project.version -q -DforceStdout
+  if [ ! -f pom.xml ]; then
+    echo "::error::Missing root pom.xml." >&2
+    exit 1
+  fi
+  perl -0ne '
+    if (m{<project\b.*?<artifactId>\s*[^<]+?\s*</artifactId>\s*<version>\s*([^<]+?)\s*</version>}s) {
+      print $1;
+      exit 0;
+    }
+    exit 1;
+  ' pom.xml || {
+    echo "::error::Unable to locate the root Maven project.version in pom.xml." >&2
+    exit 1
+  }
 }
 
 read_gradle_version_output() {
-  chmod +x gradle-plugin/gradlew
   if [ "${GRADLE_VERSION_OUTPUT+x}" = x ]; then
     printf '%s' "$GRADLE_VERSION_OUTPUT"
     return
   fi
-  (
-    cd gradle-plugin
-    ./gradlew -q properties | awk -F': ' '/^version:/ {print $2; exit}'
-  )
+  perl -0ne '
+    if (m{^\s*version\s*=\s*["'\'']([^"'\''\r\n]+)["'\'']\s*$}m) {
+      print $1;
+      exit 0;
+    }
+    exit 1;
+  ' gradle-plugin/build.gradle.kts 2>/dev/null || perl -0ne '
+    if (m{^\s*version\s*=\s*["'\'']([^"'\''\r\n]+)["'\'']\s*$}m) {
+      print $1;
+      exit 0;
+    }
+    exit 1;
+  ' gradle-plugin/build.gradle 2>/dev/null || {
+    echo "::error::Unable to locate the Gradle project.version assignment in gradle-plugin/build.gradle.kts or gradle-plugin/build.gradle." >&2
+    exit 1
+  }
 }
 
 main() {

--- a/.github/scripts/verify-version-alignment.sh
+++ b/.github/scripts/verify-version-alignment.sh
@@ -5,12 +5,13 @@ usage() {
   cat <<'EOF'
 Usage: verify-version-alignment.sh [--expected-version <version>]
 
-Validates that Maven and Gradle resolve to the same single-line version after
-stripping formatting noise. When --expected-version is provided, the sanitized
-version must also match it exactly.
+Validates that the root Maven POM version and Gradle plugin version resolve to
+the same single-line value after stripping formatting noise. When
+--expected-version is provided, the sanitized version must also match it
+exactly.
 
-Set MAVEN_VERSION_OUTPUT or GRADLE_VERSION_OUTPUT to inject raw command output
-for local dry-runs of malformed version scenarios.
+Set MAVEN_VERSION_OUTPUT or GRADLE_VERSION_OUTPUT to override the default file-
+based version sources for local dry-runs of malformed version scenarios.
 EOF
 }
 
@@ -116,6 +117,7 @@ read_gradle_version_output() {
 
 main() {
   local expected_version=""
+  local expected_version_requested=false
   local maven_version
   local gradle_version
 
@@ -127,6 +129,7 @@ main() {
           usage >&2
           exit 1
         fi
+        expected_version_requested=true
         expected_version="$2"
         shift 2
         ;;
@@ -150,7 +153,7 @@ main() {
     exit 1
   fi
 
-  if [ -n "$expected_version" ]; then
+  if [ "$expected_version_requested" = true ]; then
     expected_version="$(normalize_single_line "Expected version" "$expected_version")"
     if [ "$maven_version" != "$expected_version" ]; then
       echo "::error::Resolved project version ${maven_version} does not match expected version ${expected_version}." >&2

--- a/.github/scripts/verify-version-alignment.sh
+++ b/.github/scripts/verify-version-alignment.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: verify-version-alignment.sh [--expected-version <version>]
+
+Validates that Maven and Gradle resolve to the same single-line version after
+stripping formatting noise. When --expected-version is provided, the sanitized
+version must also match it exactly.
+
+Set MAVEN_VERSION_OUTPUT or GRADLE_VERSION_OUTPUT to inject raw command output
+for local dry-runs of malformed version scenarios.
+EOF
+}
+
+strip_formatting_noise() {
+  printf '%s' "$1" \
+    | tr -d '\r' \
+    | sed -E $'s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g'
+}
+
+normalize_single_line() {
+  local label="$1"
+  local raw_value="$2"
+  local sanitized_value
+  local non_empty_line_count
+  local normalized_value
+
+  sanitized_value="$(strip_formatting_noise "$raw_value")"
+  non_empty_line_count="$(
+    printf '%s\n' "$sanitized_value" | awk '
+      {
+        line = $0
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        if (length(line) > 0) {
+          count++
+        }
+      }
+      END {
+        print count + 0
+      }
+    '
+  )"
+
+  if [ "$non_empty_line_count" -ne 1 ]; then
+    echo "::error::${label} must resolve to exactly one non-empty line after stripping formatting noise." >&2
+    printf 'Sanitized output for %s:\n%s\n' "$label" "$sanitized_value" >&2
+    exit 1
+  fi
+
+  normalized_value="$(
+    printf '%s\n' "$sanitized_value" | awk '
+      {
+        line = $0
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        if (length(line) > 0) {
+          print line
+          exit
+        }
+      }
+    '
+  )"
+
+  if [ -z "$normalized_value" ]; then
+    echo "::error::${label} resolved to an empty value after stripping formatting noise." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$normalized_value"
+}
+
+read_maven_version_output() {
+  if [ "${MAVEN_VERSION_OUTPUT+x}" = x ]; then
+    printf '%s' "$MAVEN_VERSION_OUTPUT"
+    return
+  fi
+  mvn help:evaluate -Dexpression=project.version -q -DforceStdout
+}
+
+read_gradle_version_output() {
+  chmod +x gradle-plugin/gradlew
+  if [ "${GRADLE_VERSION_OUTPUT+x}" = x ]; then
+    printf '%s' "$GRADLE_VERSION_OUTPUT"
+    return
+  fi
+  (
+    cd gradle-plugin
+    ./gradlew -q properties | awk -F': ' '/^version:/ {print $2; exit}'
+  )
+}
+
+main() {
+  local expected_version=""
+  local maven_version
+  local gradle_version
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --expected-version)
+        if [ "$#" -lt 2 ]; then
+          echo "::error::Missing value for --expected-version." >&2
+          usage >&2
+          exit 1
+        fi
+        expected_version="$2"
+        shift 2
+        ;;
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "::error::Unknown argument: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  maven_version="$(normalize_single_line "Maven project.version" "$(read_maven_version_output)")"
+  gradle_version="$(normalize_single_line "Gradle project.version" "$(read_gradle_version_output)")"
+
+  if [ "$maven_version" != "$gradle_version" ]; then
+    echo "::error::Maven and Gradle versions disagree: Maven=${maven_version}, Gradle=${gradle_version}." >&2
+    exit 1
+  fi
+
+  if [ -n "$expected_version" ]; then
+    expected_version="$(normalize_single_line "Expected version" "$expected_version")"
+    if [ "$maven_version" != "$expected_version" ]; then
+      echo "::error::Resolved project version ${maven_version} does not match expected version ${expected_version}." >&2
+      exit 1
+    fi
+  fi
+
+  echo "Validated version alignment: ${maven_version}"
+}
+
+main "$@"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -453,6 +453,10 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_ENV"
 
+      - name: Verify release version parity
+        shell: bash
+        run: bash ./.github/scripts/verify-version-alignment.sh
+
       - name: Run Maven publishing preflight
         run: mvn -B -Prelease -Dcentral.skipPublishing=true -pl .,cli,maven-plugin -am deploy
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,17 +37,7 @@ jobs:
 
       - name: Verify release version
         shell: bash
-        run: |
-          tag_version="${GITHUB_REF_NAME#v}"
-          extract_semver() {
-            printf '%s\n' "$1" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1
-          }
-          pom_version="$(extract_semver "$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)")"
-          gradle_version="$(extract_semver "$(cd gradle-plugin && ./gradlew -q properties | awk -F': ' '/^version:/ {print $2; exit}')")"
-          test -n "${pom_version}"
-          test -n "${gradle_version}"
-          test "${pom_version}" = "${tag_version}"
-          test "${gradle_version}" = "${tag_version}"
+        run: bash ./.github/scripts/verify-version-alignment.sh --expected-version "${GITHUB_REF_NAME#v}"
 
       - name: Run cognitive-java gate
         run: mvn -B cognitive-java:check


### PR DESCRIPTION
Closes #176

## Summary
- replace the lossy release-version normalization with a shared lossless helper
- reuse the same helper from `release.yml` and `build.yml` preflight
- add local-injection support so malformed version output can be exercised directly

## Validation
- `bash ./.github/scripts/verify-version-alignment.sh --expected-version 0.6.0`
- `MAVEN_VERSION_OUTPUT=$''0.6.0\nwarning'' GRADLE_VERSION_OUTPUT=$''0.6.0'' bash ./.github/scripts/verify-version-alignment.sh` *(expected failure)*