### PR TITLE
Mirror clean Maven release flow in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -461,14 +461,9 @@ jobs:
         shell: bash
         run: |
           # Use a clean local repository so preflight does not inherit reactor-masking artifacts.
-          echo "PREFLIGHT_MAVEN_REPO_LOCAL=$(mktemp -d)" >> "$GITHUB_ENV"
-
-      - name: Build CLI from clean Maven release workspace
-        run: >
-          mvn -B -ntp
-          "-Dmaven.repo.local=${PREFLIGHT_MAVEN_REPO_LOCAL}"
-          -P!quality-gates-all
-          -pl cli -am package
+          preflight_maven_repo_local="$(mktemp -d)"
+          test -n "$preflight_maven_repo_local"
+          echo "PREFLIGHT_MAVEN_REPO_LOCAL=${preflight_maven_repo_local}" >> "$GITHUB_ENV"
 
       - name: Run Maven publishing preflight
         run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -473,6 +473,11 @@ jobs:
           -Dcentral.skipPublishing=true
           -pl .,cli,maven-plugin -am deploy
 
+      - name: Clean Maven release workspace
+        if: always()
+        shell: bash
+        run: rm -rf "${PREFLIGHT_MAVEN_REPO_LOCAL}"
+
       - name: Set up Gradle wrapper permissions
         run: chmod +x gradle-plugin/gradlew
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -457,8 +457,26 @@ jobs:
         shell: bash
         run: bash ./.github/scripts/verify-version-alignment.sh
 
+      - name: Prepare clean Maven release workspace
+        shell: bash
+        run: |
+          # Use a clean local repository so preflight does not inherit reactor-masking artifacts.
+          echo "PREFLIGHT_MAVEN_REPO_LOCAL=$(mktemp -d)" >> "$GITHUB_ENV"
+
+      - name: Build CLI from clean Maven release workspace
+        run: >
+          mvn -B -ntp
+          "-Dmaven.repo.local=${PREFLIGHT_MAVEN_REPO_LOCAL}"
+          -P!quality-gates-all
+          -pl cli -am package
+
       - name: Run Maven publishing preflight
-        run: mvn -B -Prelease -Dcentral.skipPublishing=true -pl .,cli,maven-plugin -am deploy
+        run: >
+          mvn -B -ntp
+          "-Dmaven.repo.local=${PREFLIGHT_MAVEN_REPO_LOCAL}"
+          -P!quality-gates-all,release
+          -Dcentral.skipPublishing=true
+          -pl .,cli,maven-plugin -am deploy
 
       - name: Set up Gradle wrapper permissions
         run: chmod +x gradle-plugin/gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
         shell: bash
         run: bash ./.github/scripts/verify-version-alignment.sh --expected-version "${GITHUB_REF_NAME#v}"
 
+      - name: Remove Maven plugin IT fixtures from cognitive-java gate workspace
+        run: rm -rf maven-plugin/src/it
+
       - name: Run cognitive-java gate
         run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -DskipTests verify
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,22 @@ jobs:
         shell: bash
         run: bash ./.github/scripts/verify-version-alignment.sh --expected-version "${GITHUB_REF_NAME#v}"
 
-      - name: Remove Maven plugin IT fixtures from cognitive-java gate workspace
-        run: rm -rf maven-plugin/src/it
-
       - name: Run cognitive-java gate
-        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -DskipTests verify
+        shell: bash
+        run: |
+          temp_workspace="$(mktemp -d)"
+          restore_it_fixtures() {
+            if [ -d "${temp_workspace}/it" ]; then
+              mkdir -p maven-plugin/src
+              mv "${temp_workspace}/it" maven-plugin/src/it
+            fi
+            rm -rf "${temp_workspace}"
+          }
+          trap restore_it_fixtures EXIT
+          if [ -d maven-plugin/src/it ]; then
+            mv maven-plugin/src/it "${temp_workspace}/it"
+          fi
+          mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -DskipTests verify
 
       - name: Build CLI for crap-java gate
         run: mvn -B -ntp -P!quality-gates-all -pl cli -am package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
         run: bash ./.github/scripts/verify-version-alignment.sh --expected-version "${GITHUB_REF_NAME#v}"
 
       - name: Run cognitive-java gate
-        run: mvn -B cognitive-java:check
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -DskipTests verify
 
       - name: Build CLI for crap-java gate
-        run: mvn -B -pl cli -am package
+        run: mvn -B -ntp -P!quality-gates-all -pl cli -am package
 
       - name: Resolve CLI jar path
         shell: bash
@@ -96,7 +96,7 @@ jobs:
           MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
           MAVEN_CENTRAL_TOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-        run: mvn -B -Prelease -pl .,cli,maven-plugin -am deploy
+        run: mvn -B -ntp -P!quality-gates-all,release -pl .,cli,maven-plugin -am deploy
 
       - name: Publish Gradle plugin artifacts to Maven Central
         env:


### PR DESCRIPTION
Closes #181

## Summary
- disable the self-hosting `quality-gates-all` profile for clean release Maven commands
- run the cognitive release gate with the same CI-style verify flow while temporarily moving and restoring Maven plugin IT fixtures around that gate
- make publishing preflight validate against an isolated `maven.repo.local` and clean it up afterward

## Validation
- `mvn -B -ntp -P!quality-gates-all,quality-gate-cognitive -DskipTests verify`
- `mvn -B -ntp -P!quality-gates-all -pl cli -am package`
