### PR TITLE
ci: quality-spotbugs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build
         run: mvn -B -ntp -P!quality-gates-all -DskipTests install
 
+      - name: Prime SpotBugs Maven cache
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-spotbugs -DskipTests org.apache.maven.plugins:maven-dependency-plugin:3.7.0:go-offline
+
       - name: Upload Maven repository
         uses: actions/upload-artifact@v7
         with:
@@ -521,6 +524,127 @@ jobs:
         working-directory: maven-plugin
         run: mvn -B -ntp -P!quality-gates-all -DskipTests verify
 
+  quality-spotbugs-core:
+    name: verify / quality-spotbugs-core
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v8
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Run SpotBugs gate for core
+        working-directory: core
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-spotbugs -o -DskipTests verify
+
+  quality-spotbugs-cli:
+    name: verify / quality-spotbugs-cli
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v8
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Run SpotBugs gate for cli
+        working-directory: cli
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-spotbugs -o -DskipTests verify
+
+  quality-spotbugs-gradle-plugin:
+    name: verify / quality-spotbugs-gradle-plugin
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v8
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Build core jar for SpotBugs gate
+        run: mvn -B -ntp -P!quality-gates-all -pl core -am -o -DskipTests package
+
+      - name: Set up Gradle wrapper permissions
+        run: chmod +x gradle-plugin/gradlew
+
+      - name: Run SpotBugs gate for gradle-plugin
+        working-directory: gradle-plugin
+        run: ./gradlew spotbugsMain
+
+  quality-spotbugs-maven-plugin:
+    name: verify / quality-spotbugs-maven-plugin
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v8
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Remove Maven plugin IT fixtures from gate workspace
+        run: rm -rf maven-plugin/src/it
+
+      - name: Run SpotBugs gate for maven-plugin
+        working-directory: maven-plugin
+        run: mvn -B -ntp -P!quality-gates-all,quality-gate-spotbugs -o -DskipTests verify
+
   publishing-preflight:
     name: publish / preflight
     runs-on: ubuntu-latest
@@ -538,6 +662,10 @@ jobs:
       - quality-nullaway-cli
       - quality-nullaway-gradle-plugin
       - quality-nullaway-maven-plugin
+      - quality-spotbugs-core
+      - quality-spotbugs-cli
+      - quality-spotbugs-gradle-plugin
+      - quality-spotbugs-maven-plugin
     env:
       MAVEN_CENTRAL_TOKEN_USERNAME: preflight-token-user
       MAVEN_CENTRAL_TOKEN_PASSWORD: preflight-token-password

--- a/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
+++ b/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
@@ -70,7 +70,8 @@ final class CrapAnalyzer {
         }
         Path normalizedFile = file.toAbsolutePath().normalize();
         String source = Files.readString(file);
-        String sourceName = file.getFileName().toString();
+        Path fileName = file.getFileName();
+        String sourceName = fileName == null ? normalizedFile.toString() : fileName.toString();
         for (MethodDescriptor method : JavaMethodParser.parse(sourceName, source)) {
             addMetricIfIncluded(method, projectRoot, normalizedFile, coverageMap, exclusions, audit, excludedClasses, metrics);
         }

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -285,10 +285,15 @@ public final class Main {
         public ResolvedCoverageModule {
             moduleRoot = moduleRoot.toAbsolutePath().normalize();
             coverageReport = coverageReport.toAbsolutePath().normalize();
-            sourceFiles = sourceFiles.stream()
+            sourceFiles = List.copyOf(sourceFiles.stream()
                     .map(path -> path.toAbsolutePath().normalize())
                     .sorted()
-                    .toList();
+                    .toList());
+        }
+
+        @Override
+        public List<Path> sourceFiles() {
+            return List.copyOf(sourceFiles);
         }
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -92,9 +92,13 @@ record ReportOptions(
     }
 
     private static boolean sameAliasedParent(Path firstParent, Path secondParent) throws IOException {
-        return sameExistingFile(firstParent, secondParent)
-                || sameRealPath(firstParent, secondParent)
+        return sameFilesystemTarget(firstParent, secondParent)
                 || sameCaseInsensitivePath(firstParent, secondParent);
+    }
+
+    private static boolean sameFilesystemTarget(Path firstParent, Path secondParent) throws IOException {
+        return sameExistingFile(firstParent, secondParent)
+                || sameRealPath(firstParent, secondParent);
     }
 
     private static boolean sameRealPath(Path first, Path second) {
@@ -113,20 +117,40 @@ record ReportOptions(
         }
         Path normalized = path.toAbsolutePath().normalize();
         try {
-            if (Files.isSymbolicLink(normalized)) {
-                return symbolicLinkTargetForComparison(normalized, symlinkDepth);
-            }
-            if (Files.exists(normalized)) {
-                return normalized.toRealPath();
-            }
-            Path existing = nearestExistingPath(normalized);
-            if (existing != null) {
-                return existing.toRealPath().resolve(existing.relativize(normalized)).normalize();
-            }
+            return resolvedRealPath(normalized, symlinkDepth);
         } catch (IOException | SecurityException exception) {
             return null;
         }
-        return null;
+    }
+
+    private static @Nullable Path resolvedRealPath(Path normalized, int symlinkDepth) throws IOException {
+        Path symbolicLinkTarget = symbolicLinkTarget(normalized, symlinkDepth);
+        if (symbolicLinkTarget != null) {
+            return symbolicLinkTarget;
+        }
+        return existingOrDerivedRealPath(normalized);
+    }
+
+    private static @Nullable Path symbolicLinkTarget(Path normalized, int symlinkDepth) throws IOException {
+        if (!Files.isSymbolicLink(normalized)) {
+            return null;
+        }
+        return symbolicLinkTargetForComparison(normalized, symlinkDepth);
+    }
+
+    private static @Nullable Path existingOrDerivedRealPath(Path normalized) throws IOException {
+        if (Files.exists(normalized)) {
+            return normalized.toRealPath();
+        }
+        return realPathFromNearestExisting(normalized);
+    }
+
+    private static @Nullable Path realPathFromNearestExisting(Path normalized) throws IOException {
+        Path existing = nearestExistingPath(normalized);
+        if (existing == null) {
+            return null;
+        }
+        return existing.toRealPath().resolve(existing.relativize(normalized)).normalize();
     }
 
     private static @Nullable Path symbolicLinkTargetForComparison(Path link, int symlinkDepth) throws IOException {
@@ -142,13 +166,22 @@ record ReportOptions(
     private static boolean sameFileName(Path first, Path second, @Nullable Path parent) {
         Path firstFileName = first.getFileName();
         Path secondFileName = second.getFileName();
+        return sameNamedPaths(firstFileName, secondFileName, parent);
+    }
+
+    private static boolean sameNamedPaths(@Nullable Path firstFileName,
+                                          @Nullable Path secondFileName,
+                                          @Nullable Path parent) {
         if (firstFileName == null || secondFileName == null) {
             return false;
         }
-        String firstName = firstFileName.toString();
-        String secondName = secondFileName.toString();
-        return firstName.equals(secondName)
-                || (firstName.equalsIgnoreCase(secondName) && isCaseInsensitive(parent));
+        return sameFileNames(firstFileName.toString(), secondFileName.toString(), parent);
+    }
+
+    private static boolean sameFileNames(String firstName,
+                                         String secondName,
+                                         @Nullable Path parent) {
+        return firstName.equals(secondName) || sameCaseInsensitiveFileName(firstName, secondName, parent);
     }
 
     private static boolean isCaseInsensitive(@Nullable Path path) {
@@ -183,12 +216,20 @@ record ReportOptions(
         if (fileName == null) {
             return false;
         }
-        String name = fileName.toString();
+        return caseVariantExists(probe, fileName.toString());
+    }
+
+    private static boolean caseVariantExists(Path probe, String name) {
         Path variant = probe.resolveSibling(name.toUpperCase(Locale.ROOT));
         Path variantFileName = variant.getFileName();
-        return variantFileName != null
-                && !name.equals(variantFileName.toString())
-                && Files.exists(variant);
+        if (variantFileName == null) {
+            return false;
+        }
+        return differentExistingVariant(name, variantFileName.toString(), variant);
+    }
+
+    private static boolean differentExistingVariant(String name, String variantName, Path variant) {
+        return !name.equals(variantName) && Files.exists(variant);
     }
 
     static boolean isLikelyCaseInsensitiveOs() {
@@ -198,5 +239,11 @@ record ReportOptions(
 
     private static boolean sameCaseInsensitivePath(Path first, Path second) {
         return first.toString().equalsIgnoreCase(second.toString()) && isCaseInsensitive(first);
+    }
+
+    private static boolean sameCaseInsensitiveFileName(String firstName,
+                                                       String secondName,
+                                                       @Nullable Path parent) {
+        return firstName.equalsIgnoreCase(secondName) && isCaseInsensitive(parent);
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportOptions.java
+++ b/core/src/main/java/media/barney/crap/core/ReportOptions.java
@@ -82,7 +82,7 @@ record ReportOptions(
 
     private static boolean sameParent(@Nullable Path firstParent, @Nullable Path secondParent) throws IOException {
         return (firstParent == null || secondParent == null)
-                ? firstParent == secondParent
+                ? Objects.equals(firstParent, secondParent)
                 : sameNonNullParent(firstParent, secondParent);
     }
 
@@ -140,8 +140,13 @@ record ReportOptions(
     }
 
     private static boolean sameFileName(Path first, Path second, @Nullable Path parent) {
-        String firstName = first.getFileName().toString();
-        String secondName = second.getFileName().toString();
+        Path firstFileName = first.getFileName();
+        Path secondFileName = second.getFileName();
+        if (firstFileName == null || secondFileName == null) {
+            return false;
+        }
+        String firstName = firstFileName.toString();
+        String secondName = secondFileName.toString();
         return firstName.equals(secondName)
                 || (firstName.equalsIgnoreCase(secondName) && isCaseInsensitive(parent));
     }
@@ -174,8 +179,16 @@ record ReportOptions(
     }
 
     private static boolean caseVariantExists(Path probe) {
-        Path variant = probe.resolveSibling(probe.getFileName().toString().toUpperCase(Locale.ROOT));
-        return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
+        Path fileName = probe.getFileName();
+        if (fileName == null) {
+            return false;
+        }
+        String name = fileName.toString();
+        Path variant = probe.resolveSibling(name.toUpperCase(Locale.ROOT));
+        Path variantFileName = variant.getFileName();
+        return variantFileName != null
+                && !name.equals(variantFileName.toString())
+                && Files.exists(variant);
     }
 
     static boolean isLikelyCaseInsensitiveOs() {

--- a/core/src/main/java/media/barney/crap/core/SourceExclusionOptions.java
+++ b/core/src/main/java/media/barney/crap/core/SourceExclusionOptions.java
@@ -19,14 +19,29 @@ public record SourceExclusionOptions(
         return new SourceExclusionOptions(List.of(), List.of(), List.of(), true);
     }
 
+    @Override
+    public List<String> excludes() {
+        return List.copyOf(excludes);
+    }
+
+    @Override
+    public List<String> excludeClasses() {
+        return List.copyOf(excludeClasses);
+    }
+
+    @Override
+    public List<String> excludeAnnotations() {
+        return List.copyOf(excludeAnnotations);
+    }
+
     private static List<String> normalized(List<String> values) {
         if (values == null) {
             return List.of();
         }
-        return values.stream()
+        return List.copyOf(values.stream()
                 .filter(Objects::nonNull)
                 .map(String::trim)
                 .filter(value -> !value.isEmpty())
-                .toList();
+                .toList());
     }
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.github.spotbugs.snom.Confidence
+import com.github.spotbugs.snom.Effort
+import com.github.spotbugs.snom.SpotBugsTask
 import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.plugin.compatibility.compatibility
@@ -11,6 +14,7 @@ import javax.xml.parsers.DocumentBuilderFactory
 plugins {
     `java-gradle-plugin`
     id("com.gradle.plugin-publish") version "2.1.1"
+    id("com.github.spotbugs") version "6.5.5"
     id("net.ltgt.errorprone") version "5.1.0" apply false
     jacoco
     signing
@@ -27,6 +31,13 @@ jacoco {
     toolVersion = "0.8.13"
 }
 
+spotbugs {
+    toolVersion.set(spotbugsVersion)
+    effort.set(Effort.MAX)
+    reportLevel.set(Confidence.MEDIUM)
+    ignoreFailures.set(false)
+}
+
 val projectVersion = version.toString()
 val jtoonVersion = parentPomProperty("jtoon.version")
 val jacksonVersion = parentPomProperty("jackson.version")
@@ -35,6 +46,7 @@ val jspecifyVersion = parentPomProperty("jspecify.version")
 val errorproneVersion = parentPomProperty("errorprone.version")
 val nullawayVersion = parentPomProperty("nullaway.version")
 val nullawayAnnotatedPackages = parentPomProperty("nullaway.annotated.packages")
+val spotbugsVersion = parentPomProperty("spotbugs.version")
 val qualityNullaway = providers.gradleProperty("qualityNullaway").map(String::toBoolean).getOrElse(false)
 val coreJar = layout.projectDirectory.file("../core/target/crap-java-core-${projectVersion}.jar")
 val gpgPrivateKey = providers.environmentVariable("MAVEN_GPG_PRIVATE_KEY")
@@ -135,6 +147,10 @@ tasks.named<JacocoReport>("jacocoTestReport") {
         csv.required.set(false)
         html.required.set(false)
     }
+}
+
+tasks.named<SpotBugsTask>("spotbugsMain") {
+    dependsOn(verifyCoreJar)
 }
 
 tasks.named("pluginUnderTestMetadata") {

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -54,9 +54,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private final Provider<RegularFile> defaultJunitReport;
     private final Provider<RegularFile> executionMarker;
-    private final RegularFileProperty junitReportState;
-    private final RegularFileProperty outputState;
-    private final RegularFileProperty stateLock;
+    private final Provider<RegularFile> junitReportState;
+    private final Provider<RegularFile> outputState;
+    private final Provider<RegularFile> stateLock;
     private final List<Provider<Directory>> internalExecutionMarkerRootProviders;
     private final List<Path> internalRememberedStateRootPaths;
     private final Provider<String> absentString;
@@ -70,12 +70,9 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .flatMap(path -> getProject().getLayout().getBuildDirectory().file(path));
         executionMarker = getProject().getLayout().getBuildDirectory()
                 .file("tmp/crap-java/" + getName() + "/execution.marker");
-        junitReportState = getProject().getObjects().fileProperty();
-        junitReportState.fileValue(localStateFile("junit-report.path"));
-        outputState = getProject().getObjects().fileProperty();
-        outputState.fileValue(localStateFile("primary-output.path"));
-        stateLock = getProject().getObjects().fileProperty();
-        stateLock.fileValue(globalStateFile("state.lock"));
+        junitReportState = localStateFileProvider("junit-report.path");
+        outputState = localStateFileProvider("primary-output.path");
+        stateLock = globalStateFileProvider("state.lock");
         internalExecutionMarkerRootProviders = getProject().getRootProject().getAllprojects().stream()
                 .map(project -> project.getLayout().getBuildDirectory().dir("tmp/crap-java"))
                 .toList();
@@ -202,7 +199,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             @Nullable Path configuredJunitReportPath
     ) throws Exception {
         Path lockPath = stateLockPath();
-        Files.createDirectories(lockPath.getParent());
+        Files.createDirectories(Objects.requireNonNull(lockPath.getParent()));
         try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
              FileLock ignored = channel.lock()) {
             return runAndRememberReports(
@@ -465,8 +462,16 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private boolean caseVariantExists(Path probe) {
-        Path variant = probe.resolveSibling(probe.getFileName().toString().toUpperCase(Locale.ROOT));
-        return !probe.getFileName().toString().equals(variant.getFileName().toString()) && Files.exists(variant);
+        Path fileName = probe.getFileName();
+        if (fileName == null) {
+            return false;
+        }
+        String name = fileName.toString();
+        Path variant = probe.resolveSibling(name.toUpperCase(Locale.ROOT));
+        Path variantFileName = variant.getFileName();
+        return variantFileName != null
+                && !name.equals(variantFileName.toString())
+                && Files.exists(variant);
     }
 
     static boolean isLikelyCaseInsensitiveOs() {
@@ -555,7 +560,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
 
     private void writeExecutionMarker() throws Exception {
         Path markerPath = executionMarkerPath();
-        Files.createDirectories(markerPath.getParent());
+        Files.createDirectories(Objects.requireNonNull(markerPath.getParent()));
         Files.writeString(markerPath, "ok\n");
     }
 
@@ -740,7 +745,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private void rememberReportPath(Path statePath, Path reportPath) throws Exception {
-        Files.createDirectories(statePath.getParent());
+        Files.createDirectories(Objects.requireNonNull(statePath.getParent()));
         Path ownerLink = ownerLinkPath(statePath);
         Files.deleteIfExists(ownerLink);
         String ownership = ownership(reportPath, ownerLink);
@@ -782,7 +787,7 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private Path ownerLinkPath(Path statePath) {
-        String fileName = statePath.getFileName().toString();
+        String fileName = Objects.requireNonNull(statePath.getFileName()).toString();
         String ownerFileName = fileName.endsWith(".path")
                 ? fileName.substring(0, fileName.length() - ".path".length()) + ".owner"
                 : fileName + ".owner";
@@ -844,6 +849,14 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
                 .toPath()
                 .toAbsolutePath()
                 .normalize();
+    }
+
+    private Provider<RegularFile> localStateFileProvider(String fileName) {
+        return getProject().getLayout().file(getProject().getProviders().provider(() -> localStateFile(fileName)));
+    }
+
+    private Provider<RegularFile> globalStateFileProvider(String fileName) {
+        return getProject().getLayout().file(getProject().getProviders().provider(() -> globalStateFile(fileName)));
     }
 
     private File localStateFile(String fileName) {
@@ -948,8 +961,13 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
     }
 
     private boolean sameFileName(Path first, Path second, @Nullable Path parent) {
-        String firstName = first.getFileName().toString();
-        String secondName = second.getFileName().toString();
+        Path firstFileName = first.getFileName();
+        Path secondFileName = second.getFileName();
+        if (firstFileName == null || secondFileName == null) {
+            return false;
+        }
+        String firstName = firstFileName.toString();
+        String secondName = secondFileName.toString();
         return firstName.equals(secondName) || sameCaseInsensitiveFileName(firstName, secondName, parent);
     }
 

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -466,12 +466,20 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         if (fileName == null) {
             return false;
         }
-        String name = fileName.toString();
+        return caseVariantExists(probe, fileName.toString());
+    }
+
+    private boolean caseVariantExists(Path probe, String name) {
         Path variant = probe.resolveSibling(name.toUpperCase(Locale.ROOT));
         Path variantFileName = variant.getFileName();
-        return variantFileName != null
-                && !name.equals(variantFileName.toString())
-                && Files.exists(variant);
+        if (variantFileName == null) {
+            return false;
+        }
+        return differentExistingVariant(name, variantFileName.toString(), variant);
+    }
+
+    private boolean differentExistingVariant(String name, String variantName, Path variant) {
+        return !name.equals(variantName) && Files.exists(variant);
     }
 
     static boolean isLikelyCaseInsensitiveOs() {

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,8 @@
     <errorprone.version>2.49.0</errorprone.version>
     <nullaway.version>0.13.4</nullaway.version>
     <nullaway.annotated.packages>media.barney.crap</nullaway.annotated.packages>
+    <spotbugs.version>4.9.8</spotbugs.version>
+    <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
     <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
     <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
     <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
@@ -237,6 +239,33 @@
               <execution>
                 <id>cognitive-java-check</id>
                 <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>quality-gate-spotbugs</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <version>${spotbugs.maven.plugin.version}</version>
+            <configuration>
+              <effort>Max</effort>
+              <threshold>Medium</threshold>
+              <failThreshold>Medium</failThreshold>
+            </configuration>
+            <executions>
+              <execution>
+                <id>spotbugs-check</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>spotbugs</goal>
                   <goal>check</goal>
                 </goals>
               </execution>


### PR DESCRIPTION
## Summary
- add granular SpotBugs CI jobs for core, cli, gradle-plugin, and maven-plugin
- add the Maven and Gradle SpotBugs wiring needed for the new quality gates
- fix SpotBugs findings in core path handling, immutable accessors, and the Gradle task state helpers

## Validation
- `mvn -B -ntp -P!quality-gates-all verify`
- `mvn -B -ntp "-P!quality-gates-all,quality-gate-spotbugs" -DskipTests verify`
- `gradle-plugin\\gradlew.bat spotbugsMain`

Closes #179
