### PR TITLE
chore(deps): update compatible cognitive-java dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cognitive-java.version>0.5.1</cognitive-java.version>
     <jacoco.version>0.8.14</jacoco.version>
-    <junit.version>6.1.0</junit.version>
+    <junit.version>6.0.3</junit.version>
     <jspecify.version>1.0.0</jspecify.version>
     <jtoon.version>1.0.9</jtoon.version>
     <jackson.version>2.21.3</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cognitive-java.version>0.4.0</cognitive-java.version>
+    <cognitive-java.version>0.5.1</cognitive-java.version>
     <jacoco.version>0.8.14</jacoco.version>
-    <junit.version>6.0.3</junit.version>
+    <junit.version>6.1.0</junit.version>
     <jspecify.version>1.0.0</jspecify.version>
     <jtoon.version>1.0.9</jtoon.version>
     <jackson.version>2.21.3</jackson.version>


### PR DESCRIPTION
Closes #188

## Summary

- Updates the Maven-side `cognitive-java.version` from 0.4.0 to 0.5.1.
- Keeps JUnit at 6.0.3 because the attempted 6.1.0 bump failed the repository's offline CI test phase.
- Leaves Gradle-plugin wrapper/Jacoco updates for a separate validation-cleanup task because `gradle-plugin\gradlew.bat check` currently fails in existing `spotbugsTest` findings.

## Validation

- `mvn -B verify`

## Review Notes

- Dependency-only change; Java 17 runtime floor is unchanged.
- Latest-compatible versions were selected over latest-absolute releases where CI or validation gates required it.