### PR TITLE
Handle coverage collisions as unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Machine-readable primary reports include top-level `status` (`passed` or
 `crap`, `cc`, `cov`, `covKind`, `method`, `src`, `lineStart`, and `lineEnd`.
 `src` is the project-relative source file path. `coverageKind` identifies the
 coverage input used for each CRAP score (`instruction`, `branch`, or `N/A`).
+`N/A` also covers methods whose JaCoCo coverage cannot be attributed
+unambiguously to one source method.
 Full primary reports also include exclusion audit counts when any source was
 considered; optimized primary reports produced through `--agent` omit that audit
 detail by default to stay focused on actionable failures. The JUnit sidecar

--- a/core/src/main/java/media/barney/crap/core/CoverageIndex.java
+++ b/core/src/main/java/media/barney/crap/core/CoverageIndex.java
@@ -1,0 +1,106 @@
+package media.barney.crap.core;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+final class CoverageIndex {
+
+    private final Map<String, CoverageBucket> coverageByKey;
+
+    private CoverageIndex(Map<String, CoverageBucket> coverageByKey) {
+        this.coverageByKey = Collections.unmodifiableMap(new LinkedHashMap<>(coverageByKey));
+    }
+
+    static CoverageIndex empty() {
+        return new CoverageIndex(Map.of());
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    @Nullable EffectiveCoverage lookupCoverage(String className, String methodName, int line) {
+        CoverageBucket exact = coverageByKey.get(key(className, methodName, line));
+        if (exact != null) {
+            return exact.effectiveCoverage();
+        }
+        return nearestCoverage(className, methodName, line);
+    }
+
+    @Nullable EffectiveCoverage nearestCoverage(String className, String methodName, int line) {
+        String prefix = String.format(Locale.ROOT, "%s#%s:", className, methodName);
+        CoverageBucket nearest = null;
+        int nearestDistance = Integer.MAX_VALUE;
+        for (Map.Entry<String, CoverageBucket> entry : coverageByKey.entrySet()) {
+            String entryKey = entry.getKey();
+            if (!entryKey.startsWith(prefix)) {
+                continue;
+            }
+            int jacocoLine = parseTrailingLine(entryKey);
+            int distance = Math.abs(jacocoLine - line);
+            if (distance < nearestDistance) {
+                nearestDistance = distance;
+                nearest = entry.getValue();
+            }
+        }
+        if (nearest == null) {
+            return null;
+        }
+        return nearest.effectiveCoverage();
+    }
+
+    int entryCount(String className, String methodName, int line) {
+        CoverageBucket bucket = coverageByKey.get(key(className, methodName, line));
+        return bucket == null ? 0 : bucket.count();
+    }
+
+    static int parseTrailingLine(String key) {
+        int separator = key.lastIndexOf(':');
+        if (separator < 0) {
+            return Integer.MAX_VALUE;
+        }
+        String lineText = key.substring(separator + 1);
+        if (lineText.isEmpty()) {
+            return Integer.MAX_VALUE;
+        }
+        try {
+            return Integer.parseInt(lineText);
+        } catch (NumberFormatException ex) {
+            return Integer.MAX_VALUE;
+        }
+    }
+
+    private static String key(String className, String methodName, int line) {
+        return String.format(Locale.ROOT, "%s#%s:%d", className, methodName, line);
+    }
+
+    static final class Builder {
+        private final Map<String, CoverageBucket> coverageByKey = new LinkedHashMap<>();
+
+        void add(String className, String methodName, int line, CoverageData data) {
+            coverageByKey.compute(key(className, methodName, line),
+                    (ignored, existing) -> existing == null ? new CoverageBucket(data, 1) : existing.addDuplicate());
+        }
+
+        CoverageIndex build() {
+            return new CoverageIndex(coverageByKey);
+        }
+    }
+
+    private record CoverageBucket(CoverageData data, int count) {
+
+        private CoverageBucket addDuplicate() {
+            return new CoverageBucket(data, count + 1);
+        }
+
+        private @Nullable EffectiveCoverage effectiveCoverage() {
+            if (count > 1) {
+                return null;
+            }
+            return data.effectiveCoverage();
+        }
+    }
+}

--- a/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
+++ b/core/src/main/java/media/barney/crap/core/CrapAnalyzer.java
@@ -7,10 +7,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.jspecify.annotations.Nullable;
 
 final class CrapAnalyzer {
 
@@ -32,7 +30,7 @@ final class CrapAnalyzer {
                                        Path jacocoXml,
                                        SourceExclusionMatcher exclusions,
                                        SourceExclusionAudit.Builder audit) throws IOException {
-        Map<String, CoverageData> coverageMap = JacocoCoverageParser.parse(jacocoXml);
+        CoverageIndex coverageIndex = JacocoCoverageParser.parse(jacocoXml);
         List<MethodMetrics> metrics = new ArrayList<>();
         Set<String> excludedClasses = new LinkedHashSet<>();
         Path normalizedProjectRoot = projectRoot.toAbsolutePath().normalize();
@@ -41,7 +39,7 @@ final class CrapAnalyzer {
             analyzeFile(
                     file,
                     normalizedProjectRoot,
-                    coverageMap,
+                    coverageIndex,
                     exclusions,
                     audit,
                     excludedClasses,
@@ -60,7 +58,7 @@ final class CrapAnalyzer {
 
     private static void analyzeFile(Path file,
                                     Path projectRoot,
-                                    Map<String, CoverageData> coverageMap,
+                                    CoverageIndex coverageIndex,
                                     SourceExclusionMatcher exclusions,
                                     SourceExclusionAudit.Builder audit,
                                     Set<String> excludedClasses,
@@ -73,14 +71,14 @@ final class CrapAnalyzer {
         Path fileName = file.getFileName();
         String sourceName = fileName == null ? normalizedFile.toString() : fileName.toString();
         for (MethodDescriptor method : JavaMethodParser.parse(sourceName, source)) {
-            addMetricIfIncluded(method, projectRoot, normalizedFile, coverageMap, exclusions, audit, excludedClasses, metrics);
+            addMetricIfIncluded(method, projectRoot, normalizedFile, coverageIndex, exclusions, audit, excludedClasses, metrics);
         }
     }
 
     private static void addMetricIfIncluded(MethodDescriptor method,
                                             Path projectRoot,
                                             Path file,
-                                            Map<String, CoverageData> coverageMap,
+                                            CoverageIndex coverageIndex,
                                             SourceExclusionMatcher exclusions,
                                             SourceExclusionAudit.Builder audit,
                                             Set<String> excludedClasses,
@@ -90,7 +88,7 @@ final class CrapAnalyzer {
             recordExcludedClass(method, classExclusion.get(), audit, excludedClasses);
             return;
         }
-        metrics.add(methodMetric(method, projectRoot, file, coverageMap));
+        metrics.add(methodMetric(method, projectRoot, file, coverageIndex));
     }
 
     private static void recordExcludedClass(MethodDescriptor method,
@@ -105,8 +103,8 @@ final class CrapAnalyzer {
     private static MethodMetrics methodMetric(MethodDescriptor method,
                                               Path projectRoot,
                                               Path file,
-                                              Map<String, CoverageData> coverageMap) {
-        EffectiveCoverage coverage = lookupCoverage(coverageMap, method.className(), method.name(), method.startLine());
+                                              CoverageIndex coverageIndex) {
+        EffectiveCoverage coverage = coverageIndex.lookupCoverage(method.className(), method.name(), method.startLine());
         Double coveragePercent = coverage == null ? null : coverage.percent();
         String coverageKind = coverage == null ? CoverageData.UNAVAILABLE_KIND : coverage.kind();
         Double crap = CrapScore.calculate(method.complexity(), coveragePercent);
@@ -126,72 +124,6 @@ final class CrapAnalyzer {
     private static String sourcePath(Path projectRoot, Path file) {
         Path path = file.startsWith(projectRoot) ? projectRoot.relativize(file) : file;
         return path.normalize().toString().replace('\\', '/');
-    }
-
-    static @Nullable EffectiveCoverage lookupCoverage(Map<String, CoverageData> coverageMap,
-                                                      String className,
-                                                      String methodName,
-                                                      int line) {
-        EffectiveCoverage exactCoverage = exactCoverage(coverageMap, className, methodName, line);
-        if (exactCoverage != null) {
-            return exactCoverage;
-        }
-
-        CoverageData nearest = nearestCoverage(coverageMap, className, methodName, line);
-        if (nearest == null) {
-            return null;
-        }
-        return nearest.effectiveCoverage();
-    }
-
-    static @Nullable EffectiveCoverage exactCoverage(Map<String, CoverageData> coverageMap,
-                                                     String className,
-                                                     String methodName,
-                                                     int line) {
-        String exactKey = className + "#" + methodName + ":" + line;
-        CoverageData exact = coverageMap.get(exactKey);
-        if (exact == null) {
-            return null;
-        }
-        return exact.effectiveCoverage();
-    }
-
-    static @Nullable CoverageData nearestCoverage(Map<String, CoverageData> coverageMap,
-                                                  String className,
-                                                  String methodName,
-                                                  int line) {
-        String prefix = className + "#" + methodName + ":";
-        CoverageData nearest = null;
-        int nearestDistance = Integer.MAX_VALUE;
-        for (Map.Entry<String, CoverageData> entry : coverageMap.entrySet()) {
-            String key = entry.getKey();
-            if (!key.startsWith(prefix)) {
-                continue;
-            }
-            int jacocoLine = parseTrailingLine(key);
-            int distance = Math.abs(jacocoLine - line);
-            if (distance < nearestDistance) {
-                nearestDistance = distance;
-                nearest = entry.getValue();
-            }
-        }
-        return nearest;
-    }
-
-    static int parseTrailingLine(String key) {
-        int separator = key.lastIndexOf(':');
-        if (separator < 0) {
-            return Integer.MAX_VALUE;
-        }
-        String lineText = key.substring(separator + 1);
-        if (lineText.isEmpty()) {
-            return Integer.MAX_VALUE;
-        }
-        try {
-            return Integer.parseInt(lineText);
-        } catch (NumberFormatException ex) {
-            return Integer.MAX_VALUE;
-        }
     }
 }
 

--- a/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
+++ b/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
@@ -8,11 +8,9 @@ import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.XMLConstants;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
-import java.io.StringReader;
 import org.jspecify.annotations.Nullable;
 
 final class JacocoCoverageParser {
@@ -20,9 +18,9 @@ final class JacocoCoverageParser {
     private JacocoCoverageParser() {
     }
 
-    static Map<String, CoverageData> parse(@Nullable Path jacocoXmlPath) {
+    static CoverageIndex parse(@Nullable Path jacocoXmlPath) {
         if (jacocoXmlPath == null || !Files.exists(jacocoXmlPath)) {
-            return Map.of();
+            return CoverageIndex.empty();
         }
 
         try {
@@ -33,7 +31,7 @@ final class JacocoCoverageParser {
 
             Document document = builder.parse(jacocoXmlPath.toFile());
             NodeList classes = document.getElementsByTagName("class");
-            Map<String, CoverageData> coverage = new HashMap<>();
+            CoverageIndex.Builder coverage = CoverageIndex.builder();
 
             for (int i = 0; i < classes.getLength(); i++) {
                 Element classNode = (Element) classes.item(i);
@@ -41,7 +39,7 @@ final class JacocoCoverageParser {
                 readClassMethods(classNode, className, coverage);
             }
 
-            return coverage;
+            return coverage.build();
         } catch (Exception ex) {
             throw new IllegalStateException("Unable to parse JaCoCo XML: " + jacocoXmlPath, ex);
         }
@@ -61,7 +59,7 @@ final class JacocoCoverageParser {
         return factory;
     }
 
-    private static void readClassMethods(Element classNode, String className, Map<String, CoverageData> coverage) {
+    private static void readClassMethods(Element classNode, String className, CoverageIndex.Builder coverage) {
         for (Node node = classNode.getFirstChild(); node != null; node = node.getNextSibling()) {
             if (!(node instanceof Element method) || !"method".equals(method.getTagName())) {
                 continue;
@@ -72,8 +70,7 @@ final class JacocoCoverageParser {
             }
             String methodName = method.getAttribute("name");
             int line = parseInt("line", method.getAttribute("line"));
-            String key = className + "#" + methodName + ":" + line;
-            coverage.put(key, data);
+            coverage.add(className, methodName, line, data);
         }
     }
 

--- a/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
+++ b/core/src/test/java/media/barney/crap/core/CrapAnalyzerTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -368,13 +367,100 @@ class CrapAnalyzerTest {
     }
 
     @Test
+    void sameLineOverloadCoverageCollisionsAreSkippedAsUnavailable() throws IOException {
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+                class Sample {
+                    int sum(int a, int b) { return a + b; } int sum(double a, double b) { return (int) (a + b); }
+                }
+                """);
+
+        Path jacoco = tempDir.resolve("jacoco.xml");
+        Files.writeString(jacoco, """
+                <report>
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="sum" desc="(II)I" line="3">
+                        <counter type="INSTRUCTION" missed="1" covered="3"/>
+                      </method>
+                      <method name="sum" desc="(DD)I" line="3">
+                        <counter type="INSTRUCTION" missed="0" covered="8"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        List<MethodMetrics> result = CrapAnalyzer.analyze(tempDir, List.of(source), jacoco);
+
+        assertEquals(2, result.size());
+        for (MethodMetrics metric : result) {
+            assertEquals("sum", metric.methodName());
+            assertEquals(3, metric.startLine());
+            assertNull(metric.coveragePercent());
+            assertEquals("N/A", metric.coverageKind());
+            assertNull(metric.crapScore());
+        }
+    }
+
+    @Test
+    void overloadsOnDifferentLinesKeepUniqueCoverage() throws IOException {
+        Path sourceRoot = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceRoot);
+        Path source = sourceRoot.resolve("Sample.java");
+        Files.writeString(source, """
+                package demo;
+
+                class Sample {
+                    int sum(int a, int b) {
+                        return a + b;
+                    }
+
+                    int sum(double a, double b) {
+                        return (int) (a + b);
+                    }
+                }
+                """);
+
+        Path jacoco = tempDir.resolve("jacoco.xml");
+        Files.writeString(jacoco, """
+                <report>
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="sum" desc="(II)I" line="4">
+                        <counter type="INSTRUCTION" missed="1" covered="3"/>
+                      </method>
+                      <method name="sum" desc="(DD)I" line="8">
+                        <counter type="INSTRUCTION" missed="1" covered="9"/>
+                        <counter type="BRANCH" missed="1" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        Map<Integer, MethodMetrics> metricsByLine = CrapAnalyzer.analyze(tempDir, List.of(source), jacoco).stream()
+                .collect(java.util.stream.Collectors.toMap(MethodMetrics::startLine, Function.identity()));
+
+        MethodMetrics intOverload = Objects.requireNonNull(metricsByLine.get(4));
+        assertEquals(75.0, Objects.requireNonNull(intOverload.coveragePercent()), 0.001);
+        assertEquals("instruction", intOverload.coverageKind());
+        MethodMetrics doubleOverload = Objects.requireNonNull(metricsByLine.get(8));
+        assertEquals(50.0, Objects.requireNonNull(doubleOverload.coveragePercent()), 0.001);
+        assertEquals("branch", doubleOverload.coverageKind());
+    }
+
+    @Test
     void lookupCoveragePrefersExactLineBeforeNearestMatch() {
-        Map<String, CoverageData> coverageMap = Map.of(
-                "demo.Sample#alpha:10", new CoverageData(1, 3),
-                "demo.Sample#alpha:12", new CoverageData(0, 8)
+        CoverageIndex coverageIndex = coverageIndex(
+                entry("alpha", 10, new CoverageData(1, 3)),
+                entry("alpha", 12, new CoverageData(0, 8))
         );
 
-        EffectiveCoverage coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 10);
+        EffectiveCoverage coverage = coverageIndex.lookupCoverage("demo.Sample", "alpha", 10);
 
         assertEquals(75.0, Objects.requireNonNull(coverage).percent(), 0.001);
         assertEquals("instruction", coverage.kind());
@@ -382,12 +468,12 @@ class CrapAnalyzerTest {
 
     @Test
     void lookupCoverageFallsBackToNearestLineWithinMethod() {
-        Map<String, CoverageData> coverageMap = Map.of(
-                "demo.Sample#alpha:10", new CoverageData(1, 3),
-                "demo.Sample#alpha:15", new CoverageData(0, 8)
+        CoverageIndex coverageIndex = coverageIndex(
+                entry("alpha", 10, new CoverageData(1, 3)),
+                entry("alpha", 15, new CoverageData(0, 8))
         );
 
-        EffectiveCoverage coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 13);
+        EffectiveCoverage coverage = coverageIndex.lookupCoverage("demo.Sample", "alpha", 13);
 
         assertEquals(100.0, Objects.requireNonNull(coverage).percent(), 0.001);
         assertEquals("instruction", coverage.kind());
@@ -395,11 +481,9 @@ class CrapAnalyzerTest {
 
     @Test
     void lookupCoverageReturnsBranchKindWhenBranchCoverageIsWorse() {
-        Map<String, CoverageData> coverageMap = Map.of(
-                "demo.Sample#alpha:10", new CoverageData(1, 9, 1, 1)
-        );
+        CoverageIndex coverageIndex = coverageIndex(entry("alpha", 10, new CoverageData(1, 9, 1, 1)));
 
-        EffectiveCoverage coverage = CrapAnalyzer.lookupCoverage(coverageMap, "demo.Sample", "alpha", 10);
+        EffectiveCoverage coverage = coverageIndex.lookupCoverage("demo.Sample", "alpha", 10);
 
         assertEquals(50.0, Objects.requireNonNull(coverage).percent(), 0.001);
         assertEquals("branch", coverage.kind());
@@ -407,37 +491,38 @@ class CrapAnalyzerTest {
 
     @Test
     void nearestCoverageKeepsFirstEntryWhenDistancesTie() {
-        Map<String, CoverageData> coverageMap = new LinkedHashMap<>();
-        coverageMap.put("demo.Sample#alpha:10", new CoverageData(1, 3));
-        coverageMap.put("demo.Sample#alpha:14", new CoverageData(0, 8));
+        CoverageIndex coverageIndex = coverageIndex(
+                entry("alpha", 10, new CoverageData(1, 3)),
+                entry("alpha", 14, new CoverageData(0, 8))
+        );
 
-        CoverageData nearest = Objects.requireNonNull(CrapAnalyzer.nearestCoverage(coverageMap, "demo.Sample", "alpha", 12));
+        EffectiveCoverage nearest = Objects.requireNonNull(coverageIndex.nearestCoverage("demo.Sample", "alpha", 12));
 
-        assertEquals(75.0, nearest.coveragePercent(), 0.001);
+        assertEquals(75.0, nearest.percent(), 0.001);
     }
 
     @Test
     void lookupCoverageReturnsNullWhenMethodHasNoCoverageEntries() {
-        EffectiveCoverage coverage = CrapAnalyzer.lookupCoverage(Map.of(), "demo.Sample", "alpha", 10);
+        EffectiveCoverage coverage = CoverageIndex.empty().lookupCoverage("demo.Sample", "alpha", 10);
 
         assertNull(coverage);
     }
 
     @Test
     void parseTrailingLineReturnsMaxValueForMalformedKeys() {
-        assertEquals(Integer.MAX_VALUE, CrapAnalyzer.parseTrailingLine("demo.Sample#alpha"));
-        assertEquals(Integer.MAX_VALUE, CrapAnalyzer.parseTrailingLine("demo.Sample#alpha:"));
-        assertEquals(Integer.MAX_VALUE, CrapAnalyzer.parseTrailingLine("demo.Sample#alpha:oops"));
+        assertEquals(Integer.MAX_VALUE, CoverageIndex.parseTrailingLine("demo.Sample#alpha"));
+        assertEquals(Integer.MAX_VALUE, CoverageIndex.parseTrailingLine("demo.Sample#alpha:"));
+        assertEquals(Integer.MAX_VALUE, CoverageIndex.parseTrailingLine("demo.Sample#alpha:oops"));
     }
 
     @Test
     void parseTrailingLineReturnsParsedLineNumberForValidKey() {
-        assertEquals(10, CrapAnalyzer.parseTrailingLine("demo.Sample#alpha:10"));
+        assertEquals(10, CoverageIndex.parseTrailingLine("demo.Sample#alpha:10"));
     }
 
     @Test
     void parseTrailingLineAcceptsLeadingSeparator() {
-        assertEquals(10, CrapAnalyzer.parseTrailingLine(":10"));
+        assertEquals(10, CoverageIndex.parseTrailingLine(":10"));
     }
 
     @Test
@@ -542,6 +627,21 @@ class CrapAnalyzerTest {
 
         assertEquals(List.of("zeta", "omega", "beta"),
                 result.stream().map(MethodMetrics::methodName).toList());
+    }
+
+    private static CoverageEntry entry(String methodName, int line, CoverageData coverage) {
+        return new CoverageEntry(methodName, line, coverage);
+    }
+
+    private static CoverageIndex coverageIndex(CoverageEntry... entries) {
+        CoverageIndex.Builder builder = CoverageIndex.builder();
+        for (CoverageEntry entry : entries) {
+            builder.add("demo.Sample", entry.methodName(), entry.line(), entry.coverage());
+        }
+        return builder.build();
+    }
+
+    private record CoverageEntry(String methodName, int line, CoverageData coverage) {
     }
 }
 

--- a/core/src/test/java/media/barney/crap/core/JacocoCoverageParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JacocoCoverageParserTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,12 +37,36 @@ class JacocoCoverageParserTest {
                 </report>
                 """);
 
-        Map<String, CoverageData> result = JacocoCoverageParser.parse(xml);
+        CoverageIndex result = JacocoCoverageParser.parse(xml);
 
-        assertEquals(90.0, Objects.requireNonNull(result.get("demo.Sample#alpha:10")).coveragePercent(), 0.001);
-        assertEquals("instruction", Objects.requireNonNull(result.get("demo.Sample#alpha:10")).coverageKind());
-        assertEquals(0.0, Objects.requireNonNull(result.get("demo.Sample#beta:20")).coveragePercent(), 0.001);
-        assertEquals("instruction", Objects.requireNonNull(result.get("demo.Sample#beta:20")).coverageKind());
+        assertEquals(90.0, coverage(result, "demo.Sample", "alpha", 10).percent(), 0.001);
+        assertEquals("instruction", coverage(result, "demo.Sample", "alpha", 10).kind());
+        assertEquals(0.0, coverage(result, "demo.Sample", "beta", 20).percent(), 0.001);
+        assertEquals("instruction", coverage(result, "demo.Sample", "beta", 20).kind());
+    }
+
+    @Test
+    void recordsDuplicateSourceCoordinateAsAmbiguous() throws IOException {
+        Path xml = tempDir.resolve("jacoco-duplicate-source-coordinate.xml");
+        Files.writeString(xml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="sum" desc="(II)I" line="10">
+                        <counter type="INSTRUCTION" missed="1" covered="9"/>
+                      </method>
+                      <method name="sum" desc="(DD)I" line="10">
+                        <counter type="INSTRUCTION" missed="9" covered="1"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        CoverageIndex result = JacocoCoverageParser.parse(xml);
+
+        assertEquals(2, result.entryCount("demo.Sample", "sum", 10));
+        assertNull(result.lookupCoverage("demo.Sample", "sum", 10));
     }
 
     @Test
@@ -62,10 +85,10 @@ class JacocoCoverageParserTest {
                 </report>
                 """);
 
-        CoverageData result = Objects.requireNonNull(JacocoCoverageParser.parse(xml).get("demo.Sample#alpha:10"));
+        EffectiveCoverage result = coverage(JacocoCoverageParser.parse(xml), "demo.Sample", "alpha", 10);
 
-        assertEquals(50.0, result.coveragePercent(), 0.001);
-        assertEquals("branch", result.coverageKind());
+        assertEquals(50.0, result.percent(), 0.001);
+        assertEquals("branch", result.kind());
     }
 
     @Test
@@ -84,10 +107,10 @@ class JacocoCoverageParserTest {
                 </report>
                 """);
 
-        CoverageData result = Objects.requireNonNull(JacocoCoverageParser.parse(xml).get("demo.Sample#alpha:10"));
+        EffectiveCoverage result = coverage(JacocoCoverageParser.parse(xml), "demo.Sample", "alpha", 10);
 
-        assertEquals(75.0, result.coveragePercent(), 0.001);
-        assertEquals("instruction", result.coverageKind());
+        assertEquals(75.0, result.percent(), 0.001);
+        assertEquals("instruction", result.kind());
     }
 
     @Test
@@ -106,10 +129,10 @@ class JacocoCoverageParserTest {
                 </report>
                 """);
 
-        CoverageData result = Objects.requireNonNull(JacocoCoverageParser.parse(xml).get("demo.Sample#alpha:10"));
+        EffectiveCoverage result = coverage(JacocoCoverageParser.parse(xml), "demo.Sample", "alpha", 10);
 
-        assertEquals(50.0, result.coveragePercent(), 0.001);
-        assertEquals("instruction", result.coverageKind());
+        assertEquals(50.0, result.percent(), 0.001);
+        assertEquals("instruction", result.kind());
     }
 
     @Test
@@ -128,10 +151,10 @@ class JacocoCoverageParserTest {
                 </report>
                 """);
 
-        CoverageData result = Objects.requireNonNull(JacocoCoverageParser.parse(xml).get("demo.Sample#alpha:10"));
+        EffectiveCoverage result = coverage(JacocoCoverageParser.parse(xml), "demo.Sample", "alpha", 10);
 
-        assertEquals(0.0, result.coveragePercent(), 0.001);
-        assertEquals("instruction", result.coverageKind());
+        assertEquals(0.0, result.percent(), 0.001);
+        assertEquals("instruction", result.kind());
     }
 
     @Test
@@ -149,9 +172,9 @@ class JacocoCoverageParserTest {
                 </report>
                 """);
 
-        Map<String, CoverageData> result = JacocoCoverageParser.parse(xml);
+        CoverageIndex result = JacocoCoverageParser.parse(xml);
 
-        assertNull(result.get("demo.Sample#alpha:10"));
+        assertNull(result.lookupCoverage("demo.Sample", "alpha", 10));
     }
 
     @Test
@@ -170,9 +193,9 @@ class JacocoCoverageParserTest {
                 </report>
                 """);
 
-        Map<String, CoverageData> result = JacocoCoverageParser.parse(xml);
+        CoverageIndex result = JacocoCoverageParser.parse(xml);
 
-        assertEquals(90.0, Objects.requireNonNull(result.get("demo.Sample#alpha:10")).coveragePercent(), 0.001);
+        assertEquals(90.0, coverage(result, "demo.Sample", "alpha", 10).percent(), 0.001);
     }
 
     @Test
@@ -232,6 +255,10 @@ class JacocoCoverageParserTest {
         assertEquals("", factory.getAttribute(javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA));
         assertFalse(factory.isXIncludeAware());
         assertFalse(factory.isExpandEntityReferences());
+    }
+
+    private static EffectiveCoverage coverage(CoverageIndex index, String className, String methodName, int line) {
+        return Objects.requireNonNull(index.lookupCoverage(className, methodName, line));
     }
 }
 


### PR DESCRIPTION
## Summary
- add an ambiguity-aware JaCoCo coverage index instead of overwriting duplicate source coordinates
- preserve exact-line and nearest-line lookup for unique matches
- report same-line overload coverage collisions through the existing skipped/`N/A` result shape
- document that `N/A` can include unambiguously unattributable JaCoCo coverage

## Verification
- `mvn -B -pl core -am test`
- `mvn -B verify`

Closes #111
