### PR TITLE
Exclude lambda bodies from source-method CRAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ and switch case clauses. Switch handling follows the javac AST: each
 in that clause. For example, `case A, B, C ->` contributes `1`, not `3`, and
 `default` also contributes `1`.
 
+Lambda bodies are not first-class report rows in the current source-first model.
+Their internal decision nodes are excluded from the enclosing source method's
+complexity, and javac synthetic JaCoCo methods named like `lambda$...$<digits>`
+are ignored during coverage attribution.
+
 ## Coverage Pipeline
 
 For each resolved module today:

--- a/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
+++ b/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
@@ -11,9 +11,11 @@ import javax.xml.XMLConstants;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
 
 final class JacocoCoverageParser {
+    private static final Pattern JAVAC_LAMBDA_METHOD = Pattern.compile("^lambda\\$.*\\$\\d+$");
 
     private JacocoCoverageParser() {
     }
@@ -64,11 +66,14 @@ final class JacocoCoverageParser {
             if (!(node instanceof Element method) || !"method".equals(method.getTagName())) {
                 continue;
             }
+            String methodName = method.getAttribute("name");
+            if (JAVAC_LAMBDA_METHOD.matcher(methodName).matches()) {
+                continue;
+            }
             CoverageData data = readCoverage(method);
             if (data == null) {
                 continue;
             }
-            String methodName = method.getAttribute("name");
             int line = parseInt("line", method.getAttribute("line"));
             coverage.add(className, methodName, line, data);
         }

--- a/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
+++ b/core/src/main/java/media/barney/crap/core/JavaMethodParser.java
@@ -10,6 +10,7 @@ import com.sun.source.tree.DoWhileLoopTree;
 import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ForLoopTree;
 import com.sun.source.tree.IfTree;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.WhileLoopTree;
@@ -220,6 +221,11 @@ final class JavaMethodParser {
 
         @Override
         public Void visitClass(ClassTree node, Void unused) {
+            return null;
+        }
+
+        @Override
+        public Void visitLambdaExpression(LambdaExpressionTree node, Void unused) {
             return null;
         }
 

--- a/core/src/test/java/media/barney/crap/core/JacocoCoverageParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JacocoCoverageParserTest.java
@@ -70,6 +70,30 @@ class JacocoCoverageParserTest {
     }
 
     @Test
+    void skipsSyntheticLambdaImplementationMethods() throws IOException {
+        Path xml = tempDir.resolve("jacoco-lambda.xml");
+        Files.writeString(xml, """
+                <report name="demo">
+                  <package name="demo">
+                    <class name="demo/Sample" sourcefilename="Sample.java">
+                      <method name="alpha" desc="()V" line="10">
+                        <counter type="INSTRUCTION" missed="1" covered="9"/>
+                      </method>
+                      <method name="lambda$alpha$0" desc="()V" line="11">
+                        <counter type="INSTRUCTION" missed="0" covered="10"/>
+                      </method>
+                    </class>
+                  </package>
+                </report>
+                """);
+
+        CoverageIndex result = JacocoCoverageParser.parse(xml);
+
+        assertEquals(90.0, coverage(result, "demo.Sample", "alpha", 10).percent(), 0.001);
+        assertNull(result.lookupCoverage("demo.Sample", "lambda$alpha$0", 11));
+    }
+
+    @Test
     void usesBranchCoverageWhenBranchCoverageIsWorse() throws IOException {
         Path xml = tempDir.resolve("jacoco-branch-worse.xml");
         Files.writeString(xml, """

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -102,6 +102,29 @@ class JavaMethodParserTest {
     }
 
     @Test
+    void excludesLambdaBodyComplexityFromEnclosingMethod() {
+        String source = """
+                class Sample {
+                    int outer(boolean flag) {
+                        if (flag) {
+                        }
+                        java.util.function.Predicate<String> predicate = value -> {
+                            if (value.isEmpty()) {
+                                return flag;
+                            }
+                            return value.length() > 1 && flag;
+                        };
+                        return flag ? 1 : 0;
+                    }
+                }
+                """;
+
+        List<MethodDescriptor> methods = JavaMethodParser.parse("Sample", source);
+
+        assertEquals(List.of(new MethodDescriptor("Sample", "outer", 2, 12, 3)), methods);
+    }
+
+    @Test
     void parsesMethodsWithoutResolvingSiblingTypes() {
         String source = """
                 package demo;


### PR DESCRIPTION
## Summary
- stop source-method complexity traversal at lambda bodies
- ignore javac synthetic JaCoCo lambda implementation rows named `lambda$...$<digits>`
- document that lambdas are not first-class report rows in the current source-first model

## Verification
- `mvn -B -pl core -am test`
- `mvn -B verify`

Closes #107
