### PR TITLE
Document anonymous class scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Their internal decision nodes are excluded from the enclosing source method's
 complexity, and javac synthetic JaCoCo methods named like `lambda$...$<digits>`
 are ignored during coverage attribution.
 
+Anonymous-class bodies are also outside the supported source-method scope.
+`crap-java` does not synthesize `$N` owners from source, does not report methods
+or nested declarations inside anonymous classes, and does not fold anonymous-body
+complexity into the enclosing source method.
+
 ## Coverage Pipeline
 
 For each resolved module today:

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -102,7 +102,7 @@ class JavaMethodParserTest {
     }
 
     @Test
-    void ignoresNestedAnonymousClassSubtrees() {
+    void ignoresDeclarationsInsideAnonymousClassBodies() {
         String source = """
                 class Sample {
                     int outer() {

--- a/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
+++ b/core/src/test/java/media/barney/crap/core/JavaMethodParserTest.java
@@ -102,6 +102,34 @@ class JavaMethodParserTest {
     }
 
     @Test
+    void ignoresNestedAnonymousClassSubtrees() {
+        String source = """
+                class Sample {
+                    int outer() {
+                        Object value = new Object() {
+                            class Nested {
+                                int nested() {
+                                    if (true) {
+                                    }
+                                    return 1;
+                                }
+                            }
+
+                            int local() {
+                                return 2;
+                            }
+                        };
+                        return 1;
+                    }
+                }
+                """;
+
+        List<MethodDescriptor> methods = JavaMethodParser.parse("Sample", source);
+
+        assertEquals(List.of(new MethodDescriptor("Sample", "outer", 2, 17, 1)), methods);
+    }
+
+    @Test
     void excludesLambdaBodyComplexityFromEnclosingMethod() {
         String source = """
                 class Sample {


### PR DESCRIPTION
## Summary
- document anonymous-class bodies as outside the supported source-method scope
- add parser regression coverage for anonymous-class subtrees, including nested declarations
- keep production behavior unchanged

## Verification
- `mvn -B -pl core -am test`
- `mvn -B verify`

Closes #105
