### PR TITLE
Prepare v0.6.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,40 @@ jobs:
           -Dcentral.skipPublishing=true
           -pl .,cli,maven-plugin -am deploy
 
+      - name: Create GitHub release draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v version="${version}" '
+            $1 == "##" && $2 == version {
+              found = 1
+            }
+            found {
+              if ($1 == "##" && $2 != version) {
+                exit
+              }
+              print
+            }
+            END {
+              if (!found) {
+                exit 1
+              }
+            }
+          ' CHANGELOG.md > release-notes.md
+          test -s release-notes.md
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            is_draft="$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq .isDraft)"
+            if [ "${is_draft}" != "true" ]; then
+              echo "GitHub release ${GITHUB_REF_NAME} already exists and is not a draft." >&2
+              exit 1
+            fi
+            gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md --draft
+          else
+            gh release create "${GITHUB_REF_NAME}" --verify-tag --draft --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+          fi
+
       - name: Publish Maven artifacts
         env:
           MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
@@ -90,34 +124,11 @@ jobs:
         working-directory: gradle-plugin
         run: ./gradlew publishPlugins -Pgradle.publish.key="${GRADLE_PUBLISH_KEY}" -Pgradle.publish.secret="${GRADLE_PUBLISH_SECRET}"
 
-      - name: Create GitHub release
+      - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          awk -v version="${version}" '
-            $1 == "##" && $2 == version {
-              found = 1
-            }
-            found {
-              if ($1 == "##" && $2 != version) {
-                exit
-              }
-              print
-            }
-            END {
-              if (!found) {
-                exit 1
-              }
-            }
-          ' CHANGELOG.md > release-notes.md
-          test -s release-notes.md
-          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
-          else
-            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
-          fi
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --latest
 
       - name: Clean up imported GPG home
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## 0.6.1 - 2026-06-01
+
+### Fixed
+
+- Stopped lambda-body decision nodes from inflating the enclosing source method's complexity and ignored javac synthetic lambda coverage methods during attribution.
+- Treated ambiguous same-line overload coverage collisions as unavailable instead of assigning coverage to the wrong source method.
+
+### Changed
+
+- Documented the current anonymous-class scope explicitly: anonymous-class methods are not reported as first-class rows and their body complexity is not folded into the enclosing method.
+- Expanded CI with granular NullAway and SpotBugs gates across modules, plus release-preflight cache priming for SpotBugs.
+
+### Dependencies
+
+- Updated compatible Java test and analysis tooling while keeping the JUnit version aligned with current CI compatibility.
+
 ## 0.6.0 - 2026-05-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ mvn -B -pl cli -am -DskipTests package
 From the project root you want to analyze:
 
 ```bash
-java -jar cli/target/crap-java-cli-0.6.0.jar
+java -jar cli/target/crap-java-cli-0.6.1.jar
 ```
 
 ## CLI
@@ -163,27 +163,27 @@ Value-taking long options may also be written with inline assignment, such as
 Examples:
 
 ```bash
-java -jar cli/target/crap-java-cli-0.6.0.jar --help
-java -jar cli/target/crap-java-cli-0.6.0.jar
-java -jar cli/target/crap-java-cli-0.6.0.jar --changed
-java -jar cli/target/crap-java-cli-0.6.0.jar --build-tool gradle
-java -jar cli/target/crap-java-cli-0.6.0.jar --build-tool=maven
-java -jar cli/target/crap-java-cli-0.6.0.jar --format json
-java -jar cli/target/crap-java-cli-0.6.0.jar --format none --junit-report target/crap-java/TEST-crap-java.xml
-java -jar cli/target/crap-java-cli-0.6.0.jar --format json --output target/crap-java/report.json
-java -jar cli/target/crap-java-cli-0.6.0.jar --failures-only=false --format json
-java -jar cli/target/crap-java-cli-0.6.0.jar --omit-redundancy=false --format json
-java -jar cli/target/crap-java-cli-0.6.0.jar --agent
-java -jar cli/target/crap-java-cli-0.6.0.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
-java -jar cli/target/crap-java-cli-0.6.0.jar --junit-report target/crap-java/TEST-crap-java.xml
-java -jar cli/target/crap-java-cli-0.6.0.jar --threshold 6
-java -jar cli/target/crap-java-cli-0.6.0.jar --threshold=6
-java -jar cli/target/crap-java-cli-0.6.0.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
-java -jar cli/target/crap-java-cli-0.6.0.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
-java -jar cli/target/crap-java-cli-0.6.0.jar --source-root src/java --source-root src/main/java17
-java -jar cli/target/crap-java-cli-0.6.0.jar --build-tool maven module-a/src/main/java/demo/Sample.java
-java -jar cli/target/crap-java-cli-0.6.0.jar src/main/java/demo/Sample.java
-java -jar cli/target/crap-java-cli-0.6.0.jar module-a module-b
+java -jar cli/target/crap-java-cli-0.6.1.jar --help
+java -jar cli/target/crap-java-cli-0.6.1.jar
+java -jar cli/target/crap-java-cli-0.6.1.jar --changed
+java -jar cli/target/crap-java-cli-0.6.1.jar --build-tool gradle
+java -jar cli/target/crap-java-cli-0.6.1.jar --build-tool=maven
+java -jar cli/target/crap-java-cli-0.6.1.jar --format json
+java -jar cli/target/crap-java-cli-0.6.1.jar --format none --junit-report target/crap-java/TEST-crap-java.xml
+java -jar cli/target/crap-java-cli-0.6.1.jar --format json --output target/crap-java/report.json
+java -jar cli/target/crap-java-cli-0.6.1.jar --failures-only=false --format json
+java -jar cli/target/crap-java-cli-0.6.1.jar --omit-redundancy=false --format json
+java -jar cli/target/crap-java-cli-0.6.1.jar --agent
+java -jar cli/target/crap-java-cli-0.6.1.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
+java -jar cli/target/crap-java-cli-0.6.1.jar --junit-report target/crap-java/TEST-crap-java.xml
+java -jar cli/target/crap-java-cli-0.6.1.jar --threshold 6
+java -jar cli/target/crap-java-cli-0.6.1.jar --threshold=6
+java -jar cli/target/crap-java-cli-0.6.1.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
+java -jar cli/target/crap-java-cli-0.6.1.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
+java -jar cli/target/crap-java-cli-0.6.1.jar --source-root src/java --source-root src/main/java17
+java -jar cli/target/crap-java-cli-0.6.1.jar --build-tool maven module-a/src/main/java/demo/Sample.java
+java -jar cli/target/crap-java-cli-0.6.1.jar src/main/java/demo/Sample.java
+java -jar cli/target/crap-java-cli-0.6.1.jar module-a module-b
 ```
 
 The CLI writes only the requested primary report format to stdout unless
@@ -244,12 +244,12 @@ rely on properties.
 
 ## Distribution
 
-The current `0.6.0` release ships through Maven Central, with the Gradle Plugin Portal as the primary Gradle plugin channel:
+The current `0.6.1` release ships through Maven Central, with the Gradle Plugin Portal as the primary Gradle plugin channel:
 
-- `media.barney:crap-java-core:0.6.0`
-- `media.barney:crap-java-cli:0.6.0`
-- `media.barney:crap-java-maven-plugin:0.6.0`
-- Gradle plugin id `media.barney.crap-java` version `0.6.0`
+- `media.barney:crap-java-core:0.6.1`
+- `media.barney:crap-java-cli:0.6.1`
+- `media.barney:crap-java-maven-plugin:0.6.1`
+- Gradle plugin id `media.barney.crap-java` version `0.6.1`
 
 ### Gradle Plugin Portal
 
@@ -257,7 +257,7 @@ Apply the plugin in `build.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("media.barney.crap-java") version "0.6.0"
+    id("media.barney.crap-java") version "0.6.1"
 }
 ```
 
@@ -313,14 +313,14 @@ Then apply the same plugin id in `build.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("media.barney.crap-java") version "0.6.0"
+    id("media.barney.crap-java") version "0.6.1"
 }
 ```
 
 The marker publication lives at
-`media.barney.crap-java:media.barney.crap-java.gradle.plugin:0.6.0` and
+`media.barney.crap-java:media.barney.crap-java.gradle.plugin:0.6.1` and
 resolves to the implementation artifact
-`media.barney:crap-java-gradle-plugin:0.6.0`.
+`media.barney:crap-java-gradle-plugin:0.6.1`.
 
 ### Maven Central
 
@@ -351,7 +351,7 @@ Add the plugin:
     <plugin>
       <groupId>media.barney</groupId>
       <artifactId>crap-java-maven-plugin</artifactId>
-      <version>0.6.0</version>
+      <version>0.6.1</version>
       <executions>
         <execution>
           <goals>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
   </parent>
 
   <artifactId>crap-java-cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
   </parent>
 
   <artifactId>crap-java-core</artifactId>

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = "media.barney"
-version = "0.6.0"
+version = "0.6.1"
 
 repositories {
     mavenCentral()

--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
   </parent>
 
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>media.barney</groupId>
   <artifactId>crap-java-parent</artifactId>
-  <version>0.6.0</version>
+  <version>0.6.1</version>
   <packaging>pom</packaging>
 
   <name>crap-java Parent</name>


### PR DESCRIPTION
## Summary
- prepare the `v0.6.1` patch release across Maven, Gradle, and consumer-facing docs
- add the `0.6.1` changelog entry for the fixes and maintenance merged since `v0.6.0`
- create the GitHub Release as a draft before public artifact publication, then promote it after Maven Central and Gradle Plugin Portal publication succeeds

## Review focus
- `.github/workflows/release.yml`: draft creation happens before public publish steps, and final release promotion happens last
- version alignment across Maven POMs, `gradle-plugin/build.gradle.kts`, README examples, and changelog

## Validation
- `C:\Program Files\Git\bin\bash.exe ./.github/scripts/verify-version-alignment.sh --expected-version 0.6.1`
- `git diff --check`
- `git grep -n -F "v0.6.0" -- .`
- `git grep -n -F "0.6.0" -- pom.xml core/pom.xml cli/pom.xml gradle-plugin/pom.xml maven-plugin/pom.xml gradle-plugin/build.gradle.kts README.md .github/workflows/release.yml`

## Residual risk
The actual registry publication still depends on the tag-triggered Release workflow and configured repository secrets.

Closes #193
