### PR TITLE
Reduce default CRAP threshold to 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,6 +224,7 @@ jobs:
           java -jar "$CLI_JAR" \
             --format none \
             --junit-report target/crap-java/TEST-crap-java-gradle-plugin.xml \
+            --threshold 8.0 \
             --build-tool gradle \
             gradle-plugin/src/main/java
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Reduced the default CRAP threshold from `8.0` to `6.0` while keeping the recommended `4.0` to `8.0` range unchanged.
+
 ## 0.6.1 - 2026-06-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ java -jar cli/target/crap-java-cli-0.6.1.jar
 --source-root <path>  Override production source roots; repeatable
 --output <path>       Write the selected output format to a file instead of stdout
 --junit-report <path> Also write a JUnit XML report for CI test-report UIs
---threshold <number>  Override the CRAP threshold (`8.0` by default)
+--threshold <number>  Override the CRAP threshold (`6.0` by default)
 <file ...>            Analyze only these files
 <directory ...>       Analyze all Java files under each directory's nested source roots
 ```
@@ -176,8 +176,8 @@ java -jar cli/target/crap-java-cli-0.6.1.jar --omit-redundancy=false --format js
 java -jar cli/target/crap-java-cli-0.6.1.jar --agent
 java -jar cli/target/crap-java-cli-0.6.1.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
 java -jar cli/target/crap-java-cli-0.6.1.jar --junit-report target/crap-java/TEST-crap-java.xml
-java -jar cli/target/crap-java-cli-0.6.1.jar --threshold 6
-java -jar cli/target/crap-java-cli-0.6.1.jar --threshold=6
+java -jar cli/target/crap-java-cli-0.6.1.jar --threshold 8
+java -jar cli/target/crap-java-cli-0.6.1.jar --threshold=8
 java -jar cli/target/crap-java-cli-0.6.1.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
 java -jar cli/target/crap-java-cli-0.6.1.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
 java -jar cli/target/crap-java-cli-0.6.1.jar --source-root src/java --source-root src/main/java17
@@ -277,7 +277,7 @@ Configure default report behavior in `build.gradle(.kts)`:
 
 ```kotlin
 crapJava {
-    threshold.set(6.0)
+    threshold.set(8.0)
     format.set("json")
     agent.set(false)
     failuresOnly.set(false)
@@ -388,7 +388,7 @@ mvn verify -DcrapJava.agent=true
 mvn verify -DcrapJava.failuresOnly=false -DcrapJava.omitRedundancy=true
 mvn verify -DcrapJava.junit=false
 mvn verify -DcrapJava.junitReport=target/custom-crap-java.xml
-mvn verify -DcrapJava.threshold=6.0
+mvn verify -DcrapJava.threshold=8.0
 mvn verify -DcrapJava.excludes='module-a/**,**/custom-generated/**'
 mvn verify -DcrapJava.excludeClasses='.*MapperImpl$' -DcrapJava.excludeAnnotations=Generated
 mvn verify -DcrapJava.useDefaultExclusions=false
@@ -415,7 +415,7 @@ mvn verify -DcrapJava.junitReport=target/custom-crap-java.xml
 Override the threshold with:
 
 ```bash
-mvn verify -DcrapJava.threshold=6.0
+mvn verify -DcrapJava.threshold=8.0
 ```
 
 In GitLab CI, upload the generated XML with `artifacts:reports:junit`. In

--- a/README.md
+++ b/README.md
@@ -277,7 +277,6 @@ Configure default report behavior in `build.gradle(.kts)`:
 
 ```kotlin
 crapJava {
-    threshold.set(8.0)
     format.set("json")
     agent.set(false)
     failuresOnly.set(false)

--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ Assigned boolean CLI values must be lowercase `true` or `false`; bare boolean fl
 `--junit-report <path>` always writes the complete unfiltered JUnit XML sidecar,
 and it can be combined with any primary format, including `none`.
 
-The default threshold is `8.0`. Values below `4.0` print a warning because they
+The default threshold is `6.0`. Values below `4.0` print a warning because they
 are likely too noisy; values above `8.0` print a warning because they are too
 lenient even for hard gates. The warning recommends `8.0` for hard gates,
-targeting `6.0` during implementation, and using the `8.0` default when in
+targeting `6.0` during implementation, and using the `6.0` default when in
 doubt.
 
 The JUnit XML format exposes each analyzed method as a testcase and is shaped

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -197,7 +197,7 @@ public final class Main {
                   crap-java --source-root src/java       Override production source roots, repeatable
                   crap-java --output report.toon          Write the selected report format to a file
                   crap-java --junit-report report.xml     Also write a JUnit XML report for CI
-                  crap-java --threshold 6                 Override the CRAP threshold (default: 8.0)
+                  crap-java --threshold 6                 Override the CRAP threshold (default: 6.0)
                   crap-java <path...>                     Analyze files, or for directory args analyze nested source roots under each path
                   crap-java --help                        Print this help message
 

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -197,7 +197,7 @@ public final class Main {
                   crap-java --source-root src/java       Override production source roots, repeatable
                   crap-java --output report.toon          Write the selected report format to a file
                   crap-java --junit-report report.xml     Also write a JUnit XML report for CI
-                  crap-java --threshold 6                 Override the CRAP threshold (default: 6.0)
+                  crap-java --threshold 8                 Override the CRAP threshold (default: 6.0)
                   crap-java <path...>                     Analyze files, or for directory args analyze nested source roots under each path
                   crap-java --help                        Print this help message
 

--- a/core/src/main/java/media/barney/crap/core/Thresholds.java
+++ b/core/src/main/java/media/barney/crap/core/Thresholds.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 
 final class Thresholds {
 
-    static final double DEFAULT = 8.0;
+    static final double DEFAULT = 6.0;
     // Keep the warning boundary independent from the recommended default.
     private static final double TOO_LENIENT_BOUNDARY = 8.0;
 
@@ -56,6 +56,6 @@ final class Thresholds {
 
     private static String recommendation() {
         return "Use 8.0 for hard gates, target 6.0 during implementation, "
-                + "and use the 8.0 default when in doubt.";
+                + "and use the 6.0 default when in doubt.";
     }
 }

--- a/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
+++ b/core/src/test/java/media/barney/crap/core/CliApplicationTest.java
@@ -334,7 +334,7 @@ class CliApplicationTest {
         assertTrue(utf8(noisyErr).contains("threshold below 4.0 is likely too noisy"));
         assertTrue(utf8(noisyErr).contains("Use 8.0 for hard gates, target 6.0 during implementation"));
         assertTrue(utf8(lenientErr).contains("threshold above 8.0 is too lenient even for hard gates"));
-        assertTrue(utf8(lenientErr).contains("8.0 default when in doubt"));
+        assertTrue(utf8(lenientErr).contains("6.0 default when in doubt"));
     }
 
     @Test

--- a/core/src/test/java/media/barney/crap/core/MainTest.java
+++ b/core/src/test/java/media/barney/crap/core/MainTest.java
@@ -351,7 +351,7 @@ class MainTest {
         assertEquals(2, exit);
         assertEquals("", utf8(out));
         assertTrue(primary.contains("\"status\": \"failed\""));
-        assertTrue(primary.contains("\"threshold\": 8.0"));
+        assertTrue(primary.contains("\"threshold\": 6.0"));
         assertFalse(primary.contains("      \"status\":"));
         assertTrue(primary.contains("\"method\": \"danger\""));
         assertFalse(primary.contains("\"method\": \"safe\""));
@@ -421,7 +421,7 @@ class MainTest {
         assertEquals(2, exit);
         assertEquals("", utf8(out));
         assertTrue(primary.contains("\"status\": \"failed\""));
-        assertTrue(primary.contains("\"threshold\": 8.0"));
+        assertTrue(primary.contains("\"threshold\": 6.0"));
         assertTrue(primary.contains("\"method\": \"danger\""));
         assertFalse(primary.contains("\"method\": \"safe\""));
         assertFalse(primary.contains("\"method\": \"unknown\""));
@@ -457,7 +457,7 @@ class MainTest {
         assertEquals(2, exit);
         assertEquals("", utf8(out));
         assertTrue(primary.contains("\"status\": \"failed\""));
-        assertTrue(primary.contains("\"threshold\": 8.0"));
+        assertTrue(primary.contains("\"threshold\": 6.0"));
         assertFalse(primary.contains("      \"status\":"));
         assertTrue(primary.contains("\"method\": \"danger\""));
         assertTrue(primary.contains("\"method\": \"safe\""));

--- a/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
+++ b/core/src/test/java/media/barney/crap/core/ReportFormatterTest.java
@@ -26,7 +26,7 @@ class ReportFormatterTest {
         ), ReportFormat.TEXT);
 
         assertTrue(report.contains("Status: passed"));
-        assertTrue(report.contains("Threshold: 8.0"));
+        assertTrue(report.contains("Threshold: 6.0"));
         assertTrue(report.contains("CovKind"));
         assertTrue(report.contains("passed"));
         assertTrue(report.contains("skipped"));
@@ -70,7 +70,7 @@ class ReportFormatterTest {
         String expected = """
                 {
                   "status": "failed",
-                  "threshold": 8.0,
+                  "threshold": 6.0,
                   "methods": [
                     {
                       "status": "failed",
@@ -109,7 +109,7 @@ class ReportFormatterTest {
         ), ReportFormat.TOON);
 
         assertTrue(report.contains("status: passed"));
-        assertTrue(report.contains("threshold: 8"));
+        assertTrue(report.contains("threshold: 6"));
         assertTrue(report.contains("methods[2]{status,crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
         assertTrue(report.contains("passed,4.5,3,85,instruction,foo,src/main/java/demo/Sample.java,4,6"));
         assertTrue(report.contains("skipped,null,2,null,N/A,bar,src/main/java/demo/Sample.java,9,11"));
@@ -135,7 +135,7 @@ class ReportFormatterTest {
         String expected = """
                 {
                   "status": "failed",
-                  "threshold": 8.0,
+                  "threshold": 6.0,
                   "methods": [
                     {
                       "crap": 9.645,
@@ -165,7 +165,7 @@ class ReportFormatterTest {
         String expected = """
                 {
                   "status": "failed",
-                  "threshold": 8.0,
+                  "threshold": 6.0,
                   "methods": [
                     {
                       "status": "failed",
@@ -193,7 +193,7 @@ class ReportFormatterTest {
                 metric("unknown", "demo.Sample", 20, 2, null, null)
         ), ReportFormat.TEXT, true, false);
 
-        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 8.0\n"));
+        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 6.0\n"));
         assertTrue(report.contains("Status"));
         assertTrue(report.contains("failed"));
         assertTrue(report.contains("danger"));
@@ -219,7 +219,7 @@ class ReportFormatterTest {
         assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("classname"));
         assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("file"));
         assertEquals("0.0", danger.getAttribute("time"));
-        assertTrue(report.contains("<property name=\"threshold\" value=\"8.0\"/>"));
+        assertTrue(report.contains("<property name=\"threshold\" value=\"6.0\"/>"));
         assertFalse(hasTestcaseNameStartingWith(document, "safe:9 "));
         assertFalse(hasTestcaseNameStartingWith(document, "unknown:20 "));
     }
@@ -234,7 +234,7 @@ class ReportFormatterTest {
         String expected = """
                 {
                   "status": "failed",
-                  "threshold": 8.0,
+                  "threshold": 6.0,
                   "methods": [
                     {
                       "crap": 9.645,
@@ -271,7 +271,7 @@ class ReportFormatterTest {
         ), ReportFormat.TOON, false, true);
 
         assertTrue(report.contains("status: passed"));
-        assertTrue(report.contains("threshold: 8"));
+        assertTrue(report.contains("threshold: 6"));
         assertTrue(report.contains("methods[2]{crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
         assertTrue(report.contains("4.5,3,85,instruction,foo,src/main/java/demo/Sample.java,4,6"));
         assertTrue(report.contains("null,2,null,N/A,bar,src/main/java/demo/Sample.java,9,11"));
@@ -288,7 +288,7 @@ class ReportFormatterTest {
         List<String> lines = report.lines().toList();
         int headerIndex = tableHeaderIndex(lines, "Method");
 
-        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 8.0\n"));
+        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 6.0\n"));
         assertTrue(lines.get(headerIndex).startsWith("Method"));
         assertFalse(lines.get(headerIndex).startsWith("Status"));
         assertTrue(report.contains("danger"));
@@ -305,7 +305,7 @@ class ReportFormatterTest {
         Element root = parseXml(report).getDocumentElement();
 
         assertEquals("2", root.getAttribute("tests"));
-        assertTrue(report.contains("<property name=\"threshold\" value=\"8.0\"/>"));
+        assertTrue(report.contains("<property name=\"threshold\" value=\"6.0\"/>"));
         assertTrue(report.contains("<property name=\"methodName\" value=\"danger\"/>"));
         assertFalse(report.contains("<property name=\"status\""));
     }
@@ -318,7 +318,7 @@ class ReportFormatterTest {
         ), ReportFormat.TOON, true, true);
 
         assertTrue(report.contains("status: failed"));
-        assertTrue(report.contains("threshold: 8"));
+        assertTrue(report.contains("threshold: 6"));
         assertTrue(report.contains("methods[1]{crap,cc,cov,covKind,method,src,lineStart,lineEnd}:"));
         assertTrue(report.contains("9.645,5,10,instruction,danger,src/main/java/demo/Sample.java,4,6"));
     }
@@ -331,7 +331,7 @@ class ReportFormatterTest {
                 metric("unknown", "demo.Sample", 20, 2, null, null)
         ), ReportFormat.TEXT, true, true);
 
-        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 8.0\n"));
+        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: failed\nThreshold: 6.0\n"));
         assertTrue(report.contains("Method"));
         assertTrue(report.contains("danger"));
         assertTrue(report.contains("9.6"));
@@ -352,7 +352,7 @@ class ReportFormatterTest {
                 metric("unknown", "demo.Sample", 20, 2, null, null)
         ), ReportFormat.TEXT, true, true);
 
-        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: passed\nThreshold: 8.0\n"));
+        assertTrue(report.startsWith("CRAP Report\n===========\nStatus: passed\nThreshold: 6.0\n"));
         assertTrue(report.contains("Method"));
         assertFalse(report.contains("safe"));
         assertFalse(report.contains("unknown"));
@@ -382,7 +382,7 @@ class ReportFormatterTest {
         assertEquals("1", root.getAttribute("skipped"));
         assertEquals("1.2", root.getAttribute("time"));
         assertEquals("1.2", suite.getAttribute("time"));
-        assertTrue(report.contains("    <property name=\"threshold\" value=\"8.0\"/>"));
+        assertTrue(report.contains("    <property name=\"threshold\" value=\"6.0\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"instruction\"/>"));
         assertTrue(report.contains("<property name=\"coverageKind\" value=\"N/A\"/>"));
         assertEquals("src/main/java/demo/Sample.java", danger.getAttribute("classname"));
@@ -391,23 +391,23 @@ class ReportFormatterTest {
         assertEquals("src/main/java/demo/Sample.java", unknown.getAttribute("classname"));
         assertEquals("src/main/java/demo/Sample.java", unknown.getAttribute("file"));
         assertEquals("0.6", unknown.getAttribute("time"));
-        assertEquals("CRAP threshold exceeded: 9.6 > 8.0", failure.getAttribute("message"));
+        assertEquals("CRAP threshold exceeded: 9.6 > 6.0", failure.getAttribute("message"));
         assertEquals("crap-java.threshold", failure.getAttribute("type"));
         assertTrue(failure.getTextContent().contains("CRAP score: 9.6"));
-        assertTrue(failure.getTextContent().contains("Threshold: 8.0"));
+        assertTrue(failure.getTextContent().contains("Threshold: 6.0"));
         assertTrue(failure.getTextContent().contains("Coverage: 10.0% (instruction)"));
         assertTrue(failure.getTextContent().contains("Source: src/main/java/demo/Sample.java:4-6"));
         assertTrue(dangerSystemOut.contains("CRAP score: 9.6"));
-        assertTrue(dangerSystemOut.contains("Threshold: 8.0"));
+        assertTrue(dangerSystemOut.contains("Threshold: 6.0"));
         assertTrue(dangerSystemOut.contains("Coverage: 10.0% (instruction)"));
         assertTrue(dangerSystemOut.contains("Source: src/main/java/demo/Sample.java:4-6"));
         assertEquals("CRAP score unavailable", skipped.getAttribute("message"));
         assertTrue(skipped.getTextContent().contains("CRAP score: N/A"));
-        assertTrue(skipped.getTextContent().contains("Threshold: 8.0"));
+        assertTrue(skipped.getTextContent().contains("Threshold: 6.0"));
         assertTrue(skipped.getTextContent().contains("Coverage: N/A (N/A)"));
         assertTrue(skipped.getTextContent().contains("Source: src/main/java/demo/Sample.java:20-22"));
         assertTrue(unknownSystemOut.contains("CRAP score: N/A"));
-        assertTrue(unknownSystemOut.contains("Threshold: 8.0"));
+        assertTrue(unknownSystemOut.contains("Threshold: 6.0"));
         assertTrue(unknownSystemOut.contains("Coverage: N/A (N/A)"));
         assertTrue(unknownSystemOut.contains("Source: src/main/java/demo/Sample.java:20-22"));
     }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.jvm.tasks.Jar
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.plugins.signing.Sign
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import javax.xml.parsers.DocumentBuilderFactory
 
@@ -210,6 +211,10 @@ signing {
         useInMemoryPgpKeys(key, gpgPassphrase.orNull)
         sign(publishing.publications)
     }
+}
+
+tasks.withType<Sign>().configureEach {
+    onlyIf { !gpgPrivateKey.orNull.isNullOrBlank() }
 }
 
 gradlePlugin {

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginFunctionalTest.java
@@ -307,7 +307,7 @@ class CrapJavaGradlePluginFunctionalTest {
         assertTrue(Files.exists(junit));
         assertFalse(Files.exists(tempDir.resolve("build/reports/crap-java/TEST-crap-java.xml")));
         assertTrue(primaryReport.contains("\"status\": \"passed\""));
-        assertTrue(primaryReport.contains("\"threshold\": 8.0"));
+        assertTrue(primaryReport.contains("\"threshold\": 6.0"));
         assertTrue(primaryReport.contains("\"method\": \"alpha\""));
         assertFalse(primaryReport.contains("      \"status\":"));
         assertTrue(junitReport.contains("<testsuites tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\""));

--- a/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
+++ b/gradle-plugin/src/test/java/media/barney/crap/gradle/CrapJavaGradlePluginTest.java
@@ -46,7 +46,7 @@ class CrapJavaGradlePluginTest {
 
         assertEquals("verification", checkTask.getGroup());
         assertEquals("Runs the crap-java CRAP metric gate.", checkTask.getDescription());
-        assertEquals(8.0, extension.getThreshold().get());
+        assertEquals(6.0, extension.getThreshold().get());
         assertFalse(extension.getAgent().get());
         assertEquals("none", extension.getFormat().get());
         assertFalse(extension.getFailuresOnly().get());
@@ -60,7 +60,7 @@ class CrapJavaGradlePluginTest {
         assertEquals(List.of(), extension.getExcludeClasses().get());
         assertEquals(List.of(), extension.getExcludeAnnotations().get());
         assertTrue(extension.getUseDefaultExclusions().get());
-        assertEquals(8.0, checkTask.getThreshold().get());
+        assertEquals(6.0, checkTask.getThreshold().get());
         assertEquals("none", checkTask.getFormat().get());
         assertFalse(checkTask.getAgent().get());
         assertFalse(checkTask.getFailuresOnly().get());
@@ -89,11 +89,11 @@ class CrapJavaGradlePluginTest {
 
         project.getPluginManager().apply("java");
         project.getPluginManager().apply(CrapJavaGradlePlugin.class);
-        project.getExtensions().getByType(CrapJavaExtension.class).getThreshold().set(6.0);
+        project.getExtensions().getByType(CrapJavaExtension.class).getThreshold().set(8.0);
 
         CrapJavaCheckTask checkTask = (CrapJavaCheckTask) project.getTasks().getByName("crap-java-check");
 
-        assertEquals(6.0, checkTask.getThreshold().get());
+        assertEquals(8.0, checkTask.getThreshold().get());
     }
 
     @Test
@@ -139,7 +139,7 @@ class CrapJavaGradlePluginTest {
 
         CrapJavaCheckTask checkTask = project.getTasks().register("custom-crap-java-check", CrapJavaCheckTask.class).get();
 
-        assertEquals(8.0, checkTask.getThreshold().get());
+        assertEquals(6.0, checkTask.getThreshold().get());
         assertFalse(checkTask.getAgent().get());
         assertEquals("none", checkTask.getFormat().get());
         assertFalse(checkTask.getFailuresOnly().get());

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -58,7 +58,7 @@ public class CrapJavaCheckMojo extends AbstractMojo {
     @Parameter(property = "crapJava.junitReport")
     private @Nullable File junitReport;
 
-    @Parameter(property = "crapJava.threshold", defaultValue = "8.0")
+    @Parameter(property = "crapJava.threshold", defaultValue = "6.0")
     private double threshold = Main.DEFAULT_THRESHOLD;
 
     @Parameter

--- a/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
+++ b/maven-plugin/src/test/java/media/barney/crap/maven/CrapJavaCheckMojoTest.java
@@ -65,7 +65,7 @@ class CrapJavaCheckMojoTest {
                 "--format",
                 "none",
                 "--threshold",
-                "8.0",
+                "6.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));
@@ -93,7 +93,7 @@ class CrapJavaCheckMojoTest {
                 "--source-root",
                 sourceRoot.toString(),
                 "--threshold",
-                "8.0",
+                "6.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));
@@ -122,7 +122,7 @@ class CrapJavaCheckMojoTest {
                 "--format",
                 "none",
                 "--threshold",
-                "8.0",
+                "6.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));
@@ -153,7 +153,7 @@ class CrapJavaCheckMojoTest {
                 "--source-root",
                 sourceRoot.toString(),
                 "--threshold",
-                "8.0",
+                "6.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));
@@ -187,7 +187,7 @@ class CrapJavaCheckMojoTest {
                 "--source-root",
                 sourceRoot.toString(),
                 "--threshold",
-                "8.0",
+                "6.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));
@@ -227,7 +227,7 @@ class CrapJavaCheckMojoTest {
 
         mojo.execute();
 
-        assertEquals(List.of("--format", "none", "--threshold", "8.0", "--junit-report", report.toString()), List.of(runner.args));
+        assertEquals(List.of("--format", "none", "--threshold", "6.0", "--junit-report", report.toString()), List.of(runner.args));
     }
 
     @Test
@@ -257,7 +257,7 @@ class CrapJavaCheckMojoTest {
                 "--output",
                 output.toString(),
                 "--threshold",
-                "8.0",
+                "6.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));
@@ -305,7 +305,7 @@ class CrapJavaCheckMojoTest {
                 "com.acme.Generated",
                 "--use-default-exclusions=false",
                 "--threshold",
-                "8.0",
+                "6.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));
@@ -324,7 +324,7 @@ class CrapJavaCheckMojoTest {
 
         mojo.execute();
 
-        assertEquals(List.of("--format", "none", "--threshold", "8.0"), List.of(runner.args));
+        assertEquals(List.of("--format", "none", "--threshold", "6.0"), List.of(runner.args));
     }
 
     @Test
@@ -347,7 +347,7 @@ class CrapJavaCheckMojoTest {
                 "--output",
                 root.resolve("target/crap-java/report.json").toString(),
                 "--threshold",
-                "8.0",
+                "6.0",
                 "--junit-report",
                 root.resolve("target/crap-java/custom-junit.xml").toString()
         ), List.of(runner.args));
@@ -362,7 +362,7 @@ class CrapJavaCheckMojoTest {
         CrapJavaCheckMojo mojo = mojo(runner);
         setField(mojo, "session", session(List.of(project(root, "root")), root));
         setField(mojo, "project", project(root, "root"));
-        setField(mojo, "threshold", 6.0);
+        setField(mojo, "threshold", 8.0);
 
         mojo.execute();
 
@@ -370,7 +370,7 @@ class CrapJavaCheckMojoTest {
                 "--format",
                 "none",
                 "--threshold",
-                "6.0",
+                "8.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));
@@ -479,7 +479,7 @@ class CrapJavaCheckMojoTest {
                 "--format",
                 "none",
                 "--threshold",
-                "8.0",
+                "6.0",
                 "--junit-report",
                 root.resolve("target/crap-java/TEST-crap-java.xml").toString()
         ), List.of(runner.args));

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
             <artifactId>crap-java-maven-plugin</artifactId>
             <version>${project.version}</version>
             <configuration>
+              <threshold>8.0</threshold>
             </configuration>
             <executions>
               <execution>
@@ -230,6 +231,7 @@
             <artifactId>crap-java-maven-plugin</artifactId>
             <version>${project.version}</version>
             <configuration>
+              <threshold>8.0</threshold>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
## Summary
- Reduce the default CRAP threshold from `8.0` to `6.0` across core, CLI help, Maven, Gradle, docs, changelog, and tests.
- Keep the hard-gate warning boundary at `8.0` while recommending the new `6.0` default.
- Skip Gradle signing tasks when no local GPG key is configured so `publishToMavenLocal` remains runnable locally.

Closes #199

## Validation
- `git diff --check`
- `mvn -B verify '-Dcentral.skipPublishing=true'`
- `mvn -B -pl maven-plugin -am verify`
- `mvn -B -pl core -am package`
- `gradle-plugin\\gradlew.bat test validatePlugins publishToMavenLocal`
