### PR TITLE
chore: use default quality thresholds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,6 @@ jobs:
           java -jar "$CLI_JAR" \
             --format none \
             --junit-report target/crap-java/TEST-crap-java-gradle-plugin.xml \
-            --threshold 8.0 \
             --build-tool gradle \
             gradle-plugin/src/main/java
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,6 @@ java -jar cli/target/crap-java-cli-0.6.1.jar --omit-redundancy=false --format js
 java -jar cli/target/crap-java-cli-0.6.1.jar --agent
 java -jar cli/target/crap-java-cli-0.6.1.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
 java -jar cli/target/crap-java-cli-0.6.1.jar --junit-report target/crap-java/TEST-crap-java.xml
-java -jar cli/target/crap-java-cli-0.6.1.jar --threshold 8
-java -jar cli/target/crap-java-cli-0.6.1.jar --threshold=8
 java -jar cli/target/crap-java-cli-0.6.1.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
 java -jar cli/target/crap-java-cli-0.6.1.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
 java -jar cli/target/crap-java-cli-0.6.1.jar --source-root src/java --source-root src/main/java17
@@ -387,7 +385,6 @@ mvn verify -DcrapJava.agent=true
 mvn verify -DcrapJava.failuresOnly=false -DcrapJava.omitRedundancy=true
 mvn verify -DcrapJava.junit=false
 mvn verify -DcrapJava.junitReport=target/custom-crap-java.xml
-mvn verify -DcrapJava.threshold=8.0
 mvn verify -DcrapJava.excludes='module-a/**,**/custom-generated/**'
 mvn verify -DcrapJava.excludeClasses='.*MapperImpl$' -DcrapJava.excludeAnnotations=Generated
 mvn verify -DcrapJava.useDefaultExclusions=false

--- a/core/src/main/java/media/barney/crap/core/BuildToolSelection.java
+++ b/core/src/main/java/media/barney/crap/core/BuildToolSelection.java
@@ -9,10 +9,18 @@ enum BuildToolSelection {
     GRADLE;
 
     static BuildToolSelection parse(@Nullable String value) {
+        return parseValue(requiredValue(value).toLowerCase(Locale.ROOT));
+    }
+
+    private static String requiredValue(@Nullable String value) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("--build-tool requires one of: auto, maven, gradle");
         }
-        return switch (value.toLowerCase(Locale.ROOT)) {
+        return value;
+    }
+
+    private static BuildToolSelection parseValue(String value) {
+        return switch (value) {
             case "auto" -> AUTO;
             case "maven" -> MAVEN;
             case "gradle" -> GRADLE;

--- a/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
+++ b/core/src/main/java/media/barney/crap/core/ChangedFileDetector.java
@@ -47,6 +47,12 @@ final class ChangedFileDetector {
                     "Changed-file detection command failed (" + String.join(" ", command) + "): " + output);
         }
 
+        List<Path> files = changedFiles(projectRoot, output);
+        files.sort(Path::compareTo);
+        return files;
+    }
+
+    private static List<Path> changedFiles(Path projectRoot, String output) {
         List<Path> files = new ArrayList<>();
         List<String> entries = nullDelimitedEntries(output);
         for (int index = 0; index < entries.size(); index++) {
@@ -57,13 +63,16 @@ final class ChangedFileDetector {
             if (entry.hasOriginalPathToken()) {
                 index++;
             }
-            Path file = entry.toPath(projectRoot);
-            if (file != null) {
-                files.add(file);
-            }
+            addPath(files, projectRoot, entry);
         }
-        files.sort(Path::compareTo);
         return files;
+    }
+
+    private static void addPath(List<Path> files, Path projectRoot, StatusEntry entry) {
+        Path file = entry.toPath(projectRoot);
+        if (file != null) {
+            files.add(file);
+        }
     }
 
     private static List<String> gitStatusCommand(Path projectRoot, List<String> gitCommand) {

--- a/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
+++ b/core/src/main/java/media/barney/crap/core/CliArgumentsParser.java
@@ -111,19 +111,33 @@ final class CliArgumentsParser {
     }
 
     private static int parseOption(String[] args, int index, ParseStateBuilder state, String arg) {
+        if (parseFlagOption(state, arg)) {
+            return index;
+        }
+        return parseBooleanOrValuedOption(args, index, state, arg);
+    }
+
+    private static boolean parseFlagOption(ParseStateBuilder state, String arg) {
         if ("--help".equals(arg)) {
             state.help = true;
-            return index;
+            return true;
         }
         if ("--changed".equals(arg)) {
             state.changed = true;
-            return index;
+            return true;
         }
         if ("--agent".equals(arg)) {
             state.agent = parseAgent(state.agentSeen);
             state.agentSeen = true;
-            return index;
+            return true;
         }
+        return false;
+    }
+
+    private static int parseBooleanOrValuedOption(String[] args,
+                                                   int index,
+                                                   ParseStateBuilder state,
+                                                   String arg) {
         if (isBooleanOption(arg, "--failures-only")) {
             state.failuresOnly = parseBooleanOption(arg, "--failures-only", state.failuresOnlySeen);
             state.failuresOnlySeen = true;

--- a/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
+++ b/core/src/main/java/media/barney/crap/core/JacocoCoverageParser.java
@@ -66,37 +66,43 @@ final class JacocoCoverageParser {
             if (!(node instanceof Element method) || !"method".equals(method.getTagName())) {
                 continue;
             }
-            String methodName = method.getAttribute("name");
-            if (JAVAC_LAMBDA_METHOD.matcher(methodName).matches()) {
-                continue;
-            }
-            CoverageData data = readCoverage(method);
-            if (data == null) {
-                continue;
-            }
-            int line = parseInt("line", method.getAttribute("line"));
-            coverage.add(className, methodName, line, data);
+            addMethodCoverage(method, className, coverage);
         }
     }
 
+    private static void addMethodCoverage(Element method,
+                                          String className,
+                                          CoverageIndex.Builder coverage) {
+        String methodName = method.getAttribute("name");
+        if (JAVAC_LAMBDA_METHOD.matcher(methodName).matches()) {
+            return;
+        }
+        CoverageData data = readCoverage(method);
+        if (data == null) {
+            return;
+        }
+        int line = parseInt("line", method.getAttribute("line"));
+        coverage.add(className, methodName, line, data);
+    }
+
     private static @Nullable CoverageData readCoverage(Element method) {
-        CoverageCounter instructionCoverage = null;
-        CoverageCounter branchCoverage = null;
+        CoverageCounter instructionCoverage = findCounter(method, "INSTRUCTION");
+        if (instructionCoverage == null) {
+            return null;
+        }
+        return new CoverageData(instructionCoverage, findCounter(method, "BRANCH"));
+    }
+
+    private static @Nullable CoverageCounter findCounter(Element method, String counterType) {
         for (Node node = method.getFirstChild(); node != null; node = node.getNextSibling()) {
             if (!(node instanceof Element counter) || !"counter".equals(counter.getTagName())) {
                 continue;
             }
-            String type = counter.getAttribute("type");
-            if ("INSTRUCTION".equals(type)) {
-                instructionCoverage = readCounter(counter);
-            } else if ("BRANCH".equals(type)) {
-                branchCoverage = readCounter(counter);
+            if (counterType.equals(counter.getAttribute("type"))) {
+                return readCounter(counter);
             }
         }
-        if (instructionCoverage == null) {
-            return null;
-        }
-        return new CoverageData(instructionCoverage, branchCoverage);
+        return null;
     }
 
     private static CoverageCounter readCounter(Element counter) {

--- a/core/src/main/java/media/barney/crap/core/Main.java
+++ b/core/src/main/java/media/barney/crap/core/Main.java
@@ -264,10 +264,21 @@ public final class Main {
         Path absoluteRight = right.toAbsolutePath().normalize();
         Path common = absoluteLeft.getRoot();
         int max = Math.min(absoluteLeft.getNameCount(), absoluteRight.getNameCount());
-        for (int index = 0; index < max && absoluteLeft.getName(index).equals(absoluteRight.getName(index)); index++) {
-            common = common == null ? absoluteLeft.getName(index) : common.resolve(absoluteLeft.getName(index));
+        for (int index = 0; index < max; index++) {
+            if (!sameName(absoluteLeft, absoluteRight, index)) {
+                break;
+            }
+            common = appendCommonName(common, absoluteLeft.getName(index));
         }
         return common == null ? absoluteLeft : common;
+    }
+
+    private static boolean sameName(Path left, Path right, int index) {
+        return left.getName(index).equals(right.getName(index));
+    }
+
+    private static Path appendCommonName(@Nullable Path common, Path name) {
+        return common == null ? name : common.resolve(name);
     }
 
     static double maxCrap(List<MethodMetrics> metrics) {

--- a/core/src/main/java/media/barney/crap/core/ProductionSourceRoots.java
+++ b/core/src/main/java/media/barney/crap/core/ProductionSourceRoots.java
@@ -38,10 +38,18 @@ final class ProductionSourceRoots {
                 }
                 continue;
             }
-            for (int index = 0; index <= normalized.getNameCount() - normalizedSourceRoot.getNameCount(); index++) {
-                if (matchesSourceRoot(normalized, normalizedSourceRoot, index)) {
-                    return true;
-                }
+            if (isUnderRelativeSourceRoot(normalized, normalizedSourceRoot)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isUnderRelativeSourceRoot(Path normalized, Path sourceRoot) {
+        int lastStart = normalized.getNameCount() - sourceRoot.getNameCount();
+        for (int index = 0; index <= lastStart; index++) {
+            if (matchesSourceRoot(normalized, sourceRoot, index)) {
+                return true;
             }
         }
         return false;

--- a/core/src/main/java/media/barney/crap/core/ProjectModuleResolver.java
+++ b/core/src/main/java/media/barney/crap/core/ProjectModuleResolver.java
@@ -14,15 +14,25 @@ final class ProjectModuleResolver {
     static ProjectModule resolve(Path workspaceRoot, Path file, BuildToolSelection selection) {
         Path normalizedWorkspaceRoot = workspaceRoot.normalize();
         Path candidate = Files.isDirectory(file) ? file.normalize() : file.normalize().getParent();
-        while (candidate != null && candidate.startsWith(normalizedWorkspaceRoot)) {
+        ProjectModule module = findModule(normalizedWorkspaceRoot, candidate, selection);
+        if (module != null) {
+            return module;
+        }
+        throw new IllegalArgumentException("No Maven or Gradle module found for " + file.normalize());
+    }
+
+    private static @Nullable ProjectModule findModule(Path workspaceRoot,
+                                                      @Nullable Path candidate,
+                                                      BuildToolSelection selection) {
+        while (candidate != null && candidate.startsWith(workspaceRoot)) {
             EnumSet<BuildTool> detected = BuildTool.detect(candidate);
             if (!detected.isEmpty()) {
                 BuildTool buildTool = selectBuildTool(candidate, detected, selection);
-                return new ProjectModule(candidate, executionRoot(normalizedWorkspaceRoot, candidate, buildTool), buildTool);
+                return new ProjectModule(candidate, executionRoot(workspaceRoot, candidate, buildTool), buildTool);
             }
             candidate = candidate.getParent();
         }
-        throw new IllegalArgumentException("No Maven or Gradle module found for " + file.normalize());
+        return null;
     }
 
     private static BuildTool selectBuildTool(Path moduleRoot,

--- a/core/src/main/java/media/barney/crap/core/ReportFormat.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormat.java
@@ -1,6 +1,7 @@
 package media.barney.crap.core;
 
 import java.util.Locale;
+import java.util.Map;
 
 enum ReportFormat {
     TOON,
@@ -9,14 +10,19 @@ enum ReportFormat {
     JUNIT,
     NONE;
 
+    private static final Map<String, ReportFormat> VALUES = Map.of(
+            "toon", TOON,
+            "json", JSON,
+            "text", TEXT,
+            "junit", JUNIT,
+            "none", NONE
+    );
+
     static ReportFormat parse(String value) {
-        return switch (value.toLowerCase(Locale.ROOT)) {
-            case "toon" -> TOON;
-            case "json" -> JSON;
-            case "text" -> TEXT;
-            case "junit" -> JUNIT;
-            case "none" -> NONE;
-            default -> throw new IllegalArgumentException("Unknown report format: " + value);
-        };
+        ReportFormat format = VALUES.get(value.toLowerCase(Locale.ROOT));
+        if (format == null) {
+            throw new IllegalArgumentException("Unknown report format: " + value);
+        }
+        return format;
     }
 }

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -75,7 +75,7 @@ final class ReportFormatter {
         if (format == ReportFormat.JUNIT) {
             return formatJunit(report, omitRedundancy, includeExclusionAudit);
         }
-        return "";
+        throw new IllegalStateException("Unhandled report format: " + format);
     }
 
     private static String formatText(CrapReport report, boolean omitRedundancy, boolean includeExclusionAudit) {

--- a/core/src/main/java/media/barney/crap/core/ReportFormatter.java
+++ b/core/src/main/java/media/barney/crap/core/ReportFormatter.java
@@ -56,13 +56,26 @@ final class ReportFormatter {
                                      ReportFormat format,
                                      boolean omitRedundancy,
                                      boolean includeExclusionAudit) {
-        return switch (format) {
-            case TOON -> JToon.encodeJson(formatJson(report, omitRedundancy, includeExclusionAudit));
-            case JSON -> formatJson(report, omitRedundancy, includeExclusionAudit);
-            case TEXT -> formatText(report, omitRedundancy, includeExclusionAudit);
-            case JUNIT -> formatJunit(report, omitRedundancy, includeExclusionAudit);
-            case NONE -> "";
-        };
+        if (format == ReportFormat.TOON) {
+            return JToon.encodeJson(formatJson(report, omitRedundancy, includeExclusionAudit));
+        }
+        return formatNonToon(report, format, omitRedundancy, includeExclusionAudit);
+    }
+
+    private static String formatNonToon(CrapReport report,
+                                        ReportFormat format,
+                                        boolean omitRedundancy,
+                                        boolean includeExclusionAudit) {
+        if (format == ReportFormat.JSON) {
+            return formatJson(report, omitRedundancy, includeExclusionAudit);
+        }
+        if (format == ReportFormat.TEXT) {
+            return formatText(report, omitRedundancy, includeExclusionAudit);
+        }
+        if (format == ReportFormat.JUNIT) {
+            return formatJunit(report, omitRedundancy, includeExclusionAudit);
+        }
+        return "";
     }
 
     private static String formatText(CrapReport report, boolean omitRedundancy, boolean includeExclusionAudit) {

--- a/core/src/main/java/media/barney/crap/core/SourceExclusionMatcher.java
+++ b/core/src/main/java/media/barney/crap/core/SourceExclusionMatcher.java
@@ -50,12 +50,26 @@ final class SourceExclusionMatcher {
 
     Optional<String> pathExclusionReason(Path file) {
         String relativePath = normalizedRelativePath(file);
-        if (useDefaultExclusions && isUnderGeneratedDirectory(relativePath)) {
+        if (useDefaultExclusions) {
+            Optional<String> defaultReason = defaultPathExclusionReason(relativePath);
+            if (defaultReason.isPresent()) {
+                return defaultReason;
+            }
+        }
+        return userPathExclusionReason(relativePath);
+    }
+
+    private static Optional<String> defaultPathExclusionReason(String relativePath) {
+        if (isUnderGeneratedDirectory(relativePath)) {
             return Optional.of("default:path:generated-directory");
         }
-        if (useDefaultExclusions && isUnderSrcMainJavaGen(relativePath)) {
+        if (isUnderSrcMainJavaGen(relativePath)) {
             return Optional.of("default:path:src-main-java-gen");
         }
+        return Optional.empty();
+    }
+
+    private Optional<String> userPathExclusionReason(String relativePath) {
         for (GlobRule rule : userPathRules) {
             if (rule.pattern().matcher(relativePath).matches()) {
                 return Optional.of("user:path:" + rule.glob());
@@ -70,12 +84,12 @@ final class SourceExclusionMatcher {
     }
 
     private Optional<String> classRegexExclusionReason(String className) {
-        for (RegexRule rule : defaultClassRules) {
-            if (rule.pattern().matcher(className).matches()) {
-                return Optional.of(rule.reason());
-            }
-        }
-        for (RegexRule rule : userClassRules) {
+        return matchingClassRule(className, defaultClassRules)
+                .or(() -> matchingClassRule(className, userClassRules));
+    }
+
+    private static Optional<String> matchingClassRule(String className, List<RegexRule> rules) {
+        for (RegexRule rule : rules) {
             if (rule.pattern().matcher(className).matches()) {
                 return Optional.of(rule.reason());
             }
@@ -119,16 +133,11 @@ final class SourceExclusionMatcher {
         if (lastSeparator < 0) {
             return false;
         }
-        int segmentStart = 0;
-        while (segmentStart < lastSeparator) {
-            int segmentEnd = normalizedPath.indexOf('/', segmentStart);
-            if (segmentEnd < 0 || segmentEnd > lastSeparator) {
-                segmentEnd = lastSeparator;
-            }
-            if (normalizedPath.substring(segmentStart, segmentEnd).contains("generated")) {
+        String parentPath = normalizedPath.substring(0, lastSeparator);
+        for (String segment : parentPath.split("/", -1)) {
+            if (segment.contains("generated")) {
                 return true;
             }
-            segmentStart = segmentEnd + 1;
         }
         return false;
     }

--- a/core/src/main/java/media/barney/crap/core/SourceExclusionMatcher.java
+++ b/core/src/main/java/media/barney/crap/core/SourceExclusionMatcher.java
@@ -18,6 +18,7 @@ final class SourceExclusionMatcher {
             "(^|.*\\.)AutoValue_[^.]*$"
     );
     private static final String DEFAULT_GENERATED_ANNOTATION = "Generated";
+    private static final String GENERATED_SEGMENT = "generated";
 
     private final Path projectRoot;
     private final boolean useDefaultExclusions;
@@ -133,11 +134,20 @@ final class SourceExclusionMatcher {
         if (lastSeparator < 0) {
             return false;
         }
-        String parentPath = normalizedPath.substring(0, lastSeparator);
-        for (String segment : parentPath.split("/", -1)) {
-            if (segment.contains("generated")) {
+        return hasGeneratedSegment(normalizedPath, lastSeparator);
+    }
+
+    private static boolean hasGeneratedSegment(String normalizedPath, int lastSeparator) {
+        int segmentStart = 0;
+        while (segmentStart < lastSeparator) {
+            int nextSeparator = normalizedPath.indexOf('/', segmentStart);
+            int segmentEnd = nextSeparator < 0 ? lastSeparator : Math.min(nextSeparator, lastSeparator);
+            int generatedStart = normalizedPath.indexOf(GENERATED_SEGMENT, segmentStart);
+            if (generatedStart >= segmentStart
+                    && generatedStart + GENERATED_SEGMENT.length() <= segmentEnd) {
                 return true;
             }
+            segmentStart = segmentEnd + 1;
         }
         return false;
     }

--- a/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
+++ b/core/src/test/java/media/barney/crap/core/SourceFileFinderTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SourceFileFinderTest {
@@ -99,6 +100,14 @@ class SourceFileFinderTest {
         );
 
         assertEquals(List.of(customSource), files);
+    }
+
+    @Test
+    void ignoresAbsoluteSourceRootsThatDoNotContainTheCandidate() {
+        Path candidate = tempDir.resolve("src/main/java/demo/Sample.java");
+        Path otherSourceRoot = tempDir.resolve("other/src/main/java");
+
+        assertFalse(ProductionSourceRoots.isUnderSourceRoot(candidate, List.of(otherSourceRoot)));
     }
 
     @Test

--- a/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
+++ b/gradle-plugin/src/main/java/media/barney/crap/gradle/CrapJavaCheckTask.java
@@ -399,20 +399,27 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
         }
         Path normalized = path.toAbsolutePath().normalize();
         try {
-            if (Files.isSymbolicLink(normalized)) {
-                return symbolicLinkTargetForComparison(normalized, symlinkDepth);
-            }
-            if (Files.exists(normalized)) {
-                return normalized.toRealPath();
-            }
-            Path existing = nearestExistingPath(normalized);
-            if (existing != null) {
-                return existing.toRealPath().resolve(existing.relativize(normalized)).normalize();
-            }
+            return realPathForNormalizedPath(normalized, symlinkDepth);
         } catch (IOException | SecurityException exception) {
             return null;
         }
-        return null;
+    }
+
+    private @Nullable Path realPathForNormalizedPath(Path normalized, int symlinkDepth) throws IOException {
+        if (Files.isSymbolicLink(normalized)) {
+            return symbolicLinkTargetForComparison(normalized, symlinkDepth);
+        }
+        if (Files.exists(normalized)) {
+            return normalized.toRealPath();
+        }
+        return realPathForMissingPath(normalized);
+    }
+
+    private @Nullable Path realPathForMissingPath(Path normalized) throws IOException {
+        Path existing = nearestExistingPath(normalized);
+        return existing == null
+                ? null
+                : existing.toRealPath().resolve(existing.relativize(normalized)).normalize();
     }
 
     private @Nullable Path symbolicLinkTargetForComparison(Path link, int symlinkDepth) throws IOException {
@@ -525,15 +532,21 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             ReportSnapshot before,
             @Nullable RememberedReport rememberedReport
     ) throws IOException {
-        if (rememberedReport == null || before.exists()) {
-            return;
-        }
-        if (isCurrentRememberedPath(rememberedReport, reportPath)) {
-            return;
-        }
-        if (reportPath != null && reportChanged(reportPath, before)) {
+        if (isNewUnrememberedChangedReport(reportPath, before, rememberedReport)) {
             Files.deleteIfExists(reportPath);
         }
+    }
+
+    private boolean isNewUnrememberedChangedReport(
+            @Nullable Path reportPath,
+            ReportSnapshot before,
+            @Nullable RememberedReport rememberedReport
+    ) throws IOException {
+        return rememberedReport != null
+                && !before.exists()
+                && !isCurrentRememberedPath(rememberedReport, reportPath)
+                && reportPath != null
+                && reportChanged(reportPath, before);
     }
 
     private boolean shouldRememberChangedReport(
@@ -704,17 +717,26 @@ public abstract class CrapJavaCheckTask extends DefaultTask {
             return false;
         }
         Path stateRoot = projectCacheRoot(getProject()).resolve("crap-java");
+        return isOtherOwnerLinkPresent(stateRoot, rememberedReport);
+    }
+
+    private boolean isOtherOwnerLinkPresent(Path stateRoot, RememberedReport rememberedReport)
+            throws IOException {
         if (!Files.isDirectory(stateRoot)) {
             return false;
         }
         try (Stream<Path> paths = Files.walk(stateRoot)) {
             for (Path path : paths.filter(this::isOwnerLink).toList()) {
-                if (!path.equals(rememberedReport.ownerLink()) && sameExistingFile(path, rememberedReport.path())) {
+                if (isOtherOwnerLink(path, rememberedReport)) {
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    private boolean isOtherOwnerLink(Path path, RememberedReport rememberedReport) throws IOException {
+        return !path.equals(rememberedReport.ownerLink()) && sameExistingFile(path, rememberedReport.path());
     }
 
     private boolean isOwnerLink(Path path) {

--- a/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
+++ b/maven-plugin/src/main/java/media/barney/crap/maven/CrapJavaCheckMojo.java
@@ -124,6 +124,15 @@ public class CrapJavaCheckMojo extends AbstractMojo {
 
     private String[] reportArgs(Path executionRoot) {
         List<String> args = new ArrayList<>();
+        addReportControls(args);
+        addExclusionControls(args, executionRoot);
+        addOutputArgument(args, executionRoot);
+        addThresholdArgument(args);
+        addJunitReportArgument(args, executionRoot);
+        return args.toArray(String[]::new);
+    }
+
+    private void addReportControls(List<String> args) {
         args.add("--format");
         args.add(format);
         if (agent) {
@@ -135,6 +144,9 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         if (omitRedundancy != null) {
             args.add("--omit-redundancy=" + omitRedundancy);
         }
+    }
+
+    private void addExclusionControls(List<String> args, Path executionRoot) {
         addRepeated(args, "--exclude", excludesProperty, excludes);
         addRepeated(args, "--exclude-class", excludeClassesProperty, excludeClasses);
         addRepeated(args, "--exclude-annotation", excludeAnnotationsProperty, excludeAnnotations);
@@ -142,17 +154,25 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         if (!useDefaultExclusions) {
             args.add("--use-default-exclusions=false");
         }
+    }
+
+    private void addOutputArgument(List<String> args, Path executionRoot) {
         if (output != null) {
             args.add("--output");
             args.add(configuredPath(executionRoot, output).toString());
         }
+    }
+
+    private void addThresholdArgument(List<String> args) {
         args.add("--threshold");
         args.add(Double.toString(threshold));
+    }
+
+    private void addJunitReportArgument(List<String> args, Path executionRoot) {
         if (junit) {
             args.add("--junit-report");
             args.add(junitReportPath(executionRoot).toString());
         }
-        return args.toArray(String[]::new);
     }
 
     private static void addRepeated(List<String> args, String option, @Nullable String propertyValue, List<String> values) {
@@ -185,7 +205,7 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         StringBuilder current = new StringBuilder();
         for (int index = 0; index < propertyValue.length(); index++) {
             char character = propertyValue.charAt(index);
-            if (character == '\\' && index + 1 < propertyValue.length() && propertyValue.charAt(index + 1) == ',') {
+            if (isEscapedComma(propertyValue, index, character)) {
                 current.append(',');
                 index++;
                 continue;
@@ -199,6 +219,10 @@ public class CrapJavaCheckMojo extends AbstractMojo {
         }
         values.add(current.toString());
         return values;
+    }
+
+    private static boolean isEscapedComma(String propertyValue, int index, char character) {
+        return character == '\\' && index + 1 < propertyValue.length() && propertyValue.charAt(index + 1) == ',';
     }
 
     private static List<String> configuredListValues(List<String> values) {

--- a/pom.xml
+++ b/pom.xml
@@ -192,9 +192,6 @@
             <groupId>media.barney</groupId>
             <artifactId>crap-java-maven-plugin</artifactId>
             <version>${project.version}</version>
-            <configuration>
-              <threshold>8.0</threshold>
-            </configuration>
             <executions>
               <execution>
                 <id>crap-java-check</id>
@@ -230,9 +227,6 @@
             <groupId>media.barney</groupId>
             <artifactId>crap-java-maven-plugin</artifactId>
             <version>${project.version}</version>
-            <configuration>
-              <threshold>8.0</threshold>
-            </configuration>
             <executions>
               <execution>
                 <id>crap-java-check</id>


### PR DESCRIPTION
## Summary

- Closes #202.
- Confirmed the published dependencies remain current: `crap-java` `0.6.1` and `cognitive-java` `0.6.0`.
- Removed repository-owned `8.0` overrides from the root Maven quality profiles and Gradle self-check workflow so they inherit the `6.0` default.
- Updated README examples to use the inherited default while preserving explicit overrides and the recommended hard-gate guidance.
- Refactored the affected core and Maven-plugin dispatch paths so the repository itself passes the inherited 6.0 CRAP gate without changing behavior, plus a focused absolute-source-root coverage test.

## Review focus

- Verify the threshold overrides are removed only from the repository gates and ordinary examples.
- Verify explicit `--threshold` / `crapJava.threshold` support remains intact.
- Verify the complexity refactors preserve parsing, source-root, report-format, exclusion, resolver, and Maven-plugin argument behavior.

## Validation

- `mvn -B -ntp verify`
- Core and Maven-plugin CRAP gates at the inherited `6.0` default
- `maven-plugin` integration verification
- `gradle-plugin\\gradlew.bat clean check`
- `git diff --check`
- Changed-line secret-pattern scan

## Residual risk

- The published dependency versions were checked at implementation time and were already current; no dependency update was necessary.
