### PR TITLE
chore: update Maven dependency patches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cognitive-java.version>0.6.0</cognitive-java.version>
     <jacoco.version>0.8.15</jacoco.version>
-    <junit.version>6.1.1</junit.version>
+    <junit.version>6.1.3</junit.version>
     <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
-    <jspecify.version>1.0.0</jspecify.version>
+    <jspecify.version>1.0.1</jspecify.version>
     <jtoon.version>1.0.9</jtoon.version>
-    <jackson.version>2.22.0</jackson.version>
+    <jackson.version>2.22.1</jackson.version>
     <errorprone.version>2.50.0</errorprone.version>
     <nullaway.version>0.13.7</nullaway.version>
     <nullaway.annotated.packages>media.barney.crap</nullaway.annotated.packages>


### PR DESCRIPTION
Closes #207

## Implementation Summary

- Scope: update the root Maven-managed JUnit, Jackson, and JSpecify patch versions.
- Key changes: JUnit 6.1.3, Jackson 2.22.1, and JSpecify 1.0.1.
- Non-goals: Java floor, source/API, Gradle plugin, workflow, fixture, and release changes.

## Review Focus

- `pom.xml` is the complete change; the root dependency management propagates the selected patches to
  the Maven modules and Gradle-plugin build integration.
- Fixture POMs intentionally retain their pinned compatibility versions and are not part of this update.

## Validation

- Manual checks: Maven Central update report identified only stable patch targets; `git diff --check`
  passes.
- Local limitation: on JDK 25, the existing NullAway profile passes an Error Prone response-file path
  containing `C:/Users/Fabian Barney`, which Error Prone truncates at the space. This is unrelated to
  the three version properties; `mvn -B verify` and the dependent Gradle check cannot complete locally.
- Residual risks: current-head GitHub Actions are required to validate the full Maven/Gradle matrix before
  merge; do not merge while that evidence is unavailable.
