### PR TITLE
Prepare v0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,28 @@
 
 ## Unreleased
 
+## 0.6.2 - 2026-08-09
+
 ### Changed
 
-- Reduced the default CRAP threshold from `8.0` to `6.0` while keeping the recommended `4.0` to `8.0` range unchanged.
+- Reduced the default CRAP threshold from `8.0` to `6.0` while keeping the
+  recommended `4.0` to `8.0` range unchanged. Configure `8.0` explicitly when
+  retaining the previous default behavior is required.
+- Enriched JUnit XML output with method metric summaries in testcase names and
+  detailed CRAP, coverage, and source context in diagnostic output.
+- Hardened CLI parsing, changed-file ordering, source-root and module
+  resolution, JaCoCo coverage parsing, and cross-platform path handling.
+- Hardened Maven and Gradle report defaults, report-path ownership, alias
+  handling, and configuration-cache state management.
+- Tightened CI and release plumbing with pinned workflow actions, safer JDK 25
+  quality-gate activation, blank-credential publication skips, and masked
+  Central upload authorization.
+
+### Dependencies
+
+- Updated the cognitive-java, JaCoCo, JUnit, Jackson, Error Prone, NullAway,
+  Surefire, Central publishing, and Gradle wrapper versions used by the build
+  and release workflow.
 
 ## 0.6.1 - 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ mvn -B -pl cli -am -DskipTests package
 From the project root you want to analyze:
 
 ```bash
-java -jar cli/target/crap-java-cli-0.6.1.jar
+java -jar cli/target/crap-java-cli-0.6.2.jar
 ```
 
 ## CLI
@@ -163,25 +163,25 @@ Value-taking long options may also be written with inline assignment, such as
 Examples:
 
 ```bash
-java -jar cli/target/crap-java-cli-0.6.1.jar --help
-java -jar cli/target/crap-java-cli-0.6.1.jar
-java -jar cli/target/crap-java-cli-0.6.1.jar --changed
-java -jar cli/target/crap-java-cli-0.6.1.jar --build-tool gradle
-java -jar cli/target/crap-java-cli-0.6.1.jar --build-tool=maven
-java -jar cli/target/crap-java-cli-0.6.1.jar --format json
-java -jar cli/target/crap-java-cli-0.6.1.jar --format none --junit-report target/crap-java/TEST-crap-java.xml
-java -jar cli/target/crap-java-cli-0.6.1.jar --format json --output target/crap-java/report.json
-java -jar cli/target/crap-java-cli-0.6.1.jar --failures-only=false --format json
-java -jar cli/target/crap-java-cli-0.6.1.jar --omit-redundancy=false --format json
-java -jar cli/target/crap-java-cli-0.6.1.jar --agent
-java -jar cli/target/crap-java-cli-0.6.1.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
-java -jar cli/target/crap-java-cli-0.6.1.jar --junit-report target/crap-java/TEST-crap-java.xml
-java -jar cli/target/crap-java-cli-0.6.1.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
-java -jar cli/target/crap-java-cli-0.6.1.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
-java -jar cli/target/crap-java-cli-0.6.1.jar --source-root src/java --source-root src/main/java17
-java -jar cli/target/crap-java-cli-0.6.1.jar --build-tool maven module-a/src/main/java/demo/Sample.java
-java -jar cli/target/crap-java-cli-0.6.1.jar src/main/java/demo/Sample.java
-java -jar cli/target/crap-java-cli-0.6.1.jar module-a module-b
+java -jar cli/target/crap-java-cli-0.6.2.jar --help
+java -jar cli/target/crap-java-cli-0.6.2.jar
+java -jar cli/target/crap-java-cli-0.6.2.jar --changed
+java -jar cli/target/crap-java-cli-0.6.2.jar --build-tool gradle
+java -jar cli/target/crap-java-cli-0.6.2.jar --build-tool=maven
+java -jar cli/target/crap-java-cli-0.6.2.jar --format json
+java -jar cli/target/crap-java-cli-0.6.2.jar --format none --junit-report target/crap-java/TEST-crap-java.xml
+java -jar cli/target/crap-java-cli-0.6.2.jar --format json --output target/crap-java/report.json
+java -jar cli/target/crap-java-cli-0.6.2.jar --failures-only=false --format json
+java -jar cli/target/crap-java-cli-0.6.2.jar --omit-redundancy=false --format json
+java -jar cli/target/crap-java-cli-0.6.2.jar --agent
+java -jar cli/target/crap-java-cli-0.6.2.jar --agent --format junit --output target/crap-java/TEST-crap-java-primary.xml
+java -jar cli/target/crap-java-cli-0.6.2.jar --junit-report target/crap-java/TEST-crap-java.xml
+java -jar cli/target/crap-java-cli-0.6.2.jar --exclude 'module-a/**' --exclude-class '.*MapperImpl$'
+java -jar cli/target/crap-java-cli-0.6.2.jar --exclude='module-a/**' --exclude-class='.*MapperImpl$'
+java -jar cli/target/crap-java-cli-0.6.2.jar --source-root src/java --source-root src/main/java17
+java -jar cli/target/crap-java-cli-0.6.2.jar --build-tool maven module-a/src/main/java/demo/Sample.java
+java -jar cli/target/crap-java-cli-0.6.2.jar src/main/java/demo/Sample.java
+java -jar cli/target/crap-java-cli-0.6.2.jar module-a module-b
 ```
 
 The CLI writes only the requested primary report format to stdout unless
@@ -243,12 +243,12 @@ but GitLab-visible details do not rely on properties.
 
 ## Distribution
 
-The current `0.6.1` release ships through Maven Central, with the Gradle Plugin Portal as the primary Gradle plugin channel:
+The current `0.6.2` release ships through Maven Central, with the Gradle Plugin Portal as the primary Gradle plugin channel:
 
-- `media.barney:crap-java-core:0.6.1`
-- `media.barney:crap-java-cli:0.6.1`
-- `media.barney:crap-java-maven-plugin:0.6.1`
-- Gradle plugin id `media.barney.crap-java` version `0.6.1`
+- `media.barney:crap-java-core:0.6.2`
+- `media.barney:crap-java-cli:0.6.2`
+- `media.barney:crap-java-maven-plugin:0.6.2`
+- Gradle plugin id `media.barney.crap-java` version `0.6.2`
 
 ### Gradle Plugin Portal
 
@@ -256,7 +256,7 @@ Apply the plugin in `build.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("media.barney.crap-java") version "0.6.1"
+    id("media.barney.crap-java") version "0.6.2"
 }
 ```
 
@@ -311,14 +311,14 @@ Then apply the same plugin id in `build.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("media.barney.crap-java") version "0.6.1"
+    id("media.barney.crap-java") version "0.6.2"
 }
 ```
 
 The marker publication lives at
-`media.barney.crap-java:media.barney.crap-java.gradle.plugin:0.6.1` and
+`media.barney.crap-java:media.barney.crap-java.gradle.plugin:0.6.2` and
 resolves to the implementation artifact
-`media.barney:crap-java-gradle-plugin:0.6.1`.
+`media.barney:crap-java-gradle-plugin:0.6.2`.
 
 ### Maven Central
 
@@ -349,7 +349,7 @@ Add the plugin:
     <plugin>
       <groupId>media.barney</groupId>
       <artifactId>crap-java-maven-plugin</artifactId>
-      <version>0.6.1</version>
+      <version>0.6.2</version>
       <executions>
         <execution>
           <goals>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2</version>
   </parent>
 
   <artifactId>crap-java-cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2</version>
   </parent>
 
   <artifactId>crap-java-core</artifactId>

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "media.barney"
-version = "0.6.1"
+version = "0.6.2"
 
 repositories {
     mavenCentral()

--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>media.barney</groupId>
     <artifactId>crap-java-parent</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2</version>
   </parent>
 
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>media.barney</groupId>
   <artifactId>crap-java-parent</artifactId>
-  <version>0.6.1</version>
+  <version>0.6.2</version>
   <packaging>pom</packaging>
 
   <name>crap-java Parent</name>


### PR DESCRIPTION
Closes #209

## Implementation Summary

- Scope: prepare the `v0.6.2` release from current `main` through commit
  `4c3d708`.
- Key changes: align Maven and Gradle versions, update README release
  examples, and replace the incomplete Unreleased section with the complete
  `v0.6.2` changelog entry.
- Non-goals: open PR #208, source/API changes, release-workflow changes, and
  private artifactory publication.

## Review Focus

- Generated/copied files and standard version updates that can be skimmed:
  the five Maven POMs, Gradle version, and README coordinates/examples.
- Non-obvious code paths and rationale: verify that the changelog accurately
  covers the full merged delta since `v0.6.1` and calls out the default
  threshold compatibility change from `8.0` to `6.0`.

## Validation

- Tests executed: `mvn -B -ntp -P!quality-gates-all -o verify`;
  `gradlew.bat test validatePlugins publishToMavenLocal`.
- Manual checks: version alignment passed for `0.6.2`; `git diff --check`
  passed; the previous `0.6.1` scan found only the historical changelog
  heading; staged scope contains eight intended release files.
- Residual risks: tag-triggered publication still depends on valid Maven
  Central, GPG, and Gradle Plugin Portal credentials and must be monitored
  target by target after the GitHub Release draft is created.
